### PR TITLE
Remove the layer's link by garbage-collect

### DIFF
--- a/registry/storage/driver/base/regulator.go
+++ b/registry/storage/driver/base/regulator.go
@@ -38,11 +38,7 @@ func (r *regulator) enter() {
 
 func (r *regulator) exit() {
 	r.L.Lock()
-	// We only need to signal to a waiting FS operation if we're already at the
-	// limit of threads used
-	if r.available == 0 {
-		r.Signal()
-	}
+	r.Signal()
 	r.available++
 	r.L.Unlock()
 }

--- a/registry/storage/driver/base/regulator_test.go
+++ b/registry/storage/driver/base/regulator_test.go
@@ -1,0 +1,67 @@
+package base
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRegulatorEnterExit(t *testing.T) {
+	const limit = 500
+
+	r := NewRegulator(nil, limit).(*regulator)
+
+	for try := 0; try < 50; try++ {
+		run := make(chan struct{})
+
+		var firstGroupReady sync.WaitGroup
+		var firstGroupDone sync.WaitGroup
+		firstGroupReady.Add(limit)
+		firstGroupDone.Add(limit)
+		for i := 0; i < limit; i++ {
+			go func() {
+				r.enter()
+				firstGroupReady.Done()
+				<-run
+				r.exit()
+				firstGroupDone.Done()
+			}()
+		}
+		firstGroupReady.Wait()
+
+		// now we exhausted all the limit, let's run a little bit more
+		var secondGroupReady sync.WaitGroup
+		var secondGroupDone sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			secondGroupReady.Add(1)
+			secondGroupDone.Add(1)
+			go func() {
+				secondGroupReady.Done()
+				r.enter()
+				r.exit()
+				secondGroupDone.Done()
+			}()
+		}
+		secondGroupReady.Wait()
+
+		// allow the first group to return resources
+		close(run)
+
+		done := make(chan struct{})
+		go func() {
+			secondGroupDone.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("some r.enter() are still locked")
+		}
+
+		firstGroupDone.Wait()
+
+		if r.available != limit {
+			t.Fatalf("r.available: got %d, want %d", r.available, limit)
+		}
+	}
+}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -231,7 +231,7 @@ func (lbs *linkedBlobStore) Delete(ctx context.Context, dgst digest.Digest) erro
 	return nil
 }
 
-func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingestor func(digest.Digest) error) error {
+func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
 	rootPath, err := pathFor(lbs.linkDirectoryPathSpec)
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingestor func(digest.
 			return err
 		}
 
-		err = ingestor(digest)
+		err = ingester(digest)
 		if err != nil {
 			return err
 		}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -219,6 +219,8 @@ func pathFor(spec pathSpec) (string, error) {
 		blobLinkPathComponents := append(repoPrefix, v.name, "_layers")
 
 		return path.Join(path.Join(append(blobLinkPathComponents, components...)...), "link"), nil
+	case layerDirectoryPathSpec:
+		return path.Join(append(repoPrefix, v.name, "_layers")...), nil
 	case blobsPathSpec:
 		blobsPathPrefix := append(rootPrefix, "blobs")
 		return path.Join(blobsPathPrefix...), nil
@@ -366,6 +368,12 @@ type layerLinkPathSpec struct {
 }
 
 func (layerLinkPathSpec) pathSpec() {}
+
+type layerDirectoryPathSpec struct {
+	name string
+}
+
+func (layerDirectoryPathSpec) pathSpec() {}
 
 // blobAlgorithmReplacer does some very simple path sanitization for user
 // input. Paths should be "safe" before getting this far due to strict digest

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -289,6 +289,8 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		statter = repo.registry.blobDescriptorServiceFactory.BlobAccessController(statter)
 	}
 
+	LayerDirectoryPathSpec := layerDirectoryPathSpec{name: repo.name.Name()}
+
 	return &linkedBlobStore{
 		registry:             repo.registry,
 		blobStore:            repo.blobStore,
@@ -300,6 +302,7 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		// TODO(stevvooe): linkPath limits this blob store to only layers.
 		// This instance cannot be used for manifest checks.
 		linkPathFns:            []linkPathFunc{blobLinkPath},
+		linkDirectoryPathSpec:  LayerDirectoryPathSpec,
 		deleteEnabled:          repo.registry.deleteEnabled,
 		resumableDigestEnabled: repo.resumableDigestEnabled,
 	}

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -27,6 +27,20 @@ type Vacuum struct {
 	ctx    context.Context
 }
 
+// RemoveLayers removes a layers from the filesystem
+func (v Vacuum) RemoveLayers(repoName string, dgst digest.Digest) error {
+	layerLinkPath, err := pathFor(layerLinkPathSpec{name: repoName, digest: dgst})
+	if err != nil {
+		return err
+	}
+	err = v.driver.Delete(v.ctx, layerLinkPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RemoveBlob removes a blob from the filesystem
 func (v Vacuum) RemoveBlob(dgst string) error {
 	d, err := digest.Parse(dgst)


### PR DESCRIPTION
Signed-off-by: Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
The gabage-collect command should removes layer's link files (``_layers/<algorithm>/<digest>/link``).
These link files don't have blobs to link with. 