### PR TITLE
Add new parameter s3accelerate to S3 storage driver.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
+    s3accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid
@@ -378,6 +379,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
+    s3accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -98,6 +98,7 @@ type DriverParameters struct {
 	StorageClass                string
 	UserAgent                   string
 	ObjectACL                   string
+	S3Accelerate                bool
 }
 
 func init() {
@@ -331,6 +332,23 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		objectACL = objectACLString
 	}
 
+	s3accelerateBool := false
+	s3accelerate := parameters["s3accelerate"]
+	switch s3accelerate := s3accelerate.(type) {
+	case string:
+		b, err := strconv.ParseBool(s3accelerate)
+		if err != nil {
+			return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+		}
+		s3accelerateBool = b
+	case bool:
+		s3accelerateBool = s3accelerate
+	case nil:
+		// do nothing
+	default:
+		return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+	}
+
 	params := DriverParameters{
 		fmt.Sprint(accessKey),
 		fmt.Sprint(secretKey),
@@ -349,6 +367,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		storageClass,
 		fmt.Sprint(userAgent),
 		objectACL,
+		s3accelerateBool,
 	}
 
 	return New(params)
@@ -408,6 +427,10 @@ func New(params DriverParameters) (*Driver, error) {
 	if params.RegionEndpoint != "" {
 		awsConfig.WithS3ForcePathStyle(true)
 		awsConfig.WithEndpoint(params.RegionEndpoint)
+	}
+
+	if params.S3Accelerate {
+		awsConfig.WithS3UseAccelerate(true)
 	}
 
 	awsConfig.WithCredentials(creds)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -36,6 +36,7 @@ func init() {
 	objectACL := os.Getenv("S3_OBJECT_ACL")
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
+	s3accelerate := os.Getenv("S3_ACCELERATE")
 	if err != nil {
 		panic(err)
 	}
@@ -66,6 +67,14 @@ func init() {
 			}
 		}
 
+		s3accelerateBool := true
+		if s3accelerate != "" {
+			s3accelerateBool, err = strconv.ParseBool(s3accelerate)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
@@ -84,6 +93,7 @@ func init() {
 			storageClass,
 			driverName + "-test",
 			objectACL,
+			s3accelerateBool,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Hello folks,

I've added an optional parameter to enable S3 Transfer acceleration for the S3 storage driver.   Thank you very much for considering the change.

If s3accelerate is set to true then we turn on S3 Transfer Acceleration via the AWS SDK.  It defaults to false since this is an opt-in feature on the S3 bucket.

best,
-Kirat