### PR TITLE
Add a multi-stage dockerfile that builds just the required executable

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,27 @@
+FROM golang:1.7-alpine AS builder 
+
+ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
+ENV DOCKER_BUILDTAGS include_oss include_gcs
+
+RUN set -ex \
+    && apk add --no-cache make git gcc libc-dev
+
+WORKDIR $DISTRIBUTION_DIR
+COPY . $DISTRIBUTION_DIR
+
+RUN make PREFIX=/go clean binaries
+
+
+FROM alpine:3.5
+
+RUN set -ex \
+    && apk add --no-cache ca-certificates apache2-utils
+
+ENV PATH /go/bin:$PATH
+COPY --from=builder /go/bin/registry /go/bin/registry
+COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+
+VOLUME ["/var/lib/registry"]
+EXPOSE 5000
+ENTRYPOINT ["registry"]
+CMD ["serve", "/etc/docker/registry/config.yml"]


### PR DESCRIPTION
This can be used to build the registry official image direcly from source.
This dockerfile only copies the registry binary into the final image
as this is all that is required for the official image.
Also the alpine version of the final image has been bumped to 3.5 as
this version has ARM support.