### PR TITLE
Add IPv6 support for domain parsing

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -22,6 +22,9 @@ func TestValidateReferenceName(t *testing.T) {
 		"127.0.0.1:5000/docker/docker",
 		"127.0.0.1:5000/library/debian",
 		"127.0.0.1:5000/debian",
+		"[fc00::1%eth0]:5000/docker/docker",
+		"[fc00::1%eth0]:5000/library/debian",
+		"[fc00::1%eth0]:5000/debian",
 		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
 
 		// This test case was moved from invalid to valid since it is valid input

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -5,12 +5,26 @@
 //
 // 	reference                       := name [ ":" tag ] [ "@" digest ]
 //	name                            := [domain '/'] path-component ['/' path-component]*
-//	domain                          := domain-component ['.' domain-component]* [':' port-number]
+//	domain                          := ( '[' ipv6 [ '%' zone-id ] ']' | domain-component ['.' domain-component]*) [':' port-number]
 //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
+//	ipv6                            :=                               ( h16 ':' ){6} ls32 |
+//	                                :=                          '::' ( h16 ':' ){5} ls32 |
+//	                                := [                  h16 ] '::' ( h16 ':' ){4} ls32 |
+//	                                := [ ( h16 ':' ){0,1} h16 ] '::' ( h16 ':' ){3} ls32 |
+//	                                := [ ( h16 ':' ){0,2} h16 ] '::' ( h16 ':' ){2} ls32 |
+//	                                := [ ( h16 ':' ){0,3} h16 ] '::'   h16 ':'      ls32 |
+//	                                := [ ( h16 ':' ){0,4} h16 ] '::'                ls32 |
+//	                                := [ ( h16 ':' ){0,5} h16 ] '::'                 h16 |
+//	                                := [ ( h16 ':' ){0,6} h16 ] '::'
+//	ls32                            := h16 ':' h16 | ipv4
+//	h16                             := /[a-fA-F0-9]{1,4}/
+//	ipv4                            := d8 '.' d8 '.' d8 '.' d8
+//	d8                              := /[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]/
+//	zone-id                         := /[a-zA-Z0-9-._~]+/
 //
 //	tag                             := /[\w][\w.-]{0,127}/
 //

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -78,6 +78,68 @@ func TestReferenceParse(t *testing.T) {
 			repository: "test:5000/repo",
 		},
 		{
+			input: "[fc00::1]:tag",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[fc00::1]:5000",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input:      "[fc00::1]/repo",
+			domain:     "[fc00::1]",
+			repository: "[fc00::1]/repo",
+		},
+		{
+			input:      "[fc00::1]/repo:tag",
+			domain:     "[fc00::1]",
+			repository: "[fc00::1]/repo",
+			tag:        "tag",
+		},
+		{
+			input:      "[fc00::1]:5000/repo",
+			domain:     "[fc00::1]:5000",
+			repository: "[fc00::1]:5000/repo",
+		},
+		{
+			input:      "[fc00::1]:5000/repo:tag",
+			domain:     "[fc00::1]:5000",
+			repository: "[fc00::1]:5000/repo",
+			tag:        "tag",
+		},
+		{
+			input:      "[fc00::1]:5000/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			domain:     "[fc00::1]:5000",
+			repository: "[fc00::1]:5000/repo",
+			digest:     "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		},
+		{
+			input:      "[fc00::1]:5000/repo:tag@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			domain:     "[fc00::1]:5000",
+			repository: "[fc00::1]:5000/repo",
+			tag:        "tag",
+			digest:     "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		},
+		{
+			input:      "[fc00::]:5000/repo",
+			domain:     "[fc00::]:5000",
+			repository: "[fc00::]:5000/repo",
+		},
+		{
+			input:      "[::1]:5000/repo",
+			domain:     "[::1]:5000",
+			repository: "[::1]:5000/repo",
+		},
+		{
+			input:      "[fc00::1%eth0]:5000/repo",
+			domain:     "[fc00::1%eth0]:5000",
+			repository: "[fc00::1%eth0]:5000/repo",
+		},
+		{
+			input: "[fc00::1%@invalidzone]:5000/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
 			input: "",
 			err:   ErrNameEmpty,
 		},

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -86,6 +86,64 @@ func TestReferenceParse(t *testing.T) {
 			err:   ErrReferenceInvalidFormat,
 		},
 		{
+			input: "[fc00::1::1]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[::fc00:1:1::]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[fc00::00001]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[fc00]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[someinvalidstring]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[:::]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input: "[fc00::300.168.134.145]/repo",
+			err:   ErrReferenceInvalidFormat,
+		},
+		{
+			input:      "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/repo",
+			domain:     "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+			repository: "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/repo",
+		},
+		{
+			input:      "[2001:0db8:85a3:0:0:8a2e:0370:7334]/repo",
+			domain:     "[2001:0db8:85a3:0:0:8a2e:0370:7334]",
+			repository: "[2001:0db8:85a3:0:0:8a2e:0370:7334]/repo",
+		},
+		{
+			input:      "[2001:0db8:85a3::8a2e:0370:7334]/repo",
+			domain:     "[2001:0db8:85a3::8a2e:0370:7334]",
+			repository: "[2001:0db8:85a3::8a2e:0370:7334]/repo",
+		},
+		{
+			input:      "[fc00::192.168.134.145]/repo",
+			domain:     "[fc00::192.168.134.145]",
+			repository: "[fc00::192.168.134.145]/repo",
+		},
+		{
+			input:      "[fc00::192.168.134.145%eth0]/repo",
+			domain:     "[fc00::192.168.134.145%eth0]",
+			repository: "[fc00::192.168.134.145%eth0]/repo",
+		},
+		{
+			input:      "[::]/repo",
+			domain:     "[::]",
+			repository: "[::]/repo",
+		},
+		{
 			input:      "[fc00::1]/repo",
 			domain:     "[fc00::1]",
 			repository: "[fc00::1]/repo",
@@ -376,6 +434,11 @@ func TestSplitHostname(t *testing.T) {
 		{
 			input:  "xn--n3h.com:18080/foo",
 			domain: "xn--n3h.com:18080",
+			name:   "foo",
+		},
+		{
+			input:  "[fc00::1%eth0]:8080/foo",
+			domain: "[fc00::1%eth0]:8080",
 			name:   "foo",
 		},
 	}

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -1,6 +1,9 @@
 package reference
 
-import "regexp"
+import (
+	"regexp"
+	"strconv"
+)
 
 var (
 	// alphaNumericRegexp defines the alpha numeric atom, typically a
@@ -24,18 +27,52 @@ var (
 	// and followed by an optional port.
 	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
+	// ipv6Regexp restricts the registry domain component of a repository
+	// name to valid IPv6 addresses
+	ipv6Regexp = alternate(
+		expression(exactly(6, h16Regexp, match(`:`)), ls32Regexp),
+		expression(match(`::`), exactly(5, h16Regexp, match(`:`)), ls32Regexp),
+		expression(optional(h16Regexp), match(`::`), exactly(4, h16Regexp, match(`:`)), ls32Regexp),
+		expression(optional(between(0, 1, h16Regexp, match(`:`)), h16Regexp), match(`::`), exactly(3, h16Regexp, match(`:`)), ls32Regexp),
+		expression(optional(between(0, 2, h16Regexp, match(`:`)), h16Regexp), match(`::`), exactly(2, h16Regexp, match(`:`)), ls32Regexp),
+		expression(optional(between(0, 3, h16Regexp, match(`:`)), h16Regexp), match(`::`), h16Regexp, match(`:`), ls32Regexp),
+		expression(optional(between(0, 4, h16Regexp, match(`:`)), h16Regexp), match(`::`), ls32Regexp),
+		expression(optional(between(0, 5, h16Regexp, match(`:`)), h16Regexp), match(`::`), h16Regexp),
+		expression(optional(between(0, 6, h16Regexp, match(`:`)), h16Regexp), match(`::`)),
+	)
+
+	// ls32Regexp represents the lowest 32 bits of an ipv6 address
+	ls32Regexp = alternate(
+		expression(h16Regexp, literal(`:`), h16Regexp),
+		ipv4Regexp,
+	)
+
+	// h16Regexp represents 1 to 4 hexadecimal numbers used in ipv6 addresses
+	h16Regexp = match(`[[:xdigit:]]{1,4}`)
+
+	// ipv4Regex matches ipv4 addresses
+	ipv4Regexp = expression(
+		d8Regexp, literal(`.`),
+		d8Regexp, literal(`.`),
+		d8Regexp, literal(`.`),
+		d8Regexp,
+	)
+
+	// d8Regexp matches the textual representation of one octet in ipv4 addresses
+	d8Regexp = match(`(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])`)
+
 	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
-	// names.
+	// names. In additon to matching potential domain components, it also supports
+	// matching IPv6 addresses with an optional zone id for registries without
+	// domain name resolution.
 	DomainRegexp = expression(
 		alternate(
-			expression(
-				expression(literal(`[`),
-					repeated(match(`(?:[[:xdigit:]]|:)`)),
-					optional(match(`%`), match(`[a-zA-Z0-9-._~]+`)),
-					literal(`]`),
-				),
+			expression(literal(`[`),
+				ipv6Regexp,
+				optional(literal(`%`), match(`[a-zA-Z0-9-._~]+`)),
+				literal(`]`),
 			),
 			expression(domainComponentRegexp,
 				optional(repeated(literal(`.`), domainComponentRegexp)),
@@ -150,6 +187,30 @@ func capture(res ...*regexp.Regexp) *regexp.Regexp {
 // anchored anchors the regular expression by adding start and end delimiters.
 func anchored(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(`^` + expression(res...).String() + `$`)
+}
+
+// exactly wraps the regexp in a non-capturing group to match
+// exactly n number of times
+func exactly(n int, res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `){` + strconv.Itoa(n) + `}`)
+}
+
+// atLeast wraps the regexp in a non-capturing group to match
+// at least n number of times
+func atLeast(n int, res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `){` + strconv.Itoa(n) + `,}`)
+}
+
+// atMost wraps the regexp in a non-capturing group to match
+// at most m number of times
+func atMost(m int, res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `){,` + strconv.Itoa(m) + `}`)
+}
+
+// between wraps the regexp in a non-capturing group to match
+// between n and m number of times
+func between(n, m int, res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `){` + strconv.Itoa(n) + `,` + strconv.Itoa(m) + `}`)
 }
 
 // alternate wraps the regexp in a non-capturing group with each


### PR DESCRIPTION
This allows a docker client from pulling an image from a private registry by using its IPv6 address (including an optional zone id).