### PR TITLE
Allow to use custom cache provider

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/distribution/registry/proxy"
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
+	cacheprovider "github.com/docker/distribution/registry/storage/cache/provider"
 	rediscache "github.com/docker/distribution/registry/storage/cache/redis"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/factory"
@@ -282,7 +283,20 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 			dcontext.GetLogger(app).Infof("using inmemory blob descriptor cache")
 		default:
 			if v != "" {
-				dcontext.GetLogger(app).Warnf("unknown cache type %q, caching disabled", config.Storage["cache"])
+				name, ok := v.(string)
+				if !ok {
+					panic(fmt.Sprintf("unexpected type of value %T (string expected)", v))
+				}
+				cacheProvider, err := cacheprovider.Get(app, name, cc)
+				if err != nil {
+					panic("unable to initialize cache provider: " + err.Error())
+				}
+				localOptions := append(options, storage.BlobDescriptorCacheProvider(cacheProvider))
+				app.registry, err = storage.NewRegistry(app, app.driver, localOptions...)
+				if err != nil {
+					panic("could not create registry: " + err.Error())
+				}
+				dcontext.GetLogger(app).Infof("using %s blob descriptor cache", name)
 			}
 		}
 	}

--- a/registry/storage/cache/provider/cacheprovider.go
+++ b/registry/storage/cache/provider/cacheprovider.go
@@ -1,0 +1,39 @@
+package cacheprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution/registry/storage/cache"
+)
+
+// InitFunc is the type of a CacheProvider factory function and is
+// used to register the constructor for different CacheProvider backends.
+type InitFunc func(ctx context.Context, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error)
+
+var cacheProviders map[string]InitFunc
+
+// Register is used to register an InitFunc for
+// a CacheProvider backend with the given name.
+func Register(name string, initFunc InitFunc) error {
+	if cacheProviders == nil {
+		cacheProviders = make(map[string]InitFunc)
+	}
+	if _, exists := cacheProviders[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	cacheProviders[name] = initFunc
+
+	return nil
+}
+
+// Get constructs a CacheProvider with the given options using the named backend.
+func Get(ctx context.Context, name string, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error) {
+	if cacheProviders != nil {
+		if initFunc, exists := cacheProviders[name]; exists {
+			return initFunc(ctx, options)
+		}
+	}
+	return nil, fmt.Errorf("no cache Provider registered with name: %s", name)
+}


### PR DESCRIPTION
Add the ability to define a custom cache backends. Not only `redis` and `inmemory`.
