### PR TITLE
add logs3request param

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -94,6 +94,7 @@ type DriverParameters struct {
 	Secure                      bool
 	SkipVerify                  bool
 	V4Auth                      bool
+	LogS3Request                bool
 	ChunkSize                   int64
 	MultipartCopyChunkSize      int64
 	MultipartCopyMaxConcurrency int64
@@ -271,6 +272,23 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		return nil, fmt.Errorf("The v4auth parameter should be a boolean")
 	}
 
+	logS3Bool := false
+	logS3Request := parameters["logs3request"]
+	switch logS3Request := logS3Request.(type) {
+	case string:
+		b, err := strconv.ParseBool(logS3Request)
+		if err != nil {
+			return nil, fmt.Errorf("The logs3request parameter should be a boolean")
+		}
+		logS3Bool = b
+	case bool:
+		logS3Bool = logS3Request
+	case nil:
+		// do nothing
+	default:
+		return nil, fmt.Errorf("The logs3request parameter should be a boolean")
+	}
+
 	keyID := parameters["keyid"]
 	if keyID == nil {
 		keyID = ""
@@ -352,6 +370,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		secureBool,
 		skipVerifyBool,
 		v4Bool,
+		logS3Bool,
 		chunkSize,
 		multipartCopyChunkSize,
 		multipartCopyMaxConcurrency,
@@ -431,6 +450,10 @@ func New(params DriverParameters) (*Driver, error) {
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
 
+	if params.LogS3Request {
+		awsConfig.WithLogLevel(aws.LogDebugWithSigning)
+	}
+
 	if params.UserAgent != "" || params.SkipVerify {
 		httpTransport := http.DefaultTransport
 		if params.SkipVerify {
@@ -476,11 +499,11 @@ func New(params DriverParameters) (*Driver, error) {
 	// }
 
 	d := &driver{
-		S3:                          s3obj,
-		Bucket:                      params.Bucket,
-		ChunkSize:                   params.ChunkSize,
-		Encrypt:                     params.Encrypt,
-		KeyID:                       params.KeyID,
+		S3:        s3obj,
+		Bucket:    params.Bucket,
+		ChunkSize: params.ChunkSize,
+		Encrypt:   params.Encrypt,
+		KeyID:     params.KeyID,
 		MultipartCopyChunkSize:      params.MultipartCopyChunkSize,
 		MultipartCopyMaxConcurrency: params.MultipartCopyMaxConcurrency,
 		MultipartCopyThresholdSize:  params.MultipartCopyThresholdSize,

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -499,11 +499,11 @@ func New(params DriverParameters) (*Driver, error) {
 	// }
 
 	d := &driver{
-		S3:        s3obj,
-		Bucket:    params.Bucket,
-		ChunkSize: params.ChunkSize,
-		Encrypt:   params.Encrypt,
-		KeyID:     params.KeyID,
+		S3:                          s3obj,
+		Bucket:                      params.Bucket,
+		ChunkSize:                   params.ChunkSize,
+		Encrypt:                     params.Encrypt,
+		KeyID:                       params.KeyID,
 		MultipartCopyChunkSize:      params.MultipartCopyChunkSize,
 		MultipartCopyMaxConcurrency: params.MultipartCopyMaxConcurrency,
 		MultipartCopyThresholdSize:  params.MultipartCopyThresholdSize,

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -33,6 +33,7 @@ func init() {
 	secure := os.Getenv("S3_SECURE")
 	skipVerify := os.Getenv("S3_SKIP_VERIFY")
 	v4Auth := os.Getenv("S3_V4_AUTH")
+	logS3Request := os.Getenv("LOG_S3_REQUEST")
 	region := os.Getenv("AWS_REGION")
 	objectACL := os.Getenv("S3_OBJECT_ACL")
 	root, err := ioutil.TempDir("", "driver-")
@@ -76,6 +77,14 @@ func init() {
 			}
 		}
 
+		logReqBool := true
+		if logS3Request != "" {
+			logReqBool, err = strconv.ParseBool(logS3Request)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
@@ -87,6 +96,7 @@ func init() {
 			secureBool,
 			skipVerifyBool,
 			v4Bool,
+			logReqBool,
 			minChunkSize,
 			defaultMultipartCopyChunkSize,
 			defaultMultipartCopyMaxConcurrency,


### PR DESCRIPTION
Sometimes, we need some debug logs of aws-go-sdk to dig into the problem.
So, add a logs3request param to control whether to output dbg info or not.
Signed-off-by: jimmyyan <jm.y8581@gmail.com>