### PR TITLE
closes #2246 Azure storage driver spent too much resources on SSL con…

### DIFF
--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -48,7 +48,7 @@ func init() {
 	}
 
 	azureDriverConstructor := func() (storagedriver.StorageDriver, error) {
-		return New(accountName, accountKey, container, realm)
+		return New(accountName, accountKey, container, realm, defaultMaxIdleConnsToStorage)
 	}
 
 	// Skip Azure storage driver tests if environment variable parameters are not provided


### PR DESCRIPTION
…nection to storage server

Explicitly use keep-alive on outgoing request. Increase the cached idle connections, and make it configurable.

Signed-off-by: Yu Wang <yuwa@microsoft.com>