### PR TITLE
[swift] specialized walk implementation, listing page size and retries configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,8 @@ storage:
     region: fr
     container: containername
     rootdirectory: /swift/object/name/prefix
+    pagesize: page size for object listing
+    retries: number of retries on error
   oss:
     accesskeyid: accesskeyid
     accesskeysecret: accesskeysecret
@@ -413,6 +415,8 @@ storage:
     region: fr
     container: containername
     rootdirectory: /swift/object/name/prefix
+    pagesize: page size for object listing
+    retries: number of retries on error
   oss:
     accesskeyid: accesskeyid
     accesskeysecret: accesskeysecret

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -102,6 +102,8 @@ func init() {
 			endpointType,
 			insecureSkipVerify,
 			defaultChunkSize,
+			0, // default page size
+			0, // default number of retries
 			secretKey,
 			accessKey,
 			containerKey,


### PR DESCRIPTION
This PR adds configuration of two parameters in swift storage driver: object listing page size and number of retries in case of error. Default values were not sufficient when interfacing with slow swift backend.

I also added specialized `Walk` implementation to decrease number of storage backend calls. It makes some of the registry functions such as repository listing much faster. It also speeds up garbage collection significantly.
