### PR TITLE
2490 - Allow proxy to convert to schema1 without connectivity to remote

### DIFF
--- a/manifest/schema1/config_builder.go
+++ b/manifest/schema1/config_builder.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/libtrust"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 type diffID digest.Digest
@@ -24,9 +24,9 @@ var gzippedEmptyTar = []byte{
 	0, 8, 0, 0, 255, 255, 46, 175, 181, 239, 0, 4, 0, 0,
 }
 
-// digestSHA256GzippedEmptyTar is the canonical sha256 digest of
+// DigestSHA256GzippedEmptyTar is the canonical sha256 digest of
 // gzippedEmptyTar
-const digestSHA256GzippedEmptyTar = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+const DigestSHA256GzippedEmptyTar = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
 
 // configManifestBuilder is a type for constructing manifests from an image
 // configuration and generic descriptors.
@@ -216,7 +216,7 @@ func (mb *configManifestBuilder) emptyTar(ctx context.Context) (digest.Digest, e
 		return mb.emptyTarDigest, nil
 	}
 
-	descriptor, err := mb.bs.Stat(ctx, digestSHA256GzippedEmptyTar)
+	descriptor, err := mb.bs.Stat(ctx, DigestSHA256GzippedEmptyTar)
 	switch err {
 	case nil:
 		mb.emptyTarDigest = descriptor.Digest

--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -12,7 +12,7 @@ import (
 	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/libtrust"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 type mockBlobService struct {
@@ -79,8 +79,8 @@ func TestEmptyTar(t *testing.T) {
 
 	// Confirm that digestSHA256EmptyTar is the digest of gzippedEmptyTar.
 	dgst := digest.FromBytes(gzippedEmptyTar)
-	if dgst != digestSHA256GzippedEmptyTar {
-		t.Fatalf("digest mismatch for empty tar: expected %s got %s", digestSHA256GzippedEmptyTar, dgst)
+	if dgst != DigestSHA256GzippedEmptyTar {
+		t.Fatalf("digest mismatch for empty tar: expected %s got %s", DigestSHA256GzippedEmptyTar, dgst)
 	}
 }
 
@@ -221,7 +221,7 @@ func TestConfigBuilder(t *testing.T) {
 	}
 
 	// Check that the gzipped empty layer tar was put in the blob store
-	_, err = bs.Stat(dcontext.Background(), digestSHA256GzippedEmptyTar)
+	_, err = bs.Stat(dcontext.Background(), DigestSHA256GzippedEmptyTar)
 	if err != nil {
 		t.Fatal("gzipped empty tar was not put in the blob store")
 	}

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/docker/distribution"
 	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/proxy/scheduler"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 type proxyBlobStore struct {
@@ -35,6 +36,17 @@ func setResponseHeaders(w http.ResponseWriter, length int64, mediaType string, d
 	w.Header().Set("Content-Type", mediaType)
 	w.Header().Set("Docker-Content-Digest", digest.String())
 	w.Header().Set("Etag", digest.String())
+}
+
+func emptyTarDescriptor() distribution.Descriptor {
+	return distribution.Descriptor{
+		MediaType:   "application/octect-stream",
+		Size:        32,
+		Digest:      schema1.DigestSHA256GzippedEmptyTar,
+		URLs:        []string{},
+		Annotations: make(map[string]string),
+		Platform:    nil,
+	}
 }
 
 func (pbs *proxyBlobStore) copyContent(ctx context.Context, dgst digest.Digest, writer io.Writer) (distribution.Descriptor, error) {
@@ -157,6 +169,10 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 }
 
 func (pbs *proxyBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	if dgst.String() == schema1.DigestSHA256GzippedEmptyTar.String() {
+		return emptyTarDescriptor(), nil
+	}
+
 	desc, err := pbs.localStore.Stat(ctx, dgst)
 	if err == nil {
 		return desc, err


### PR DESCRIPTION
## Details

- Makes `DigestSHA256GzippedEmptyTar` in `manifest/schema1/config_builder.go` exportable
- Adds `emptyTarDescriptor()` to `registry/proxy/proxyblobstore.go` which returns the distribution.Descriptor for the SHA256GzippedEmptyTar.
- Modifies `registry/proxy/proxyblobstore.go` Stat() method to return the `emptyTarDescriptor()` if the sha256 of the blob we looking for matches that of the `DigestSHA256GzippedEmptyTar`

## Reasoning

Older Docker clients (v1) are unable to pull images from the registry when it is configured as a pull through cache, and connectivity to the upstream has been lost.

By tracing through the code when the errors were being generated I found that the [`manifest, err := builder.Build(imh)` line in `convertSchema2Manifest()` in the file `registry/handlers/manifests.go` was returning the error. ](https://github.com/docker/distribution/blob/master/registry/handlers/manifests.go#L272)

Tracing through that we see that the error in the conversion happens in the [`manifest/schema1/config_builder.go` file in the method `Build()`](https://github.com/docker/distribution/blob/master/manifest/schema1/config_builder.go#L169-L172)

```go
if latestHistory.EmptyLayer {
    if blobsum, err = mb.emptyTar(ctx); err != nil {
```

Looking at the description of [emptyTar()](https://github.com/docker/distribution/blob/master/manifest/schema1/config_builder.go#L211-L213) we see: 

```go
// emptyTar pushes a compressed empty tar to the blob store if one doesn't
// already exist, and returns its blobsum.
```

In the case where the registry is configured as a pull through cache the [Stat()](https://github.com/docker/distribution/blob/master/registry/proxy/proxyblobstore.go#L159) method we invoke is in `registry/proxy/proxyblobstore.go` which has the following behavior:

1) Check local store for blob
   1.a) if we find the blob return
2) If the blob is not found check the error
   2.a) if the error is _not_ unknown blob return

// at this point the error is unknown blob meaning that we 
// did not find the blob

3) Try to establish and auth connection to the remote registry
4) Request the blob from the remote registry

If we succeed at both step 3 and 4, [we return the descriptor and happily return, without storing the data locally.](https://github.com/docker/distribution/blob/master/manifest/schema1/config_builder.go#L221-L223)

If either step 3 or 4 fail for reasons such as loss of network connectivity, then we [return an error and fail the conversion, again without storing the data locally.](https://github.com/docker/distribution/blob/master/manifest/schema1/config_builder.go#L226-L227)

The issue is that in the situation we are Stating for the empty tar blob, it may not be (and in our testing never is) cached locally, resulting in the proxy always making a remote call for the blob. In the situation where the proxy loses connectivity to the remote repo it will cause older docker clients to fail when attempting a docker pull. In either case, `emptyTar()` does not ever store the result in the local blob store.

This is a problem for the use case where the pull through cache can survive loss of connectivity to the (private) master remote registry. 

There are multiple ways of potentially resolving this issue. This PR implements the one I thought to be simplest and which had the lightest touch on the current code base. It is currently undergoing testing but I wanted to gather feedback early so that if there are any desired changes I can implement them sooner rather than later.

## Issues

Turns out someone already reported this issue!

- Resolves https://github.com/docker/distribution/issues/2490

Signed-off-by: marcospedreiro <mvpedreiro@gmail.com>