### PR TITLE
Replace WithName with CreateNamed

### DIFF
--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -198,7 +198,7 @@ func TestConfigBuilder(t *testing.T) {
 
 	bs := &mockBlobService{descriptors: make(map[digest.Digest]distribution.Descriptor)}
 
-	ref, err := reference.WithName("testrepo")
+	ref, err := reference.CreateNamed("", "testrepo")
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
 	}

--- a/manifest/schema1/reference_builder_test.go
+++ b/manifest/schema1/reference_builder_test.go
@@ -55,7 +55,7 @@ func TestReferenceBuilder(t *testing.T) {
 
 	handCrafted := makeSignedManifest(t, pk, []Reference{r1, r2})
 
-	ref, err := reference.WithName(handCrafted.Manifest.Name)
+	ref, err := reference.CreateNamed("", handCrafted.Manifest.Name)
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
 	}

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -53,7 +53,7 @@ func TestEventBridgeManifestPulled(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	if err := l.ManifestPulled(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestEventBridgeManifestPushed(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	if err := l.ManifestPushed(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestEventBridgeManifestPushedWithTag(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	if err := l.ManifestPushed(repoRef, sm, distribution.WithTag(m.Tag)); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestEventBridgeManifestPulledWithTag(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	if err := l.ManifestPulled(repoRef, sm, distribution.WithTag(m.Tag)); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestEventBridgeManifestDeleted(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	if err := l.ManifestDeleted(repoRef, dgst); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -188,7 +188,7 @@ func checkCommonManifest(t *testing.T, action string, event events.Event) {
 		t.Fatalf("unexpected event action: %q != %q", event.(Event).Action, action)
 	}
 
-	repoRef, _ := reference.WithName(repo)
+	repoRef, _ := reference.CreateNamed("", repo)
 	ref, _ := reference.WithDigest(repoRef, dgst)
 	u, err := ub.BuildManifestURL(ref)
 	if err != nil {

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -33,7 +33,7 @@ func TestListener(t *testing.T) {
 		ops: make(map[string]int),
 	}
 
-	repoRef, _ := reference.WithName("foo/bar")
+	repoRef, _ := reference.CreateNamed("", "foo/bar")
 	repository, err := registry.Repository(ctx, repoRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -70,7 +70,7 @@ func ParseDockerRef(ref string) (Named, error) {
 		if canonical, ok := named.(Canonical); ok {
 			// The reference is both tagged and digested, only
 			// return digested.
-			newNamed, err := WithName(canonical.Name())
+			newNamed, err := CreateNamed(Domain(canonical), Path(canonical))
 			if err != nil {
 				return nil, err
 			}

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -303,14 +303,14 @@ func TestParseReferenceWithTagAndDigest(t *testing.T) {
 
 func TestInvalidReferenceComponents(t *testing.T) {
 	if _, err := ParseNormalizedNamed("-foo"); err == nil {
-		t.Fatal("Expected WithName to detect invalid name")
+		t.Fatal("Expected ParseNormalizedNamed to detect invalid name")
 	}
 	ref, err := ParseNormalizedNamed("busybox")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := WithTag(ref, "-foo"); err == nil {
-		t.Fatal("Expected WithName to detect invalid tag")
+		t.Fatal("Expected ParseNormalizedNamed to detect invalid tag")
 	}
 	if _, err := WithDigest(ref, digest.Digest("foo")); err == nil {
 		t.Fatal("Expected WithDigest to detect invalid digest")

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -249,21 +249,29 @@ func ParseNamed(s string) (Named, error) {
 	return named, nil
 }
 
-// WithName returns a named object representing the given string. If the input
-// is invalid ErrReferenceInvalidFormat will be returned.
-func WithName(name string) (Named, error) {
-	if len(name) > NameTotalLengthMax {
+// CreateNamed returns a named object using the given domain and path. If the
+// input is invalid ErrReferenceInvalidFormat will be returned.
+func CreateNamed(domain, path string) (Named, error) {
+	repo := repository{
+		domain: domain,
+		path:   path,
+	}
+
+	if repo.domain != "" {
+		if !anchoredDomainRegexp.MatchString(repo.domain) {
+			return nil, ErrReferenceInvalidFormat
+		}
+	}
+
+	if !anchoredPathRegexp.MatchString(repo.path) {
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(repo.String()) > NameTotalLengthMax {
 		return nil, ErrNameTooLong
 	}
 
-	match := anchoredNameRegexp.FindStringSubmatch(name)
-	if match == nil || len(match) != 3 {
-		return nil, ErrReferenceInvalidFormat
-	}
-	return repository{
-		domain: match[1],
-		path:   match[2],
-	}, nil
+	return repo, nil
 }
 
 // WithTag combines the name from "name" and the tag from "tag" to form a

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -18,7 +18,7 @@ type urlBuilderTestCase struct {
 }
 
 func makeURLBuilderTestCases(urlBuilder *URLBuilder) []urlBuilderTestCase {
-	fooBarRef, _ := reference.WithName("foo/bar")
+	fooBarRef, _ := reference.CreateNamed("", "foo/bar")
 	return []urlBuilderTestCase{
 		{
 			description:  "test base url",

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -292,7 +292,7 @@ func TestBlobResume(t *testing.T) {
 func TestBlobDelete(t *testing.T) {
 	dgst, _ := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.WithName("test.example.com/repo1")
+	repo, _ := reference.CreateNamed("test.example.com", "repo1")
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "DELETE",
@@ -331,8 +331,13 @@ func TestBlobFetch(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
+<<<<<<< HEAD
 	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(repo, e, nil)
+=======
+	repo, _ := reference.CreateNamed("test.example.com", "repo1")
+	r, err := NewRepository(ctx, repo, e, nil)
+>>>>>>> ce6bd261 (Replace WithName with CreateNamed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +357,7 @@ func TestBlobFetch(t *testing.T) {
 func TestBlobExistsNoContentLength(t *testing.T) {
 	var m testutil.RequestResponseMap
 
-	repo, _ := reference.WithName("biff")
+	repo, _ := reference.CreateNamed("", "biff")
 	dgst, content := newRandomBlob(1024)
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -411,7 +416,7 @@ func TestBlobExists(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	repo, _ := reference.WithName("test.example.com/repo1")
+	repo, _ := reference.CreateNamed("test.example.com", "repo1")
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -443,7 +448,7 @@ func TestBlobUploadChunked(t *testing.T) {
 		b1[512:513],
 		b1[513:1024],
 	}
-	repo, _ := reference.WithName("test.example.com/uploadrepo")
+	repo, _ := reference.CreateNamed("test.example.com", "uploadrepo")
 	uuids := []string{uuid.Generate().String()}
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -558,7 +563,7 @@ func TestBlobUploadChunked(t *testing.T) {
 func TestBlobUploadMonolithic(t *testing.T) {
 	dgst, b1 := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.WithName("test.example.com/uploadrepo")
+	repo, _ := reference.CreateNamed("", "test.example.com/uploadrepo")
 	uploadID := uuid.Generate().String()
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -858,9 +863,9 @@ func TestBlobUploadMonolithicNoDockerUploadUUID(t *testing.T) {
 func TestBlobMount(t *testing.T) {
 	dgst, content := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.WithName("test.example.com/uploadrepo")
+	repo, _ := reference.CreateNamed("test.example.com", "uploadrepo")
 
-	sourceRepo, _ := reference.WithName("test.example.com/sourcerepo")
+	sourceRepo, _ := reference.CreateNamed("test.example.com", "sourcerepo")
 	canonicalRef, _ := reference.WithDigest(sourceRepo, dgst)
 
 	m = append(m, testutil.RequestResponseMapping{
@@ -1093,7 +1098,7 @@ func checkEqualManifest(m1, m2 *schema1.SignedManifest) error {
 
 func TestV1ManifestFetch(t *testing.T) {
 	ctx := context.Background()
-	repo, _ := reference.WithName("test.example.com/repo")
+	repo, _ := reference.CreateNamed("test.example.com", "repo")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	_, pl, err := m1.Payload()
@@ -1170,7 +1175,7 @@ func TestV1ManifestFetch(t *testing.T) {
 }
 
 func TestManifestFetchWithEtag(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo/by/tag")
+	repo, _ := reference.CreateNamed("test.example.com", "repo/by/tag")
 	_, d1, p1 := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	addTestManifestWithEtag(repo, "latest", p1, &m, d1.String())
@@ -1259,7 +1264,7 @@ func TestManifestFetchWithAccept(t *testing.T) {
 }
 
 func TestManifestDelete(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo/delete")
+	repo, _ := reference.CreateNamed("test.example.com", "repo/delete")
 	_, dgst1, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	_, dgst2, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
@@ -1299,7 +1304,7 @@ func TestManifestDelete(t *testing.T) {
 }
 
 func TestManifestPut(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo/delete")
+	repo, _ := reference.CreateNamed("test.example.com", "repo/delete")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "other", 6)
 
 	_, payload, err := m1.Payload()
@@ -1364,7 +1369,7 @@ func TestManifestPut(t *testing.T) {
 }
 
 func TestManifestTags(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo/tags/list")
+	repo, _ := reference.CreateNamed("test.example.com", "repo/tags/list")
 	tagsList := []byte(strings.TrimSpace(`
 {
 	"name": "test.example.com/repo/tags/list",
@@ -1426,7 +1431,7 @@ func TestManifestTags(t *testing.T) {
 }
 
 func TestObtainsErrorForMissingTag(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo")
+	repo, _ := reference.CreateNamed("test.example.com", "repo")
 
 	var m testutil.RequestResponseMap
 	var errors errcode.Errors
@@ -1502,7 +1507,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 	s := httptest.NewServer(http.NotFoundHandler())
 	defer s.Close()
 
-	repo, _ := reference.WithName("test.example.com/repo/tags/list")
+	repo, _ := reference.CreateNamed("test.example.com", "repo/tags/list")
 	tagsList := []string{"tag1", "tag2", "funtag"}
 	var m testutil.RequestResponseMap
 	for i := 0; i < 3; i++ {
@@ -1585,7 +1590,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 }
 
 func TestManifestUnauthorized(t *testing.T) {
-	repo, _ := reference.WithName("test.example.com/repo")
+	repo, _ := reference.CreateNamed("test.example.com", "repo")
 	_, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -280,7 +280,7 @@ func makeBlobArgs(t *testing.T) blobArgs {
 		layerFile:   layerFile,
 		layerDigest: layerDigest,
 	}
-	args.imageName, _ = reference.WithName("foo/bar")
+	args.imageName, _ = reference.CreateNamed("", "foo/bar")
 	return args
 }
 
@@ -323,7 +323,7 @@ func TestRelativeURL(t *testing.T) {
 	config.HTTP.RelativeURLs = false
 	env := newTestEnvWithConfig(t, &config)
 	defer env.Shutdown()
-	ref, _ := reference.WithName("foo/bar")
+	ref, _ := reference.CreateNamed("", "foo/bar")
 	uploadURLBaseAbs, _ := startPushLayer(t, env, ref)
 
 	u, err := url.Parse(uploadURLBaseAbs)
@@ -705,7 +705,7 @@ func TestDeleteDisabled(t *testing.T) {
 	env := newTestEnv(t, false)
 	defer env.Shutdown()
 
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	// "build" our layer file
 	layerFile, layerDigest, err := testutil.CreateRandomTarFile()
 	if err != nil {
@@ -732,7 +732,7 @@ func TestDeleteReadOnly(t *testing.T) {
 	env := newTestEnv(t, true)
 	defer env.Shutdown()
 
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	// "build" our layer file
 	layerFile, layerDigest, err := testutil.CreateRandomTarFile()
 	if err != nil {
@@ -762,7 +762,7 @@ func TestStartPushReadOnly(t *testing.T) {
 	defer env.Shutdown()
 	env.app.readOnly = true
 
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 
 	layerUploadURL, err := env.builder.BuildBlobUploadURL(imageName)
 	if err != nil {
@@ -800,8 +800,8 @@ type manifestArgs struct {
 }
 
 func TestManifestAPI(t *testing.T) {
-	schema1Repo, _ := reference.WithName("foo/schema1")
-	schema2Repo, _ := reference.WithName("foo/schema2")
+	schema1Repo, _ := reference.CreateNamed("", "foo/schema1")
+	schema2Repo, _ := reference.CreateNamed("", "foo/schema2")
 
 	deleteEnabled := false
 	env1 := newTestEnv(t, deleteEnabled)
@@ -892,22 +892,22 @@ func TestGetManifestWithStorageError(t *testing.T) {
 	env1 := newTestEnvWithConfig(t, &config)
 	defer env1.Shutdown()
 
-	repo, _ := reference.WithName(repositoryWithManifestNotFound)
+	repo, _ := reference.CreateNamed("", repositoryWithManifestNotFound)
 	testManifestWithStorageError(t, env1, repo, http.StatusNotFound, v2.ErrorCodeManifestUnknown)
 
-	repo, _ = reference.WithName(repositoryWithGenericStorageError)
+	repo, _ = reference.CreateNamed("", repositoryWithGenericStorageError)
 	testManifestWithStorageError(t, env1, repo, http.StatusInternalServerError, errcode.ErrorCodeUnknown)
 
-	repo, _ = reference.WithName(repositoryWithManifestInvalidPath)
+	repo, _ = reference.CreateNamed("", repositoryWithManifestInvalidPath)
 	testManifestWithStorageError(t, env1, repo, http.StatusInternalServerError, errcode.ErrorCodeUnknown)
 
-	repo, _ = reference.WithName(repositoryWithManifestBadLink)
+	repo, _ = reference.CreateNamed("", repositoryWithManifestBadLink)
 	testManifestWithStorageError(t, env1, repo, http.StatusInternalServerError, errcode.ErrorCodeUnknown)
 }
 
 func TestManifestDelete(t *testing.T) {
-	schema1Repo, _ := reference.WithName("foo/schema1")
-	schema2Repo, _ := reference.WithName("foo/schema2")
+	schema1Repo, _ := reference.CreateNamed("", "foo/schema1")
+	schema2Repo, _ := reference.CreateNamed("", "foo/schema2")
 
 	deleteEnabled := true
 	env := newTestEnv(t, deleteEnabled)
@@ -919,7 +919,7 @@ func TestManifestDelete(t *testing.T) {
 }
 
 func TestManifestDeleteDisabled(t *testing.T) {
-	schema1Repo, _ := reference.WithName("foo/schema1")
+	schema1Repo, _ := reference.CreateNamed("", "foo/schema1")
 	deleteEnabled := false
 	env := newTestEnv(t, deleteEnabled)
 	defer env.Shutdown()
@@ -2403,7 +2403,7 @@ func checkErr(t *testing.T, err error, msg string) {
 }
 
 func createRepository(env *testEnv, t *testing.T, imageName string, tag string) digest.Digest {
-	imageNameRef, err := reference.WithName(imageName)
+	imageNameRef, err := reference.CreateNamed("", imageName)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %v", err)
 	}
@@ -2473,7 +2473,7 @@ func TestRegistryAsCacheMutationAPIs(t *testing.T) {
 	env := newTestEnvMirror(t, deleteEnabled)
 	defer env.Shutdown()
 
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	tag := "latest"
 	tagRef, _ := reference.WithTag(imageName, tag)
 	manifestURL, err := env.builder.BuildManifestURL(tagRef)
@@ -2538,7 +2538,7 @@ func TestProxyManifestGetByTag(t *testing.T) {
 	truthConfig.Compatibility.Schema1.Enabled = true
 	truthConfig.HTTP.Headers = headerConfig
 
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	tag := "latest"
 
 	truthEnv := newTestEnvWithConfig(t, &truthConfig)

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -675,7 +675,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		r = r.WithContext(context)
 
 		if app.nameRequired(r) {
-			nameRef, err := reference.WithName(getName(context))
+			nameRef, err := reference.CreateNamed("", getName(context))
 			if err != nil {
 				dcontext.GetLogger(context).Errorf("error parsing reference from context: %v", err)
 				context.Errors = append(context.Errors, distribution.ErrRepositoryNameInvalid{

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -341,7 +341,7 @@ func (buh *blobUploadHandler) createBlobMountOption(fromRepo, mountDigest string
 		return nil, err
 	}
 
-	ref, err := reference.WithName(fromRepo)
+	ref, err := reference.CreateNamed("", fromRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -115,7 +115,7 @@ func (te *testEnv) RemoteStats() *map[string]int {
 
 // Populate remote store and record the digests
 func makeTestEnv(t *testing.T, name string) *testEnv {
-	nameRef, err := reference.WithName(name)
+	nameRef, err := reference.CreateNamed("", name)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %s", err)
 	}

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -83,7 +83,7 @@ func (m *mockChallenger) challengeManager() challenge.Manager {
 }
 
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
-	nameRef, err := reference.WithName(name)
+	nameRef, err := reference.CreateNamed("", name)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %s", err)
 	}

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -23,7 +23,7 @@ import (
 // obtained using Seek
 func TestWriteSeek(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -254,7 +254,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 // other tests.
 func TestSimpleBlobRead(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -365,8 +365,8 @@ func TestBlobMount(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	imageName, _ := reference.WithName("foo/bar")
-	sourceImageName, _ := reference.WithName("foo/source")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
+	sourceImageName, _ := reference.CreateNamed("", "foo/source")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -517,7 +517,7 @@ func TestBlobMount(t *testing.T) {
 // TestLayerUploadZeroLength uploads zero-length
 func TestLayerUploadZeroLength(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.WithName("foo/bar")
+	imageName, _ := reference.CreateNamed("", "foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -68,7 +68,7 @@ func setupFS(t *testing.T) *setupEnv {
 }
 
 func makeRepo(ctx context.Context, t *testing.T, name string, reg distribution.Namespace) {
-	named, err := reference.WithName(name)
+	named, err := reference.CreateNamed("", name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -41,7 +41,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		emit(repoName)
 
 		var err error
-		named, err := reference.WithName(repoName)
+		named, err := reference.CreateNamed("", repoName)
 		if err != nil {
 			return fmt.Errorf("failed to parse repo name %s: %v", repoName, err)
 		}

--- a/registry/storage/garbagecollect_test.go
+++ b/registry/storage/garbagecollect_test.go
@@ -39,7 +39,7 @@ func makeRepository(t *testing.T, registry distribution.Namespace, name string) 
 	ctx := context.Background()
 
 	// Initialize a dummy repository
-	named, err := reference.WithName(name)
+	named, err := reference.CreateNamed("", name)
 	if err != nil {
 		t.Fatalf("Failed to parse name %s:  %v", name, err)
 	}

--- a/registry/storage/linkedblobstore_test.go
+++ b/registry/storage/linkedblobstore_test.go
@@ -64,7 +64,7 @@ func TestLinkedBlobStoreEnumerator(t *testing.T) {
 }
 
 func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
-	fooRepoName, _ := reference.WithName("nm/foo")
+	fooRepoName, _ := reference.CreateNamed("", "nm/foo")
 	fooEnv := newManifestStoreTestEnv(t, fooRepoName, "thetag")
 	ctx := context.Background()
 	stats, err := mockRegistry(t, fooEnv.registry)
@@ -101,7 +101,7 @@ func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
 	}
 
 	// create another repository nm/bar
-	barRepoName, _ := reference.WithName("nm/bar")
+	barRepoName, _ := reference.CreateNamed("", "nm/bar")
 	barRepo, err := fooEnv.registry.Repository(ctx, barRepoName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -141,7 +141,7 @@ func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
 	clearStats(stats)
 
 	// create yet another repository nm/baz
-	bazRepoName, _ := reference.WithName("nm/baz")
+	bazRepoName, _ := reference.CreateNamed("", "nm/baz")
 	bazRepo, err := fooEnv.registry.Repository(ctx, bazRepoName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -71,7 +71,7 @@ func TestManifestStorageV1Unsupported(t *testing.T) {
 }
 
 func testManifestStorage(t *testing.T, schema1Enabled bool, options ...RegistryOption) {
-	repoName, _ := reference.WithName("foo/bar")
+	repoName, _ := reference.CreateNamed("", "foo/bar")
 	env := newManifestStoreTestEnv(t, repoName, "thetag", options...)
 	ctx := context.Background()
 	ms, err := env.repository.Manifests(ctx)

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -29,7 +29,7 @@ func testTagStore(t *testing.T) *tagsTestEnv {
 		t.Fatal(err)
 	}
 
-	repoRef, _ := reference.WithName("a/b")
+	repoRef, _ := reference.CreateNamed("", "a/b")
 	repo, err := reg.Repository(ctx, repoRef)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Based on feedback from #2142

WithName is a poorly named function and already has a similar role to ParseNamed without enforcement for normalization and no support for tags or digest values. For places that require creating a raw named value it is cleaner to explicitly pass in the domain and path needed to create a fully parsed and normalized value. The registry does not use domain and will explicitly pass in the empty string while clients such as the Docker Engine will likely have no use for `CreateNamed`.

