### PR TITLE
add hdfs storage driver

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ machine:
     - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/1.0.22/binscripts/gvm-installer)
   # Install codecov for coverage
     - pip install --user codecov
+  # Install HDFS
+    - sudo -i ~/distribution/contrib/hdfs/ci-setup.sh
 
   post:
   # go

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/azure"
 	_ "github.com/docker/distribution/registry/storage/driver/filesystem"
 	_ "github.com/docker/distribution/registry/storage/driver/gcs"
+	_ "github.com/docker/distribution/registry/storage/driver/hdfsweb"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 	_ "github.com/docker/distribution/registry/storage/driver/middleware/cloudfront"
 	_ "github.com/docker/distribution/registry/storage/driver/oss"

--- a/contrib/hdfs/ci-setup.sh
+++ b/contrib/hdfs/ci-setup.sh
@@ -1,0 +1,100 @@
+#! /bin/bash
+#
+# HDFS cluster setup in Circle CI
+#
+
+set -x
+set -e
+set -u
+
+# NODE=$(hostname)
+# 
+# echo $(ip route get 1 | awk '{print $NF;exit}') $(hostname) >> /etc/hosts
+# ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -N ""
+# cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+# ssh-keyscan $NODE >> ~/.ssh/known_hosts
+
+sudo -i apt-get update
+sudo -i apt-get install openjdk-8-jre openjdk-8-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+wget https://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz
+sudo -i tar -zxf hadoop-2.7.1.tar.gz -C /usr/local
+sudo -i mv /usr/local/hadoop-2.7.1 /usr/local/hadoop
+export PATH=$PATH:/usr/local/hadoop/bin
+
+cat > /usr/local/hadoop/etc/hadoop/core-site.xml <<EOF 
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>hadoop.tmp.dir</name>
+        <value>file:/usr/local/hadoop/tmp</value>
+        <description>Abase for other temporary directories.</description>
+    </property>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://localhost:9000</value>
+    </property>  
+</configuration>
+EOF
+
+cat > /usr/local/hadoop/etc/hadoop/hdfs-site.xml <<EOF 
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.namenode.name.dir</name>
+        <value>file:/usr/local/hadoop/tmp/dfs/name</value>
+    </property>
+    <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>file:/usr/local/hadoop/tmp/dfs/data</value>
+    </property>
+    <property>
+        <name>dfs.client.block.write.replace-datanode-on-failure.enable</name>
+        <value>false</value>
+    </property>    
+</configuration>
+EOF
+
+hdfs namenode -format
+/usr/local/hadoop/sbin/start-dfs.sh
+
+export HDFS_NAME_NODE_HOST=localhost
+export HDFS_NAME_NODE_PORT=50070

--- a/docs/storage-drivers/hdfsweb.md
+++ b/docs/storage-drivers/hdfsweb.md
@@ -1,0 +1,30 @@
+<!--[metadata]>
++++
+title = "Web HDFS storage driver"
+description = "Explains how to use the Web HDFS storage drivers"
+keywords = ["registry, service, driver, images, storage, HDFS"]
++++
+<![end-metadata]-->
+
+
+# Web HDFS storage driver
+
+An implementation of the `storagedriver.StorageDriver` interface which uses [Hadoop HDFS Web API](http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html) for object storage.
+
+## Parameters
+
+`namenodehost`: the HDFS NameNode host that manages the file system metadata and DataNodes that store the actual data.
+
+`namenodeport`: the HDFS NameNode port. 
+
+`rootdirectory`: The root directory tree on HDFS in which all registry files will be stored. 
+
+`username`: (optional) The authenticated user name. The default value is the current user name of distribution.
+
+`blocksize`: (optional) HDFS block size. The default value is 128MB.
+
+`buffersize`: (optional) buffer size for WebHDFS request. The default value is 16MB.
+
+`replication`: (optional) replication number for WebHDFS request. The default value is 1.
+
+**Note** Please use Apache Hadoop upper than version 2.6.0. And please add Datanodes host name to registry container `/etc/hosts`.

--- a/docs/storage-drivers/index.md
+++ b/docs/storage-drivers/index.md
@@ -27,6 +27,7 @@ This storage driver package comes bundled with several drivers:
 - [swift](swift.md): A driver storing objects in [Openstack Swift](http://docs.openstack.org/developer/swift/).
 - [oss](oss.md): A driver storing objects in [Aliyun OSS](http://www.aliyun.com/product/oss).
 - [gcs](gcs.md): A driver storing objects in a [Google Cloud Storage](https://cloud.google.com/storage/) bucket.
+- [hdfsweb](hdfsweb.md): A driver storing objects in [Hadoop HDFS](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html)
 
 ## Storage Driver API
 

--- a/registry/storage/driver/hdfsweb/fs.go
+++ b/registry/storage/driver/hdfsweb/fs.go
@@ -1,0 +1,543 @@
+// Refer to github.com/vladimirvivien/gowfs
+
+package hdfsweb
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	webHdfsVer string = "/webhdfs/v1"
+)
+
+// FileSystem provides the HTTP client interface to specific HDFS server.
+type FileSystem struct {
+	NameNodeHost string
+	NameNodePort string
+	UserName     string
+	BlockSize    int64
+	BufferSize   int32
+	Replication  int16
+	Client       *http.Client
+}
+
+// Create creates a new file and stores its content in HDFS.
+func (fs *FileSystem) Create(reader io.Reader, path string) error {
+	v := url.Values{
+		"user.name":   []string{fs.UserName},
+		"op":          []string{"CREATE"},
+		"overwrite":   []string{"true"},
+		"blocksize":   []string{strconv.FormatInt(fs.BlockSize, 10)},
+		"replication": []string{strconv.FormatInt(int64(fs.Replication), 10)},
+		"permission":  []string{"0666"},
+		"buffersize":  []string{strconv.FormatInt(int64(fs.BufferSize), 10)},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp1, err := fs.Client.Transport.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusTemporaryRedirect {
+		body, err := ioutil.ReadAll(resp1.Body)
+		if err != nil {
+			return err
+		}
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Create] path(%s) unknown error return (%d)", path, resp1.StatusCode)
+		}
+	}
+	location := resp1.Header.Get("Location")
+	u, err = url.ParseRequestURI(location)
+	if err != nil {
+		return err
+	}
+
+	req, err = http.NewRequest("PUT", u.String(), reader)
+	if err != nil {
+		return err
+	}
+	resp2, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		body, err := ioutil.ReadAll(resp2.Body)
+		if err != nil {
+			return err
+		}
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Create] path(%s) unknown error return (%d)", path, resp2.StatusCode)
+		}
+	}
+	return nil
+}
+
+// Append appends reader content to exist file in HDFS.
+func (fs *FileSystem) Append(reader io.Reader, path string) error {
+	v := url.Values{
+		"user.name":  []string{fs.UserName},
+		"op":         []string{"APPEND"},
+		"buffersize": []string{strconv.FormatInt(int64(fs.BufferSize), 10)},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp1, err := fs.Client.Transport.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusTemporaryRedirect {
+		body, err := ioutil.ReadAll(resp1.Body)
+		if err != nil {
+			return err
+		}
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Create] path(%s) unknown error return (%d)", path, resp1.StatusCode)
+		}
+	}
+	location := resp1.Header.Get("Location")
+	u, err = url.ParseRequestURI(location)
+	if err != nil {
+		return err
+	}
+
+	req, err = http.NewRequest("POST", u.String(), reader)
+	if err != nil {
+		return err
+	}
+	resp2, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp2.Body)
+		if err != nil {
+			return err
+		}
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Append] path(%s) unknown error return (%d)", path, resp2.StatusCode)
+		}
+	}
+	return nil
+}
+
+//Open opens the specificed Path and returns its content to be accessed locally.
+func (fs *FileSystem) Open(path string, offset, length int64) (io.ReadCloser, error) {
+	v := url.Values{
+		"user.name":  []string{fs.UserName},
+		"op":         []string{"OPEN"},
+		"offset":     []string{strconv.FormatInt(offset, 10)},
+		"length":     []string{strconv.FormatInt(length, 10)},
+		"buffersize": []string{strconv.FormatInt(int64(fs.BufferSize), 10)},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return nil, err
+		} else if re.RemoteException.Exception != "" {
+			return nil, re.RemoteException
+		} else {
+			return nil, fmt.Errorf("[Open] path(%s) unknown error return (%d)", path, resp.StatusCode)
+		}
+	}
+	return resp.Body, nil
+}
+
+// Rename renames the specified path resource to a new name.
+// See HDFS FileSystem.rename()
+func (fs *FileSystem) Rename(source, destination string) error {
+	if source == "" || destination == "" {
+		return fmt.Errorf("[Rename] empty source or destination object name")
+	}
+
+	v := url.Values{
+		"user.name":   []string{fs.UserName},
+		"op":          []string{"RENAME"},
+		"destination": []string{destination},
+		"recursive":   []string{"true"},
+	}
+	u, err := fs.buildRequestURL(source, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Rename] from (%s) to (%s) unknown error return (%d)",
+				source,
+				destination,
+				resp.StatusCode)
+		}
+	}
+
+	var boolean struct {
+		Boolean bool `json:"boolean,omitempty"`
+	}
+	err = json.Unmarshal(body, &boolean)
+	if err != nil {
+		return err
+	} else if !boolean.Boolean {
+		return ErrBoolean
+	}
+	return nil
+}
+
+//Delete deletes the specified path.
+//See HDFS FileSystem.delete()
+func (fs *FileSystem) Delete(path string) error {
+	if path == "" {
+		return fmt.Errorf("[Delete] empty path")
+	}
+	v := url.Values{
+		"user.name": []string{fs.UserName},
+		"op":        []string{"DELETE"},
+		"recursive": []string{"true"},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("DELETE", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Delete] path(%s) unknown error return (%d)", path, resp.StatusCode)
+		}
+	}
+
+	var boolean struct {
+		Boolean bool `json:"boolean,omitempty"`
+	}
+	err = json.Unmarshal(body, &boolean)
+	if err != nil {
+		return err
+	} else if !boolean.Boolean {
+		return ErrBoolean
+	}
+	return nil
+}
+
+//Truncate truncates  the specified path.
+func (fs *FileSystem) Truncate(path string, length int64) error {
+	if path == "" {
+		return fmt.Errorf("[Truncate] empty path")
+	}
+	v := url.Values{
+		"user.name": []string{fs.UserName},
+		"op":        []string{"TRUNCATE"},
+		"newlength": []string{strconv.FormatInt(length, 10)},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[Truncate] path(%s) unknown error return (%d)", path, resp.StatusCode)
+		}
+	}
+
+	var boolean struct {
+		Boolean bool `json:"boolean,omitempty"`
+	}
+	err = json.Unmarshal(body, &boolean)
+	if err != nil {
+		return err
+	} else if !boolean.Boolean {
+		return ErrBoolean
+	}
+	return nil
+}
+
+// MkDirs creates the specified directory(ies).
+func (fs *FileSystem) MkDirs(path string) error {
+	v := url.Values{
+		"user.name":  []string{fs.UserName},
+		"op":         []string{"MKDIRS"},
+		"permission": []string{"0755"},
+	}
+
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return err
+		} else if re.RemoteException.Exception != "" {
+			return re.RemoteException
+		} else {
+			return fmt.Errorf("[MkDirs] path(%s)unknown error return (%d)", path, resp.StatusCode)
+		}
+	}
+
+	var boolean struct {
+		Boolean bool `json:"boolean,omitempty"`
+	}
+	err = json.Unmarshal(body, &boolean)
+	if err != nil {
+		return err
+	} else if !boolean.Boolean {
+		return ErrBoolean
+	}
+
+	return nil
+}
+
+// GetFileStatus returns status for a given file.  The Path must represent a FILE
+// on the remote system.
+func (fs *FileSystem) GetFileStatus(path string) (FileStatus, error) {
+	v := url.Values{
+		"user.name": []string{fs.UserName},
+		"op":        []string{"GETFILESTATUS"},
+	}
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return FileStatus{}, err
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return FileStatus{}, err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return FileStatus{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return FileStatus{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return FileStatus{}, err
+		} else if re.RemoteException.Exception != "" {
+			return FileStatus{}, re.RemoteException
+		} else {
+			return FileStatus{}, fmt.Errorf("[GetFileStatus] path(%s) unknown error return (%d)",
+				path,
+				resp.StatusCode)
+		}
+	}
+
+	var fileStatus struct {
+		FileStatus FileStatus `json:"FileStatus,omitempty"`
+	}
+	err = json.Unmarshal(body, &fileStatus)
+	if err != nil {
+		return FileStatus{}, err
+	}
+	return fileStatus.FileStatus, nil
+}
+
+// ListStatus returns an array of FileStatus for a given file directory.
+// For details, see HDFS FileSystem.listStatus()
+func (fs *FileSystem) ListStatus(path string) ([]FileStatus, error) {
+	v := url.Values{
+		"user.name": []string{fs.UserName},
+		"op":        []string{"LISTSTATUS"},
+	}
+	u, err := fs.buildRequestURL(path, v)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := fs.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		re := RespException{}
+		if err := json.Unmarshal(body, &re); err != nil {
+			return nil, err
+		} else if re.RemoteException.Exception != "" {
+			return nil, re.RemoteException
+		} else {
+			return nil, fmt.Errorf("[ListStatus] path(%s) unknown error return (%d)", path, resp.StatusCode)
+		}
+	}
+
+	var fileStatuses struct {
+		FileStatuses FileStatuses `json:"FileStatuses,omitempty"`
+	}
+	err = json.Unmarshal(body, &fileStatuses)
+	if err != nil {
+		return nil, err
+	}
+	return fileStatuses.FileStatuses.FileStatus, nil
+}
+
+// Builds the canonical URL used for remote request
+func (fs *FileSystem) buildRequestURL(path string, v url.Values) (*url.URL, error) {
+	urlStr := fmt.Sprintf("http://%s:%s%s", fs.NameNodeHost, fs.NameNodePort, webHdfsVer) + "?"
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	//prepare URL - add Path and "op" to URL
+	if path[0] == '/' {
+		u.Path = u.Path + path
+	} else {
+		u.Path = u.Path + "/" + path
+	}
+	u.RawQuery = v.Encode()
+	return u, nil
+}

--- a/registry/storage/driver/hdfsweb/hdfs.go
+++ b/registry/storage/driver/hdfsweb/hdfs.go
@@ -1,0 +1,489 @@
+// Package hdfsweb provides a storagedriver.StorageDriver implementation to
+// store blobs in Hadoop HDFS cloud storage.
+//
+// This package leverages the vladimirvivien/gowfs client functions for
+// interfacing with Hadoop HDFS.
+package hdfsweb
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/user"
+	"path"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/registry/storage/driver/base"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+)
+
+const (
+	driverName         = "hdfsweb"
+	defaultBlockSize   = int64(64 << 20)
+	defaultBufferSize  = int32(4096)
+	defaultReplication = int16(1)
+)
+
+//DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
+type DriverParameters struct {
+	NameNodeHost  string
+	NameNodePort  string
+	RootDirectory string
+	UserName      string
+	BlockSize     int64
+	BufferSize    int32
+	Replication   int16
+}
+
+func init() {
+	factory.Register(driverName, &hdfsDriverFactory{})
+}
+
+// hdfsDriverFactory implements the factory.StorageDriverFactory interface
+type hdfsDriverFactory struct{}
+
+func (factory *hdfsDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+	return FromParameters(parameters)
+}
+
+type driver struct {
+	RootDirectory string
+	fs            *FileSystem
+}
+
+type baseEmbed struct {
+	base.Base
+}
+
+// Driver is a storagedriver.StorageDriver implementation backed by a local
+// hdfs. All provided paths will be subpaths of the RootDirectory.
+type Driver struct {
+	baseEmbed
+}
+
+// FromParameters constructs a new Driver with a given parameters map
+// Optional Parameters:
+func FromParameters(parameters map[string]interface{}) (*Driver, error) {
+	params := DriverParameters{
+		BlockSize:   defaultBlockSize,
+		BufferSize:  defaultBufferSize,
+		Replication: defaultReplication,
+	}
+
+	if parameters != nil {
+		if v, ok := parameters["namenodehost"]; ok {
+			params.NameNodeHost = fmt.Sprint(v)
+		} else {
+			return nil, fmt.Errorf("parameter doesn't provided")
+		}
+
+		if v, ok := parameters["namenodeport"]; ok {
+			params.NameNodePort = fmt.Sprint(v)
+		} else {
+			return nil, fmt.Errorf("parameter doesn't provided")
+		}
+
+		if v, ok := parameters["rootdirectory"]; ok {
+			params.RootDirectory = fmt.Sprint(v)
+		} else {
+			return nil, fmt.Errorf("parameter doesn't provided")
+		}
+
+		if v, ok := parameters["username"]; ok {
+			params.UserName = fmt.Sprint(v)
+		} else {
+			usr, err := user.Current()
+			if err != nil {
+				return nil, err
+			}
+			params.UserName = usr.Username
+		}
+
+		if blockSizeParam, ok := parameters["blocksize"]; ok {
+			switch v := blockSizeParam.(type) {
+			case string:
+				vv, err := strconv.ParseInt(v, 0, 64)
+				if err != nil {
+					return nil, err
+				}
+				params.BlockSize = vv
+			case int64:
+				params.BlockSize = v
+			case int, uint, int32, uint32, uint64:
+				params.BlockSize = reflect.ValueOf(v).Convert(reflect.TypeOf(params.BlockSize)).Int()
+			default:
+				return nil, fmt.Errorf("invalid valud %#v for blocksize", blockSizeParam)
+			}
+		}
+
+		if bufferSizeParam, ok := parameters["buffersize"]; ok {
+			switch v := bufferSizeParam.(type) {
+			case string:
+				vv, err := strconv.ParseInt(v, 0, 32)
+				if err != nil {
+					return nil, err
+				}
+				params.BufferSize = int32(vv)
+			case int32:
+				params.BufferSize = v
+			case int, int64, uint, uint32, uint64:
+				params.BufferSize = int32(reflect.ValueOf(v).Convert(reflect.TypeOf(params.BufferSize)).Int())
+			default:
+				return nil, fmt.Errorf("invalid valud %#v for buffersize", bufferSizeParam)
+			}
+		}
+
+		if replicationParam, ok := parameters["replication"]; ok {
+			switch v := replicationParam.(type) {
+			case string:
+				vv, err := strconv.ParseInt(v, 0, 16)
+				if err != nil {
+					return nil, err
+				}
+				params.Replication = int16(vv)
+			case int16:
+				params.Replication = v
+			case int, int64, uint, int32, uint32, uint64:
+				params.Replication = int16(reflect.ValueOf(v).Convert(reflect.TypeOf(params.Replication)).Int())
+			default:
+				return nil, fmt.Errorf("invalid valud %#v for replication", replicationParam)
+			}
+		}
+
+	}
+	return New(params)
+}
+
+// New constructs a new Driver with given parameters
+func New(params DriverParameters) (*Driver, error) {
+	return &Driver{
+		baseEmbed: baseEmbed{
+			Base: base.Base{
+				StorageDriver: &driver{
+					fs: &FileSystem{
+						NameNodeHost: params.NameNodeHost,
+						NameNodePort: params.NameNodePort,
+						UserName:     params.UserName,
+						BlockSize:    params.BlockSize,
+						BufferSize:   params.BufferSize,
+						Replication:  params.Replication,
+						Client:       &http.Client{Transport: &http.Transport{Dial: dialTimeout}},
+					},
+					RootDirectory: params.RootDirectory,
+				},
+			},
+		},
+	}, nil
+}
+
+func (d *driver) Name() string {
+	return driverName
+}
+
+// GetContent retrieves the content stored at "path" as a []byte.
+func (d *driver) GetContent(ctx context.Context, subPath string) ([]byte, error) {
+	rc, err := d.Reader(ctx, subPath, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	p, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// PutContent stores the []byte content at a location designated by "path".
+func (d *driver) PutContent(ctx context.Context, subPath string, contents []byte) error {
+	hdfsFullPath := d.fullHdfsPath(subPath)
+	return d.fs.Create(
+		bytes.NewReader(contents),
+		hdfsFullPath)
+}
+
+// ReadStream retrieves an io.ReadCloser for the content stored at "path" with a
+// given byte offset.
+func (d *driver) Reader(ctx context.Context, subPath string, offset int64) (io.ReadCloser, error) {
+	hdfsFullPath := d.fullHdfsPath(subPath)
+
+	status, err := d.fs.GetFileStatus(hdfsFullPath)
+	if err != nil {
+		if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+			return nil, storagedriver.PathNotFoundError{Path: subPath}
+		}
+		return nil, err
+	} else if status.Type != "FILE" {
+		return nil, fmt.Errorf("not file type")
+	} else if status.Length < offset {
+		return nil, storagedriver.InvalidOffsetError{Path: subPath, Offset: offset}
+	}
+
+	if status.Length == offset {
+		r := bytes.NewReader([]byte{})
+		rc := ioutil.NopCloser(r)
+		return rc, nil
+	}
+
+	reader, err := d.fs.Open(hdfsFullPath, offset, (status.Length - offset))
+	if err != nil {
+		return nil, err
+	}
+
+	return reader, nil
+}
+
+// WriteStream stores the contents of the provided io.Reader at a location
+// designated by the given path.
+func (d *driver) Writer(ctx context.Context, subPath string, append bool) (storagedriver.FileWriter, error) {
+	var size int64
+	stat, err := d.fs.GetFileStatus(d.fullHdfsPath(subPath))
+	if err == nil {
+		if append {
+			size = stat.Length
+		}
+	} else if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+		if append {
+			return nil, storagedriver.PathNotFoundError{Path: subPath}
+		}
+	} else {
+		return nil, err
+	}
+	if !append {
+		err = d.fs.Create(bytes.NewReader(make([]byte, 0)), d.fullHdfsPath(subPath))
+	}
+	return d.newWriter(subPath, size), nil
+}
+
+// Stat retrieves the FileInfo for the given path, including the current size
+// in bytes and the creation time.
+func (d *driver) Stat(ctx context.Context, subPath string) (storagedriver.FileInfo, error) {
+	fi := storagedriver.FileInfoFields{
+		Path: subPath,
+	}
+	hdfsFullPath := d.fullHdfsPath(subPath)
+	status, err := d.fs.GetFileStatus(hdfsFullPath)
+	if err != nil {
+		if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+			return nil, storagedriver.PathNotFoundError{Path: subPath}
+		}
+		return nil, err
+	}
+	if status.Type == "FILE" {
+		fi.IsDir = false
+	} else if status.Type == "DIRECTORY" {
+		fi.IsDir = true
+	} else {
+		return nil, fmt.Errorf("unknown path type")
+	}
+	fi.Size = status.Length
+	fi.ModTime = time.Unix((status.ModificationTime / 1000), 0)
+	return storagedriver.FileInfoInternal{FileInfoFields: fi}, nil
+}
+
+// List returns a list of the objects that are direct descendants of the given
+// path.
+func (d *driver) List(ctx context.Context, subPath string) ([]string, error) {
+	legalPath := subPath
+	if legalPath[len(legalPath)-1] != '/' {
+		legalPath += "/"
+	}
+	hdfsFullPath := d.fullHdfsPath(legalPath)
+	list, err := d.fs.ListStatus(hdfsFullPath)
+	if err != nil {
+		if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+			return nil, storagedriver.PathNotFoundError{Path: subPath}
+		}
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(list))
+	for _, stat := range list {
+		keys = append(keys, path.Join(legalPath, stat.PathSuffix))
+	}
+	return keys, nil
+}
+
+// Move moves an object stored at subSrcPath to subDstPath, removing the original
+// object.
+func (d *driver) Move(ctx context.Context, subSrcPath, subDstPath string) error {
+	fullSrcPath := d.fullHdfsPath(subSrcPath)
+	fullDstPath := d.fullHdfsPath(subDstPath)
+
+	// check if source path exist
+	if _, err := d.fs.GetFileStatus(fullSrcPath); err != nil {
+		if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+			return storagedriver.PathNotFoundError{Path: subSrcPath}
+		}
+		return err
+	}
+	// delete destination if exists
+	// for loop is for avoiding the clients competitive
+	for {
+		if _, err := d.fs.GetFileStatus(fullDstPath); err == nil {
+			if err := d.Delete(ctx, subDstPath); err != nil && err != ErrBoolean {
+				return err
+			}
+		}
+		if err := d.fs.MkDirs(path.Dir(fullDstPath)); err != nil {
+			return err
+		}
+		if err := d.fs.Rename(fullSrcPath, fullDstPath); err == ErrBoolean {
+			continue
+		} else {
+			return err
+		}
+	}
+}
+
+// Delete recursively deletes all objects stored at "path" and its subpaths.
+func (d *driver) Delete(ctx context.Context, subPath string) error {
+	hdfsFullPath := d.fullHdfsPath(subPath)
+	// check if path exist
+	if _, err := d.fs.GetFileStatus(hdfsFullPath); err != nil {
+		if re, ok := err.(RemoteException); ok && re.Exception == ExceptionFileNotFound {
+			return storagedriver.PathNotFoundError{Path: subPath}
+		}
+		return err
+	}
+	if err := d.fs.Delete(hdfsFullPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+// URLFor returns a URL which may be used to retrieve the content stored at the given path.
+// May return an UnsupportedMethodErr in certain StorageDriver implementations.
+func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	return "", storagedriver.ErrUnsupportedMethod{}
+}
+
+func (d *driver) fullHdfsPath(subPath string) string {
+	return path.Join(d.RootDirectory, subPath)
+}
+
+func checkFileExist(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+
+	return false
+}
+
+func convIntParameter(param interface{}) (int64, error) {
+	var num int64
+	switch v := param.(type) {
+	case string:
+		vv, err := strconv.ParseInt(v, 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parameter must be an integer, %v invalid", param)
+		}
+		num = vv
+	case int64:
+		num = v
+	case int, uint, int32, uint32, uint64:
+		num = reflect.ValueOf(v).Convert(reflect.TypeOf(num)).Int()
+	default:
+		return 0, fmt.Errorf("invalid valud %#v", param)
+	}
+	return num, nil
+}
+
+func dialTimeout(network, addr string) (net.Conn, error) {
+	return net.DialTimeout(network, addr, time.Duration(2*time.Second))
+}
+
+type writer struct {
+	driver    *driver
+	bw        *bufio.Writer
+	path      string
+	size      int64
+	closed    bool
+	committed bool
+	cancelled bool
+}
+
+func (d *driver) newWriter(subPath string, size int64) storagedriver.FileWriter {
+	return &writer{
+		driver: d,
+		size:   size,
+		path:   d.fullHdfsPath(subPath),
+		bw: bufio.NewWriterSize(&blobWriter{
+			fs:   d.fs,
+			path: d.fullHdfsPath(subPath),
+		}, int(d.fs.BlockSize)),
+	}
+}
+
+func (w *writer) Write(p []byte) (int, error) {
+	if w.closed {
+		return 0, fmt.Errorf("already closed")
+	} else if w.committed {
+		return 0, fmt.Errorf("already committed")
+	} else if w.cancelled {
+		return 0, fmt.Errorf("already cancelled")
+	}
+
+	n, err := w.bw.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+func (w *writer) Size() int64 {
+	return w.size
+}
+
+func (w *writer) Close() error {
+	if w.closed {
+		return fmt.Errorf("already closed")
+	}
+	w.closed = true
+	return w.bw.Flush()
+}
+
+func (w *writer) Cancel() error {
+	if w.closed {
+		return fmt.Errorf("already closed")
+	} else if w.committed {
+		return fmt.Errorf("already committed")
+	}
+	w.cancelled = true
+	return w.driver.fs.Delete(w.path)
+}
+
+func (w *writer) Commit() error {
+	if w.closed {
+		return fmt.Errorf("already closed")
+	} else if w.committed {
+		return fmt.Errorf("already committed")
+	} else if w.cancelled {
+		return fmt.Errorf("already cancelled")
+	}
+	w.committed = true
+	return w.bw.Flush()
+}
+
+type blobWriter struct {
+	fs   *FileSystem
+	path string
+}
+
+func (bw *blobWriter) Write(p []byte) (int, error) {
+	var err error
+	err = bw.fs.Append(bytes.NewReader(p), bw.path)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/registry/storage/driver/hdfsweb/hdfs_test.go
+++ b/registry/storage/driver/hdfsweb/hdfs_test.go
@@ -1,0 +1,149 @@
+package hdfsweb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"strconv"
+	"testing"
+
+	ctx "github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/registry/storage/driver/testsuites"
+	"gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+var HdfsDriverConstructor func(rootDirectory string) (*Driver, error)
+var skipHdfs func() string
+
+func init() {
+	nameNodeHost := os.Getenv("HDFS_NAME_NODE_HOST")
+	nameNodePort := os.Getenv("HDFS_NAME_NODE_PORT")
+	root, err := ioutil.TempDir("", "driver-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(root)
+	HdfsDriverConstructor = func(rootDirectory string) (*Driver, error) {
+		var (
+			blockSize   = defaultBlockSize
+			bufferSize  = defaultBufferSize
+			replication = defaultReplication
+		)
+		if nameNodeHost == "" {
+			return nil, fmt.Errorf("not provide HDFS_NAME_NODE_HOST")
+		}
+
+		if nameNodePort == "" {
+			return nil, fmt.Errorf("not provide HDFS_NAME_NODE_HOST")
+		}
+
+		if v := os.Getenv("HDFS_BLOCK_SIZE"); v != "" {
+			blockSize, err = strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if v := os.Getenv("HDFS_BUFFER_SIZE"); v != "" {
+			i, err := strconv.ParseInt(v, 0, 32)
+			if err != nil {
+				return nil, err
+			}
+			bufferSize = int32(i)
+		}
+
+		if v := os.Getenv("HDFS_REPLICATION"); v != "" {
+			i, err := strconv.ParseInt(v, 0, 16)
+			if err != nil {
+				return nil, err
+			}
+			replication = int16(i)
+		}
+
+		userName := os.Getenv("HDFS_USER_NAME")
+		if userName == "" {
+			usr, err := user.Current()
+			if err != nil {
+				return nil, err
+			}
+			userName = usr.Username
+		}
+
+		return New(DriverParameters{
+			NameNodeHost:  nameNodeHost,
+			NameNodePort:  nameNodePort,
+			RootDirectory: rootDirectory,
+			UserName:      userName,
+			BlockSize:     blockSize,
+			BufferSize:    int32(bufferSize),
+			Replication:   int16(replication),
+		})
+	}
+
+	// Skip HDFS storage driver tests if environment variable parameters are not provided
+	skipHdfs = func() string {
+		if nameNodeHost == "" || nameNodePort == "" {
+			return "Must set HDFS_NAME_NODE_HOST, HDFS_NAME_NODE_PORT and HDFS_ROOT_DIRECTORY to run HDFS tests"
+		}
+		return ""
+	}
+
+	testsuites.RegisterSuite(func() (storagedriver.StorageDriver, error) {
+		return HdfsDriverConstructor(root)
+	}, skipHdfs)
+}
+
+func TestEmptyRootList(t *testing.T) {
+	if skipHdfs() != "" {
+		t.Skip(skipHdfs())
+	}
+
+	validRoot, err := ioutil.TempDir("", "driver-")
+	if err != nil {
+		t.Fatalf("unexpected error creating temporary directory: %v", err)
+	}
+	defer os.Remove(validRoot)
+
+	rootedDriver, err := HdfsDriverConstructor(validRoot)
+	if err != nil {
+		t.Fatalf("unexpected error creating rooted driver: %v", err)
+	}
+
+	emptyRootDriver, err := HdfsDriverConstructor("")
+	if err != nil {
+		t.Fatalf("unexpected error creating empty root driver: %v", err)
+	}
+
+	slashRootDriver, err := HdfsDriverConstructor("/")
+	if err != nil {
+		t.Fatalf("unexpected error creating slash root driver: %v", err)
+	}
+
+	filename := "/test"
+	contents := []byte("contents")
+	ctx := ctx.Background()
+	err = rootedDriver.PutContent(ctx, filename, contents)
+	if err != nil {
+		t.Fatalf("unexpected error creating content: %v", err)
+	}
+	defer rootedDriver.Delete(ctx, filename)
+
+	keys, err := emptyRootDriver.List(ctx, "/")
+	for _, path := range keys {
+		if !storagedriver.PathRegexp.MatchString(path) {
+			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
+		}
+	}
+
+	keys, err = slashRootDriver.List(ctx, "/")
+	for _, path := range keys {
+		if !storagedriver.PathRegexp.MatchString(path) {
+			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
+		}
+	}
+}

--- a/registry/storage/driver/hdfsweb/types.go
+++ b/registry/storage/driver/hdfsweb/types.go
@@ -1,0 +1,104 @@
+// Refer to github.com/vladimirvivien/gowfs
+
+package hdfsweb
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// ExceptionIllegalArgument indicates 400 Bad Request
+	ExceptionIllegalArgument = "IllegalArgumentException"
+
+	// ExceptionUnsupportedOperation indicates 400 Bad Request
+	ExceptionUnsupportedOperation = "UnsupportedOperationException"
+
+	// ExceptionSecurity indicates 401 Unauthorized
+	ExceptionSecurity = "SecurityException"
+
+	// ExceptionIO indicates 403 Forbidden
+	ExceptionIO = "IOException"
+
+	// ExceptionFileNotFound indicates 404 Not Found
+	ExceptionFileNotFound = "FileNotFoundException"
+
+	// ExceptionRuntime indicates 500 Internal Server Error
+	ExceptionRuntime = "RuntimeException"
+)
+
+// ErrBoolean means returning an error when the operation get
+// a false result from Boolean JSON Schema.
+var ErrBoolean = errors.New("Return a false boolean result")
+
+// FileStatus Represents HDFS FileStatus (FileSystem.getStatus())
+// See http://hadoop.apache.org/docs/r2.2.0/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#FileStatus_JSON_Schema
+// Example:
+// {
+//   "FileStatus":
+//   {
+//     "accessTime"      : 0, 				// integer
+//     "blockSize"       : 0, 				// integer
+//     "group"           : "grp",			// string
+//     "length"          : 0,             	// integer - zero for directories
+//     "modificationTime": 1320173277227,	// integer
+//     "owner"           : "webuser",		// string
+//     "pathSuffix"      : "",				// string
+//     "permission"      : "777",			// string
+//     "replication"     : 0,				// integer
+//     "type"            : "DIRECTORY"    	// string - enum {FILE, DIRECTORY, SYMLINK}
+//   }
+// }
+type FileStatus struct {
+	AccesTime        int64  `json:"accessTime,omitempty"`
+	BlockSize        int64  `json:"blockSize,omitempty"`
+	Group            string `json:"group,omitempty"`
+	Length           int64  `json:"length,omitempty"`
+	ModificationTime int64  `json:"modificationTime,omitempty"`
+	Owner            string `json:"owner,omitempty"`
+	PathSuffix       string `json:"pathSuffix,omitempty"`
+	Permission       string `json:"permission,omitempty"`
+	Replication      int64  `json:"replication,omitempty"`
+	Type             string `json:"type,omitempty"`
+}
+
+// FileStatuses Container type for multiple FileStatus for directory, etc
+// (see HDFS FileSystem.listStatus())
+type FileStatuses struct {
+	FileStatus []FileStatus `json:"FileStatus,omitempty"`
+}
+
+// RemoteException defines the JSON schema of error responses.
+// When the HTTP request to HDFS server get not OK or Created status, API
+// functions return printed error message with the status code. It doesn't paser and
+// return the RemoteException error content. The detailed exception content refers to:
+// http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Error_Responses
+// Example:
+// Content-Type: application/json
+// Transfer-Encoding: chunked
+// {
+//   "RemoteException":
+//   {
+//     "exception"    : "FileNotFoundException",
+//     "javaClassName": "java.io.FileNotFoundException",
+//     "message"      : "File does not exist: /foo/a.patch"
+//   }
+// }
+type RemoteException struct {
+	Exception     string `json:"exception,omitempty"`
+	JavaClassName string `json:"javaClassName,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+// Implementation of error type. it returns string representation of RemoteException.
+func (re RemoteException) Error() string {
+	return fmt.Sprintf("RemoteException = %s, JavaClassName = %s, Message = %s",
+		re.Exception,
+		re.JavaClassName,
+		re.Message)
+}
+
+// RespException wrap the structure RemoteException
+type RespException struct {
+	RemoteException RemoteException `json:"RemoteException,omitempty"`
+}


### PR DESCRIPTION
This is for issue #1086 .

This PR build `hdfs` package as HDFS Driver Factory,
to presents HDFS Storage Driver to distribution.

This allows distribution client to access Apache Hadoop
Distributed File System server. The connection protocal
is `WebHDFS REST API`, provided by Apache official.

Signed-off-by: xiekeyang xiekeyang@huawei.com
