### PR TITLE
Add content cache required changes to distribution

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -301,7 +301,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		}
 	}
 
-	app.registry, err = applyRegistryMiddleware(app, app.registry, config.Middleware["registry"])
+	app.registry, err = applyRegistryMiddleware(app, app.registry, app.driver, config.Middleware["registry"])
 	if err != nil {
 		panic(err)
 	}
@@ -958,9 +958,9 @@ func appendCatalogAccessRecord(accessRecords []auth.Access, r *http.Request) []a
 }
 
 // applyRegistryMiddleware wraps a registry instance with the configured middlewares
-func applyRegistryMiddleware(ctx context.Context, registry distribution.Namespace, middlewares []configuration.Middleware) (distribution.Namespace, error) {
+func applyRegistryMiddleware(ctx context.Context, registry distribution.Namespace, driver storagedriver.StorageDriver, middlewares []configuration.Middleware) (distribution.Namespace, error) {
 	for _, mw := range middlewares {
-		rmw, err := registrymiddleware.Get(ctx, mw.Name, mw.Options, registry)
+		rmw, err := registrymiddleware.Get(ctx, mw.Name, mw.Options, registry, driver)
 		if err != nil {
 			return nil, fmt.Errorf("unable to configure registry middleware (%s): %s", mw.Name, err)
 		}

--- a/registry/middleware/registry/middleware.go
+++ b/registry/middleware/registry/middleware.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/registry/storage"
+	storagedriver "github.com/docker/distribution/v3/registry/storage/driver"
 )
 
 // InitFunc is the type of a RegistryMiddleware factory function and is
 // used to register the constructor for different RegistryMiddleware backends.
-type InitFunc func(ctx context.Context, registry distribution.Namespace, options map[string]interface{}) (distribution.Namespace, error)
+type InitFunc func(ctx context.Context, registry distribution.Namespace, driver storagedriver.StorageDriver, options map[string]interface{}) (distribution.Namespace, error)
 
 var middlewares map[string]InitFunc
 var registryoptions []storage.RegistryOption
@@ -31,10 +32,10 @@ func Register(name string, initFunc InitFunc) error {
 }
 
 // Get constructs a RegistryMiddleware with the given options using the named backend.
-func Get(ctx context.Context, name string, options map[string]interface{}, registry distribution.Namespace) (distribution.Namespace, error) {
+func Get(ctx context.Context, name string, options map[string]interface{}, registry distribution.Namespace, driver storagedriver.StorageDriver) (distribution.Namespace, error) {
 	if middlewares != nil {
 		if initFunc, exists := middlewares[name]; exists {
-			return initFunc(ctx, registry, options)
+			return initFunc(ctx, registry, driver, options)
 		}
 	}
 

--- a/registry/middleware/registry/middleware.go
+++ b/registry/middleware/registry/middleware.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/registry/storage"
-	storagedriver "github.com/docker/distribution/v3/registry/storage/driver"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 )
 
 // InitFunc is the type of a RegistryMiddleware factory function and is


### PR DESCRIPTION
Rebased version of #2633

> Piping the storage driver through the registry middleware enables using the driver to perform out of band storage operations outside of the normal operation of the registry. One example of this is a TTL scheduler that cleans up blobs after specific TTL times have passed, which can then be used as a downstream registry cache that pulls from upstream for blobs that don't exist locally.
> 
> Note, this represents interface breakage so I want to assess the damage done here and what can be done to reduce the scope of damage.

Signed-off-by: David Wu <david.wu@docker.com>