### PR TITLE
Fix time out issue for unit test-full

### DIFF
--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -137,7 +137,7 @@ func (suite *DriverSuite) deletePath(c *check.C, path string) {
 			err = nil
 		}
 		c.Assert(err, check.IsNil)
-		paths, err := suite.StorageDriver.List(suite.ctx, path)
+		paths, _ := suite.StorageDriver.List(suite.ctx, path)
 		if len(paths) == 0 {
 			break
 		}
@@ -269,7 +269,7 @@ func (suite *DriverSuite) TestWriteReadStreamsNonUTF8(c *check.C) {
 	suite.writeReadCompareStreams(c, filename, contents)
 }
 
-// TestWriteReadLargeStreams tests that a 5GB file may be written to the storage
+// TestWriteReadLargeStreams tests that a 100MB file may be written to the storage
 // driver safely.
 func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	if testing.Short() {
@@ -280,7 +280,7 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	defer suite.deletePath(c, firstPart(filename))
 
 	checksum := sha1.New()
-	var fileSize int64 = 5 * 1024 * 1024 * 1024
+	var fileSize int64 = 100 * 1024 * 1024
 
 	contents := newRandReader(fileSize)
 
@@ -484,7 +484,7 @@ func (suite *DriverSuite) TestList(c *check.C) {
 	for i := 0; i < len(childFiles); i++ {
 		childFile := parentDirectory + "/" + randomFilename(int64(8+rand.Intn(8)))
 		childFiles[i] = childFile
-		err := suite.StorageDriver.PutContent(suite.ctx, childFile, randomContents(32))
+		err = suite.StorageDriver.PutContent(suite.ctx, childFile, randomContents(32))
 		c.Assert(err, check.IsNil)
 	}
 	sort.Strings(childFiles)
@@ -652,7 +652,7 @@ func (suite *DriverSuite) TestURLFor(c *check.C) {
 	}
 	c.Assert(err, check.IsNil)
 
-	response, err = http.Head(url)
+	response, _ = http.Head(url)
 	c.Assert(response.StatusCode, check.Equals, 200)
 	c.Assert(response.ContentLength, check.Equals, int64(32))
 }


### PR DESCRIPTION
When running the test-full (go test (not short)) bucket with a 12gig ram VM and go 1.8.1 I'm banging up against the default ten minute go test timeout on the in memory storage driver.

Lowering the size of large stream test to 100mb from 5gb results in the test passing after about 5min. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>