### PR TITLE
Update s3 ListObject api

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -571,7 +571,7 @@ func (d *driver) Writer(ctx context.Context, path string, append bool) (storaged
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
-	resp, err := d.S3.ListObjects(&s3.ListObjectsInput{
+	resp, err := d.S3.ListObjectsV2(&s3.ListObjectsV2Input{
 		Bucket:  aws.String(d.Bucket),
 		Prefix:  aws.String(d.s3Path(path)),
 		MaxKeys: aws.Int64(1),
@@ -616,7 +616,7 @@ func (d *driver) List(ctx context.Context, opath string) ([]string, error) {
 		prefix = "/"
 	}
 
-	resp, err := d.S3.ListObjects(&s3.ListObjectsInput{
+	resp, err := d.S3.ListObjectsV2(&s3.ListObjectsV2Input{
 		Bucket:    aws.String(d.Bucket),
 		Prefix:    aws.String(d.s3Path(path)),
 		Delimiter: aws.String("/"),
@@ -640,12 +640,12 @@ func (d *driver) List(ctx context.Context, opath string) ([]string, error) {
 		}
 
 		if *resp.IsTruncated {
-			resp, err = d.S3.ListObjects(&s3.ListObjectsInput{
+			resp, err = d.S3.ListObjectsV2(&s3.ListObjectsV2Input{
 				Bucket:    aws.String(d.Bucket),
 				Prefix:    aws.String(d.s3Path(path)),
 				Delimiter: aws.String("/"),
 				MaxKeys:   aws.Int64(listMax),
-				Marker:    resp.NextMarker,
+				ContinuationToken:    resp.NextContinuationToken,
 			})
 			if err != nil {
 				return nil, err
@@ -780,14 +780,14 @@ func min(a, b int) int {
 func (d *driver) Delete(ctx context.Context, path string) error {
 	s3Objects := make([]*s3.ObjectIdentifier, 0, listMax)
 	s3Path := d.s3Path(path)
-	listObjectsInput := &s3.ListObjectsInput{
+	listObjectsV2Input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(d.Bucket),
 		Prefix: aws.String(s3Path),
 	}
 ListLoop:
 	for {
 		// list all the objects
-		resp, err := d.S3.ListObjects(listObjectsInput)
+		resp, err := d.S3.ListObjectsV2(listObjectsV2Input)
 
 		// resp.Contents can only be empty on the first call
 		// if there were no more results to return after the first call, resp.IsTruncated would have been false
@@ -807,7 +807,7 @@ ListLoop:
 		}
 
 		// resp.Contents must have at least one element or we would have returned not found
-		listObjectsInput.Marker = resp.Contents[len(resp.Contents)-1].Key
+		listObjectsV2Input.ContinuationToken = resp.Contents[len(resp.Contents)-1].Key
 
 		// from the s3 api docs, IsTruncated "specifies whether (true) or not (false) all of the results were returned"
 		// if everything has been returned, break

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -641,11 +641,11 @@ func (d *driver) List(ctx context.Context, opath string) ([]string, error) {
 
 		if *resp.IsTruncated {
 			resp, err = d.S3.ListObjectsV2(&s3.ListObjectsV2Input{
-				Bucket:    aws.String(d.Bucket),
-				Prefix:    aws.String(d.s3Path(path)),
-				Delimiter: aws.String("/"),
-				MaxKeys:   aws.Int64(listMax),
-				ContinuationToken:    resp.NextContinuationToken,
+				Bucket:            aws.String(d.Bucket),
+				Prefix:            aws.String(d.s3Path(path)),
+				Delimiter:         aws.String("/"),
+				MaxKeys:           aws.Int64(listMax),
+				ContinuationToken: resp.NextContinuationToken,
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Signed-off-by: Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
Switch to v2 of S3 List Objects API in s3.go.
This is because AWS recommend that we use GET Bucket (List Objects) version 2 API.