### PR TITLE
Adds basic READMEs to inmemory and filesystem storage drivers

### DIFF
--- a/storagedriver/filesystem/README.md
+++ b/storagedriver/filesystem/README.md
@@ -1,0 +1,8 @@
+Docker-Registry Filesystem Storage Driver
+=========================================
+
+An implementation of the `storagedriver.StorageDriver` interface which uses the local filesystem.
+
+## Parameters
+
+`rootdirectory`: (optional) The root directory tree in which all registry files will be stored. Defaults to `/tmp/registry/storage`.

--- a/storagedriver/inmemory/README.md
+++ b/storagedriver/inmemory/README.md
@@ -1,0 +1,10 @@
+Docker-Registry In-Memory Storage Driver
+=========================================
+
+An implementation of the `storagedriver.StorageDriver` interface which uses local memory for object storage.
+
+**IMPORTANT**: This storage driver *does not* persist data across runs, and primarily exists for testing.
+
+## Parameters
+
+None


### PR DESCRIPTION
This change adds the minimal documentation required to use and configure the filesystem and inmemory storage drivers.
