### PR TITLE
Improve error message in case invalid env var found

### DIFF
--- a/configuration/parser.go
+++ b/configuration/parser.go
@@ -206,6 +206,7 @@ func (p *Parser) overwriteStruct(v reflect.Value, fullpath string, path []string
 		fieldVal := reflect.New(sf.Type)
 		err := yaml.Unmarshal([]byte(payload), fieldVal.Interface())
 		if err != nil {
+			logrus.Warnf("Error parsing environment variable %s", fullpath)
 			return err
 		}
 		field.Set(reflect.Indirect(fieldVal))

--- a/configuration/parser.go
+++ b/configuration/parser.go
@@ -206,7 +206,7 @@ func (p *Parser) overwriteStruct(v reflect.Value, fullpath string, path []string
 		fieldVal := reflect.New(sf.Type)
 		err := yaml.Unmarshal([]byte(payload), fieldVal.Interface())
 		if err != nil {
-			logrus.Warnf("Error parsing environment variable %s", fullpath)
+			logrus.Warnf("Error parsing environment variable %s: %s", fullpath, err)
 			return err
 		}
 		field.Set(reflect.Indirect(fieldVal))


### PR DESCRIPTION
If you set an env var with non-yaml content but accidentally collides with a possible configuration env var,... 

The current error is

```
configuration error: error parsing /etc/docker/registry/config.yml: yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `tcp://1...` into configuration.Parameters
```

With this change we can see at least which is the problematic env var.

Some orchestrators such as docker-compose set env vars on top on user env vars, so debugging can be tricky if you are not passing vars, and the error is pointing you to a problably valid config file.