### PR TITLE
WIP: Add support for oauth2 providers

### DIFF
--- a/registry/client/auth/authchallenge.go
+++ b/registry/client/auth/authchallenge.go
@@ -154,9 +154,6 @@ func parseValueAndParams(header string) (value string, params map[string]string)
 		}
 		var pvalue string
 		pvalue, s = expectTokenOrQuoted(s[1:])
-		if pvalue == "" {
-			return
-		}
 		pkey = strings.ToLower(pkey)
 		params[pkey] = pvalue
 		s = skipSpace(s)

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAuthChallengeParse(t *testing.T) {
 	header := http.Header{}
-	header.Add("WWW-Authenticate", `Bearer realm="https://auth.example.com/token",service="registry.example.com",other=fun,slashed="he\"\l\lo"`)
+	header.Add("WWW-Authenticate", `Bearer realm="https://auth.example.com/token",service="registry.example.com",empty="",other=fun,slashed="he\"\l\lo"`)
 
 	challenges := parseAuthHeader(header)
 	if len(challenges) != 1 {
@@ -30,6 +30,10 @@ func TestAuthChallengeParse(t *testing.T) {
 		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["service"], expected)
 	}
 
+	if _, ok := challenge.Parameters["empty"]; !ok {
+		t.Fatalf("No empty value in parameters")
+	}
+
 	if expected := "fun"; challenge.Parameters["other"] != expected {
 		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["other"], expected)
 	}
@@ -37,7 +41,6 @@ func TestAuthChallengeParse(t *testing.T) {
 	if expected := "he\"llo"; challenge.Parameters["slashed"] != expected {
 		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["slashed"], expected)
 	}
-
 }
 
 func TestAuthChallengeNormalization(t *testing.T) {

--- a/registry/client/auth/oauth2.go
+++ b/registry/client/auth/oauth2.go
@@ -1,18 +1,45 @@
 package auth
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
-// ErrInvalidOAuth2Scheme is used when a challenge is not using a scheme
-// supported by OAuth2.
-var ErrInvalidOAuth2Scheme = errors.New("invalid oauth2 authorization scheme")
+// IsNotSupported checks whether the error indicates that
+// the operation is not supported for the given oauth2 parameters.
+func IsNotSupported(err error) bool {
+	switch err.(type) {
+	case invalidOAuth2Scheme:
+		return true
+	case callbackListenErr:
+		return true
+	}
+	return false
+}
+
+type invalidOAuth2Scheme struct {
+	scheme string
+}
+
+func (err invalidOAuth2Scheme) Error() string {
+	return fmt.Sprintf("invalid OAuth2 scheme: %s", err.scheme)
+}
+
+type callbackListenErr struct {
+	listenErr error
+}
+
+func (err callbackListenErr) Error() string {
+	return fmt.Sprintf("unable to listen for callback: %s", err.listenErr)
+}
 
 // OAuth2Config represents a generic set of oauth2 parameters a client
 // will need to direct a user through the authorization flow to get
@@ -20,7 +47,8 @@ var ErrInvalidOAuth2Scheme = errors.New("invalid oauth2 authorization scheme")
 type OAuth2Config struct {
 	ClientID    string   `json:"client_id"`
 	AuthURL     string   `json:"auth_url"`
-	RedirectURL string   `json:"redirect_url,omitempty"`
+	CallbackURL string   `json:"callback_url,omitempty"`
+	CodeURL     string   `json:"code_url,omitempty"`
 	LandingURL  string   `json:"landing_url,omitempty"`
 	Scopes      []string `json:"scopes,omitempty"`
 }
@@ -29,8 +57,14 @@ type OAuth2Config struct {
 // This information will be parsed and used by clients.
 func (c OAuth2Config) HeaderValue() (str string) {
 	str = fmt.Sprintf("OAuth2 client_id=%q,auth_url=%q", c.ClientID, c.AuthURL)
-	if c.RedirectURL != "" {
-		str = fmt.Sprintf("%s,redirect_url=%q", str, c.RedirectURL)
+	if c.CallbackURL != "" {
+		str = fmt.Sprintf("%s,callback_url=%q", str, c.CallbackURL)
+	}
+	if c.CodeURL != "" {
+		str = fmt.Sprintf("%s,code_url=%q", str, c.CodeURL)
+	}
+	if c.LandingURL != "" {
+		str = fmt.Sprintf("%s,landing_url=%q", str, c.LandingURL)
 	}
 	if len(c.Scopes) > 0 {
 		str = fmt.Sprintf("%s,scopes=%q", str, strings.Join(c.Scopes, " "))
@@ -43,7 +77,7 @@ func (c OAuth2Config) HeaderValue() (str string) {
 // The realm is queried for an oauth2 configuration.
 func GetOAuth2Config(client *http.Client, ch Challenge) (OAuth2Config, error) {
 	if ch.Scheme != "bearer" {
-		return OAuth2Config{}, ErrInvalidOAuth2Scheme
+		return OAuth2Config{}, invalidOAuth2Scheme{ch.Scheme}
 	}
 
 	realm, ok := ch.Parameters["realm"]
@@ -65,8 +99,9 @@ func GetOAuth2Config(client *http.Client, ch Challenge) (OAuth2Config, error) {
 	config := OAuth2Config{
 		ClientID:    params["client_id"],
 		AuthURL:     params["auth_url"],
-		RedirectURL: params["redirect_url"],
+		CallbackURL: params["callback_url"],
 		LandingURL:  params["landing_url"],
+		CodeURL:     params["code_url"],
 	}
 	if scopes := params["scopes"]; scopes != "" {
 		config.Scopes = strings.Split(scopes, " ")
@@ -75,10 +110,20 @@ func GetOAuth2Config(client *http.Client, ch Challenge) (OAuth2Config, error) {
 	return config, nil
 }
 
+// OAuth2CodeHandler handles getting an oauth code back to
+// a client from an oauth2 user agent.
+type OAuth2CodeHandler interface {
+	CodeChan() <-chan string
+	Error() error
+	Cancel(error)
+}
+
 type callbackHandler struct {
 	authURL *url.URL
 
-	listener net.Listener
+	shutdown chan struct{}
+	errL     sync.Mutex
+	err      error
 
 	codeChan chan string
 	state    string
@@ -87,7 +132,7 @@ type callbackHandler struct {
 
 // NewOAuth2CallbackHandler sets up a handler to listen at a callback url
 // and return the authorization code return from the authorization process.
-func NewOAuth2CallbackHandler(callbackURL, state, redirect string) (<-chan string, error) {
+func NewOAuth2CallbackHandler(callbackURL, state, redirect string) (OAuth2CodeHandler, error) {
 	authURL, err := url.Parse(callbackURL)
 	if err != nil {
 		return nil, err
@@ -95,7 +140,7 @@ func NewOAuth2CallbackHandler(callbackURL, state, redirect string) (<-chan strin
 
 	listener, err := net.Listen("tcp", authURL.Host)
 	if err != nil {
-		return nil, err
+		return nil, callbackListenErr{err}
 	}
 
 	if redirect == "" {
@@ -103,18 +148,45 @@ func NewOAuth2CallbackHandler(callbackURL, state, redirect string) (<-chan strin
 	}
 
 	codeChan := make(chan string, 1)
+	shutdownChan := make(chan struct{})
 
 	handler := &callbackHandler{
 		authURL:  authURL,
-		listener: listener,
 		codeChan: codeChan,
+		shutdown: shutdownChan,
 		state:    state,
 		redirect: redirect,
 	}
 
 	go http.Serve(listener, handler)
+	go func() {
+		<-shutdownChan
+		time.Sleep(time.Second)
+		listener.Close()
+	}()
 
-	return codeChan, nil
+	return handler, nil
+}
+
+func (h *callbackHandler) CodeChan() <-chan string {
+	return h.codeChan
+}
+
+func (h *callbackHandler) Error() error {
+	h.errL.Lock()
+	defer h.errL.Unlock()
+	return h.err
+}
+
+func (h *callbackHandler) Cancel(err error) {
+	h.errL.Lock()
+	defer h.errL.Unlock()
+	if h.shutdown != nil {
+		close(h.shutdown)
+		close(h.codeChan)
+		h.shutdown = nil
+		h.err = err
+	}
 }
 
 // ServeHTTP serves the callback handler for an http client
@@ -131,13 +203,152 @@ func (h *callbackHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code := r.URL.Query().Get("code")
-	if code != "" {
-		h.codeChan <- code
-		go func() {
-			time.Sleep(5 * time.Second)
-			h.listener.Close()
-		}()
-	}
 	http.Redirect(rw, r, h.redirect, http.StatusMovedPermanently)
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		return
+	}
+
+	h.errL.Lock()
+	if h.shutdown != nil {
+		h.codeChan <- code
+		close(h.shutdown)
+		h.shutdown = nil
+	}
+	h.errL.Unlock()
+}
+
+type pollHandler struct {
+	codeReq *http.Request
+	client  *http.Client
+
+	errL      sync.Mutex
+	err       error
+	shutdownC chan struct{}
+	shutdown  bool
+
+	codeChan chan string
+	state    string
+}
+
+// NewOAuth2PollHandler gets the code by polling the code URL with the
+// provided state and waits for the code to be returned. Each request
+// will long poll to wait for the code to become available.
+func NewOAuth2PollHandler(client *http.Client, codeURL, state string) (OAuth2CodeHandler, error) {
+	req, err := http.NewRequest("GET", codeURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	query.Set("state", state)
+	req.URL.RawQuery = query.Encode()
+
+	codeChan := make(chan string, 1)
+	shutdownChan := make(chan struct{})
+
+	handler := &pollHandler{
+		codeReq:   req,
+		client:    client,
+		codeChan:  codeChan,
+		shutdownC: shutdownChan,
+		state:     state,
+	}
+
+	go handler.poll()
+
+	return handler, nil
+}
+
+func (h *pollHandler) CodeChan() <-chan string {
+	return h.codeChan
+}
+
+func (h *pollHandler) Error() error {
+	h.errL.Lock()
+	defer h.errL.Unlock()
+	return h.err
+}
+
+func (h *pollHandler) Cancel(err error) {
+	h.errL.Lock()
+	defer h.errL.Unlock()
+	if !h.shutdown {
+		close(h.shutdownC)
+		close(h.codeChan)
+		h.shutdown = true
+		h.err = err
+	}
+}
+
+func (h *pollHandler) poll() {
+	var (
+		code    string
+		codeErr error
+		retry   int
+	)
+	for retry < 3 {
+		codeErr = nil
+		resp, err := h.client.Do(h.codeReq)
+		if err != nil {
+			// TODO: retry on temporary network errors
+			codeErr = err
+			break
+		}
+		if resp.StatusCode != 200 {
+			if resp.StatusCode >= 500 {
+				retry++
+				codeErr = fmt.Errorf("server error: %s", resp.Status)
+				time.Sleep(time.Second)
+				continue
+			}
+			codeErr = fmt.Errorf("unable to get code: %s", resp.Status)
+			break
+		}
+		codeC := make(chan string, 1)
+		var scanErr error
+
+		go func() {
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				if scanErr = scanner.Err(); scanErr != nil {
+					close(codeC)
+					break
+				}
+				t := scanner.Text()
+				if strings.HasPrefix(t, "CODE ") {
+					codeC <- t[5:]
+					break
+				}
+			}
+		}()
+
+		select {
+		case <-h.shutdownC:
+		case code = <-codeC:
+			if scanErr != nil {
+				codeErr = fmt.Errorf("error reading body: %s", scanErr)
+				if scanErr == io.EOF {
+					retry++
+					continue
+				}
+			}
+		}
+		resp.Body.Close()
+		break
+	}
+	h.errL.Lock()
+	if !h.shutdown {
+		if code != "" {
+			h.codeChan <- code
+		} else {
+			close(h.codeChan)
+		}
+		if codeErr != nil {
+			h.err = codeErr
+		}
+		close(h.shutdownC)
+		h.shutdown = true
+	}
+	h.errL.Unlock()
 }

--- a/registry/client/auth/oauth2.go
+++ b/registry/client/auth/oauth2.go
@@ -1,0 +1,143 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrInvalidOAuth2Scheme is used when a challenge is not using a scheme
+// supported by OAuth2.
+var ErrInvalidOAuth2Scheme = errors.New("invalid oauth2 authorization scheme")
+
+// OAuth2Config represents a generic set of oauth2 parameters a client
+// will need to direct a user through the authorization flow to get
+// an authorization code.
+type OAuth2Config struct {
+	ClientID    string   `json:"client_id"`
+	AuthURL     string   `json:"auth_url"`
+	RedirectURL string   `json:"redirect_url,omitempty"`
+	LandingURL  string   `json:"landing_url,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+}
+
+// HeaderValue returns the value for an authentication header.
+// This information will be parsed and used by clients.
+func (c OAuth2Config) HeaderValue() (str string) {
+	str = fmt.Sprintf("OAuth2 client_id=%q,auth_url=%q", c.ClientID, c.AuthURL)
+	if c.RedirectURL != "" {
+		str = fmt.Sprintf("%s,redirect_url=%q", str, c.RedirectURL)
+	}
+	if len(c.Scopes) > 0 {
+		str = fmt.Sprintf("%s,scopes=%q", str, strings.Join(c.Scopes, " "))
+	}
+
+	return
+}
+
+// GetOAuth2Config gets an OAuth2 configuration using a bearer challenge.
+// The realm is queried for an oauth2 configuration.
+func GetOAuth2Config(client *http.Client, ch Challenge) (OAuth2Config, error) {
+	if ch.Scheme != "bearer" {
+		return OAuth2Config{}, ErrInvalidOAuth2Scheme
+	}
+
+	realm, ok := ch.Parameters["realm"]
+	if !ok {
+		return OAuth2Config{}, errors.New("no realm specified for token auth challenge")
+	}
+
+	resp, err := client.Head(realm)
+	if err != nil {
+		return OAuth2Config{}, err
+	}
+	defer resp.Body.Close()
+
+	value, params := parseValueAndParams(resp.Header.Get("WWW-Authenticate"))
+	if value != "oauth2" {
+		return OAuth2Config{}, errors.New("missing oauth2 config header")
+	}
+
+	config := OAuth2Config{
+		ClientID:    params["client_id"],
+		AuthURL:     params["auth_url"],
+		RedirectURL: params["redirect_url"],
+		LandingURL:  params["landing_url"],
+	}
+	if scopes := params["scopes"]; scopes != "" {
+		config.Scopes = strings.Split(scopes, " ")
+	}
+
+	return config, nil
+}
+
+type callbackHandler struct {
+	authURL *url.URL
+
+	listener net.Listener
+
+	codeChan chan string
+	state    string
+	redirect string
+}
+
+// NewOAuth2CallbackHandler sets up a handler to listen at a callback url
+// and return the authorization code return from the authorization process.
+func NewOAuth2CallbackHandler(callbackURL, state, redirect string) (<-chan string, error) {
+	authURL, err := url.Parse(callbackURL)
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", authURL.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	if redirect == "" {
+		redirect = "https://docs.docker.com/registry/"
+	}
+
+	codeChan := make(chan string, 1)
+
+	handler := &callbackHandler{
+		authURL:  authURL,
+		listener: listener,
+		codeChan: codeChan,
+		state:    state,
+		redirect: redirect,
+	}
+
+	go http.Serve(listener, handler)
+
+	return codeChan, nil
+}
+
+// ServeHTTP serves the callback handler for an http client
+// to redirect a user to after authorization.
+func (h *callbackHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != h.authURL.Path {
+		http.Error(rw, "Unexpected Path", http.StatusNotFound)
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+	if state != h.state {
+		http.Error(rw, "Bad state", http.StatusBadRequest)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code != "" {
+		h.codeChan <- code
+		go func() {
+			time.Sleep(5 * time.Second)
+			h.listener.Close()
+		}()
+	}
+	http.Redirect(rw, r, h.redirect, http.StatusMovedPermanently)
+}

--- a/registry/client/auth/oauth2_test.go
+++ b/registry/client/auth/oauth2_test.go
@@ -1,0 +1,281 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/testutil"
+)
+
+func assertEqualStrings(t *testing.T, name, expected, actual string) {
+	if expected != actual {
+		t.Errorf("Unexpected %s value %q, expected %q", name, actual, expected)
+	}
+}
+
+func assertEqualConfigs(t *testing.T, expected, actual OAuth2Config) {
+	assertEqualStrings(t, "ClientID", expected.ClientID, actual.ClientID)
+	assertEqualStrings(t, "AuthURL", expected.AuthURL, actual.AuthURL)
+	assertEqualStrings(t, "CallbackURL", expected.CallbackURL, actual.CallbackURL)
+	assertEqualStrings(t, "CodeURL", expected.CodeURL, actual.CodeURL)
+	assertEqualStrings(t, "LandingURL", expected.LandingURL, actual.LandingURL)
+	if len(expected.Scopes) != len(actual.Scopes) {
+		t.Errorf("Unexpected number of scopes %d, expected %d", len(actual.Scopes), len(expected.Scopes))
+	} else {
+		sort.Strings(expected.Scopes)
+		sort.Strings(actual.Scopes)
+		for i := range expected.Scopes {
+			if expected.Scopes[i] != actual.Scopes[i] {
+				t.Errorf("Unexpected scope %q, expected %q", actual.Scopes[i], expected.Scopes[i])
+				break
+			}
+		}
+	}
+}
+
+func TestGetHeaderConfig(t *testing.T) {
+	testValues := []struct {
+		Header   string
+		Expected OAuth2Config
+		Error    bool
+	}{
+		{
+			Header: `OAuth2 client_id="5",auth_url="http://localhost:8080/authorize",callback_url="http://localhost:8080/oauth2callback",code_url="http://localhost:8081/oauth2code",landing_url="https://docs.docker.com/registry/spec",scopes="fun fun fun"`,
+			Expected: OAuth2Config{
+				ClientID:    "5",
+				AuthURL:     "http://localhost:8080/authorize",
+				CallbackURL: "http://localhost:8080/oauth2callback",
+				CodeURL:     "http://localhost:8081/oauth2code",
+				LandingURL:  "https://docs.docker.com/registry/spec",
+				Scopes:      []string{"fun", "fun", "fun"},
+			},
+			Error: false,
+		},
+		{
+			Header: `OAuth2 client_id="",auth_url="http://localhost:8080/authorize",callback_url="http://localhost:8080/oauth2callback",landing_url="https://docs.docker.com/registry/spec"`,
+			Expected: OAuth2Config{
+				AuthURL:     "http://localhost:8080/authorize",
+				CallbackURL: "http://localhost:8080/oauth2callback",
+				LandingURL:  "https://docs.docker.com/registry/spec",
+				Scopes:      []string{},
+			},
+			Error: false,
+		},
+		{
+			Header: `OAuth2 client_id="",auth_url="",scopes="onescope"`,
+			Expected: OAuth2Config{
+				Scopes: []string{"onescope"},
+			},
+			Error: false,
+		},
+		{
+			Header:   `OAuth2 client_id="",auth_url=""`,
+			Expected: OAuth2Config{},
+			Error:    false,
+		},
+		{
+			Header:   `NotOAuth2 client_id="",auth_url=""`,
+			Expected: OAuth2Config{},
+			Error:    true,
+		},
+	}
+
+	var m []testutil.RequestResponseMapping
+	for i := range testValues {
+		m = append(m, testutil.RequestResponseMapping{
+			Request: testutil.Request{
+				Method: "HEAD",
+				Route:  "/v2/token",
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusUnauthorized,
+				Headers: http.Header{
+					"WWW-Authenticate": {testValues[i].Header},
+				},
+			},
+		})
+	}
+	ts := httptest.NewServer(testutil.NewHandler(m))
+	defer ts.Close()
+
+	challenge := Challenge{
+		Scheme: "bearer",
+		Parameters: map[string]string{
+			"realm": ts.URL + "/v2/token",
+		},
+	}
+
+	for i := range testValues {
+		config, err := GetOAuth2Config(http.DefaultClient, challenge)
+		if err != nil {
+			if !testValues[i].Error {
+				t.Error(err)
+			}
+			continue
+		}
+		assertEqualConfigs(t, testValues[i].Expected, config)
+
+		header := config.HeaderValue()
+		if header != testValues[i].Header {
+			t.Errorf("Unexpected header value\n%s, expected\n%s", header, testValues[i].Header)
+		}
+	}
+}
+
+func TestCallbackHandler(t *testing.T) {
+	state := "93282342"
+	callbackURL := "http://localhost:12945/oauth2callback"
+
+	handler, err := NewOAuth2CallbackHandler(callbackURL, state, "https://docs.docker.com/registry/spec/auth/oauth/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	redirectErr := errors.New("skip redirect")
+	client := http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return redirectErr
+		},
+	}
+
+	expectedCode := "329118352"
+
+	resp, err := client.Get(fmt.Sprintf("%s?state=%s&code=%s", callbackURL, state, expectedCode))
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); !ok || urlErr.Err != redirectErr {
+			t.Fatal(err)
+		}
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("Unexpected error code %d, expected %d", resp.StatusCode, http.StatusMovedPermanently)
+	}
+	location, err := resp.Location()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := "docs.docker.com"; location.Host != expected {
+		t.Fatalf("Unexpected redirect host %s, expected %s", location.Host, expected)
+	}
+	if expected := "/registry/spec/auth/oauth/"; location.Path != expected {
+		t.Fatalf("Unexpected redirect path %s, expected %s", location.Path, expected)
+	}
+
+	code := <-handler.CodeChan()
+
+	if err := handler.Error(); err != nil {
+		t.Fatal(err)
+	}
+
+	if code != expectedCode {
+		t.Fatalf("Unexpected code %q, expected %q", code, expectedCode)
+	}
+}
+
+func TestCancelHandler(t *testing.T) {
+	state := "93282342"
+	callbackURL := "http://localhost:12946/oauth2callback"
+
+	handler, err := NewOAuth2CallbackHandler(callbackURL, state, "https://docs.docker.com/registry/spec/auth/oauth/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancelErr := errors.New("OAuth2 handler is cancelled")
+
+	handler.Cancel(cancelErr)
+
+	code := <-handler.CodeChan()
+
+	if err := handler.Error(); err == nil {
+		t.Fatal("Expected error after cancel")
+	} else if err != cancelErr {
+		t.Fatalf("Unexpected error %s", err)
+	}
+
+	if code != "" {
+		t.Fatalf("Unexpected empty code, got %s", code)
+	}
+}
+
+type codeServer struct {
+	code  string
+	state string
+}
+
+func (c codeServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	values := r.URL.Query()
+	if values.Get("state") != c.state {
+		http.Error(rw, "unknown state", http.StatusBadRequest)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(rw, "PING\n")
+		time.Sleep(2 * time.Millisecond)
+	}
+	fmt.Fprintf(rw, "CODE %s\n", c.code)
+}
+
+func TestPollHandler(t *testing.T) {
+	cs := codeServer{
+		code:  "18371413",
+		state: "938723",
+	}
+
+	ts := httptest.NewServer(cs)
+	defer ts.Close()
+
+	handler, err := NewOAuth2PollHandler(http.DefaultClient, ts.URL+"/v2/oauth2code", cs.state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code := <-handler.CodeChan()
+
+	if err := handler.Error(); err != nil {
+		t.Fatal(err)
+	}
+
+	if code != cs.code {
+		t.Fatalf("Unexpected code %q, expected %q", code, cs.code)
+	}
+}
+
+func TestCancelPollHandler(t *testing.T) {
+	cs := codeServer{
+		code:  "18371413",
+		state: "938723",
+	}
+
+	ts := httptest.NewServer(cs)
+	defer ts.Close()
+
+	handler, err := NewOAuth2PollHandler(http.DefaultClient, ts.URL+"/v2/oauth2code", cs.state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancelErr := errors.New("OAuth2 handler is cancelled")
+
+	handler.Cancel(cancelErr)
+
+	code := <-handler.CodeChan()
+
+	if err := handler.Error(); err == nil {
+		t.Fatal("Expected error after cancel")
+	} else if err != cancelErr {
+		t.Fatalf("Unexpected error %s", err)
+	}
+
+	if code != "" {
+		t.Fatalf("Unexpected empty code, got %s", code)
+	}
+}

--- a/registry/client/auth/session_test.go
+++ b/registry/client/auth/session_test.go
@@ -93,6 +93,10 @@ func (tcs *testCredentialStore) RefreshToken(u *url.URL, service string) string 
 	return tcs.refreshTokens[service]
 }
 
+func (tcs *testCredentialStore) AuthorizationCode(*url.URL) (string, string) {
+	return "", ""
+}
+
 func (tcs *testCredentialStore) SetRefreshToken(u *url.URL, service string, token string) {
 	if tcs.refreshTokens != nil {
 		tcs.refreshTokens[service] = token

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -29,6 +29,10 @@ func (c credentials) RefreshToken(u *url.URL, service string) string {
 	return ""
 }
 
+func (c credentials) AuthorizationCode(*url.URL) (string, string) {
+	return "", ""
+}
+
 func (c credentials) SetRefreshToken(u *url.URL, service, token string) {
 }
 


### PR DESCRIPTION
Allow the token server to provide an oauth2 configuration which a client may use to get an authorization code.

Provide tools for handling oauth2 authentication headers and authorization redirects.

Implements #1708
