### PR TITLE
retain blob segments when deleting temporary objects from Swift

### DIFF
--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -78,7 +78,7 @@ func (reg *registry) Remove(ctx context.Context, name reference.Named) error {
 		return err
 	}
 	repoDir := path.Join(root, name.Name())
-	return reg.driver.Delete(ctx, repoDir)
+	return reg.driver.Delete(ctx, repoDir, false)
 }
 
 // lessPath returns true if one path a is less than path b.

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -307,7 +307,7 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(ctx context.Context, path string) error {
+func (d *driver) Delete(ctx context.Context, path string, committing bool) error {
 	blobRef := d.client.GetContainerReference(d.container).GetBlobReference(path)
 	ok, err := blobRef.DeleteIfExists(nil)
 	if err != nil {

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -198,7 +198,7 @@ func (base *Base) Move(ctx context.Context, sourcePath string, destPath string) 
 }
 
 // Delete wraps Delete of underlying storage driver.
-func (base *Base) Delete(ctx context.Context, path string) error {
+func (base *Base) Delete(ctx context.Context, path string, committing bool) error {
 	ctx, done := dcontext.WithTrace(ctx)
 	defer done("%s.Delete(%q)", base.Name(), path)
 
@@ -207,7 +207,7 @@ func (base *Base) Delete(ctx context.Context, path string) error {
 	}
 
 	start := time.Now()
-	err := base.setDriverName(base.StorageDriver.Delete(ctx, path))
+	err := base.setDriverName(base.StorageDriver.Delete(ctx, path, committing))
 	storageAction.WithValues(base.Name(), "Delete").UpdateSince(start)
 	return err
 }

--- a/registry/storage/driver/base/regulator.go
+++ b/registry/storage/driver/base/regulator.go
@@ -165,11 +165,11 @@ func (r *regulator) Move(ctx context.Context, sourcePath string, destPath string
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (r *regulator) Delete(ctx context.Context, path string) error {
+func (r *regulator) Delete(ctx context.Context, path string, committing bool) error {
 	r.enter()
 	defer r.exit()
 
-	return r.StorageDriver.Delete(ctx, path)
+	return r.StorageDriver.Delete(ctx, path, committing)
 }
 
 // URLFor returns a URL which may be used to retrieve the content stored at

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -269,7 +269,7 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(ctx context.Context, subPath string) error {
+func (d *driver) Delete(ctx context.Context, subPath string, committing bool) error {
 	fullPath := d.fullPath(subPath)
 
 	_, err := os.Stat(fullPath)

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -727,7 +727,7 @@ func (d *driver) listAll(context context.Context, prefix string) ([]string, erro
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(context context.Context, path string) error {
+func (d *driver) Delete(context context.Context, path string, committing bool) error {
 	prefix := d.pathToDirKey(path)
 	gcsContext := d.context(context)
 	keys, err := d.listAll(gcsContext, prefix)

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -223,7 +223,7 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(ctx context.Context, path string) error {
+func (d *driver) Delete(ctx context.Context, path string, committing bool) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -420,11 +420,11 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 		return parseError(sourcePath, err)
 	}
 
-	return d.Delete(ctx, sourcePath)
+	return d.Delete(ctx, sourcePath, false)
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(ctx context.Context, path string) error {
+func (d *driver) Delete(ctx context.Context, path string, committing bool) error {
 	ossPath := d.ossPath(path)
 	listResponse, err := d.Bucket.List(ossPath, "", "", listMax)
 	if err != nil || len(listResponse.Contents) == 0 {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -701,7 +701,7 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 	if err := d.copy(ctx, sourcePath, destPath); err != nil {
 		return err
 	}
-	return d.Delete(ctx, sourcePath)
+	return d.Delete(ctx, sourcePath, false)
 }
 
 // copy copies an object stored at sourcePath to destPath.
@@ -805,7 +805,7 @@ func min(a, b int) int {
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
 // We must be careful since S3 does not guarantee read after delete consistency
-func (d *driver) Delete(ctx context.Context, path string) error {
+func (d *driver) Delete(ctx context.Context, path string, committing bool) error {
 	s3Objects := make([]*s3.ObjectIdentifier, 0, listMax)
 
 	// manually add the given path if it's a file

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -151,7 +151,7 @@ func TestEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
-	defer rootedDriver.Delete(ctx, filename)
+	defer rootedDriver.Delete(ctx, filename, false)
 
 	keys, _ := emptyRootDriver.List(ctx, "/")
 	for _, path := range keys {
@@ -235,13 +235,13 @@ func TestStorageClass(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
-	defer standardDriver.Delete(ctx, standardFilename)
+	defer standardDriver.Delete(ctx, standardFilename, false)
 
 	err = rrDriver.PutContent(ctx, rrFilename, contents)
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
-	defer rrDriver.Delete(ctx, rrFilename)
+	defer rrDriver.Delete(ctx, rrFilename, false)
 
 	standardDriverUnwrapped := standardDriver.Base.StorageDriver.(*driver)
 	resp, err := standardDriverUnwrapped.S3.GetObject(&s3.GetObjectInput{
@@ -683,7 +683,7 @@ func TestOverThousandBlobs(t *testing.T) {
 	}
 
 	// cant actually verify deletion because read-after-delete is inconsistent, but can ensure no errors
-	err = standardDriver.Delete(ctx, "/thousandfiletest")
+	err = standardDriver.Delete(ctx, "/thousandfiletest", false)
 	if err != nil {
 		t.Fatalf("unexpected error deleting thousand files: %v", err)
 	}
@@ -709,8 +709,8 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 	sourcePath := "/source"
 	destPath := "/dest"
 
-	defer d.Delete(ctx, sourcePath)
-	defer d.Delete(ctx, destPath)
+	defer d.Delete(ctx, sourcePath, false)
+	defer d.Delete(ctx, destPath, false)
 
 	// An object larger than d's MultipartCopyThresholdSize will cause d.Move() to perform a multipart copy.
 	multipartCopyThresholdSize := d.baseEmbed.Base.StorageDriver.(*driver).MultipartCopyThresholdSize

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -76,7 +76,7 @@ type StorageDriver interface {
 	Move(ctx context.Context, sourcePath string, destPath string) error
 
 	// Delete recursively deletes all objects stored at "path" and its subpaths.
-	Delete(ctx context.Context, path string) error
+	Delete(ctx context.Context, path string, committing bool) error
 
 	// URLFor returns a URL which may be used to retrieve the content stored at
 	// the given path, possibly using the given options.

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -168,7 +168,7 @@ func TestEmptyRootList(t *testing.T) {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
 
-	err = rootedDriver.Delete(ctx, filename)
+	err = rootedDriver.Delete(ctx, filename, false)
 	if err != nil {
 		t.Fatalf("failed to delete: %v", err)
 	}

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -131,7 +131,7 @@ func (suite *DriverSuite) TestValidPaths(c *check.C) {
 
 func (suite *DriverSuite) deletePath(c *check.C, path string) {
 	for tries := 2; tries > 0; tries-- {
-		err := suite.StorageDriver.Delete(suite.ctx, path)
+		err := suite.StorageDriver.Delete(suite.ctx, path, false)
 		if _, ok := err.(storagedriver.PathNotFoundError); ok {
 			err = nil
 		}
@@ -611,7 +611,7 @@ func (suite *DriverSuite) TestDelete(c *check.C) {
 	err := suite.StorageDriver.PutContent(suite.ctx, filename, contents)
 	c.Assert(err, check.IsNil)
 
-	err = suite.StorageDriver.Delete(suite.ctx, filename)
+	err = suite.StorageDriver.Delete(suite.ctx, filename, false)
 	c.Assert(err, check.IsNil)
 
 	_, err = suite.StorageDriver.GetContent(suite.ctx, filename)
@@ -659,7 +659,7 @@ func (suite *DriverSuite) TestURLFor(c *check.C) {
 // TestDeleteNonexistent checks that removing a nonexistent key fails.
 func (suite *DriverSuite) TestDeleteNonexistent(c *check.C) {
 	filename := randomPath(32)
-	err := suite.StorageDriver.Delete(suite.ctx, filename)
+	err := suite.StorageDriver.Delete(suite.ctx, filename, false)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -684,7 +684,7 @@ func (suite *DriverSuite) TestDeleteFolder(c *check.C) {
 	err = suite.StorageDriver.PutContent(suite.ctx, path.Join(dirname, filename3), contents)
 	c.Assert(err, check.IsNil)
 
-	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename1))
+	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename1), false)
 	c.Assert(err, check.IsNil)
 
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename1))
@@ -698,7 +698,7 @@ func (suite *DriverSuite) TestDeleteFolder(c *check.C) {
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename3))
 	c.Assert(err, check.IsNil)
 
-	err = suite.StorageDriver.Delete(suite.ctx, dirname)
+	err = suite.StorageDriver.Delete(suite.ctx, dirname, false)
 	c.Assert(err, check.IsNil)
 
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename1))
@@ -740,7 +740,7 @@ func (suite *DriverSuite) TestDeleteOnlyDeletesSubpaths(c *check.C) {
 	err = suite.StorageDriver.PutContent(suite.ctx, path.Join(dirname, dirname+"suffix", filename), contents)
 	c.Assert(err, check.IsNil)
 
-	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename))
+	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename), false)
 	c.Assert(err, check.IsNil)
 
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename))
@@ -751,7 +751,7 @@ func (suite *DriverSuite) TestDeleteOnlyDeletesSubpaths(c *check.C) {
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename+"suffix"))
 	c.Assert(err, check.IsNil)
 
-	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, dirname))
+	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, dirname), false)
 	c.Assert(err, check.IsNil)
 
 	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, dirname, filename))
@@ -983,7 +983,7 @@ func (suite *DriverSuite) benchmarkPutGetFiles(c *check.C, size int64) {
 	parentDir := randomPath(8)
 	defer func() {
 		c.StopTimer()
-		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir))
+		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir), false)
 	}()
 
 	for i := 0; i < c.N; i++ {
@@ -1021,7 +1021,7 @@ func (suite *DriverSuite) benchmarkStreamFiles(c *check.C, size int64) {
 	parentDir := randomPath(8)
 	defer func() {
 		c.StopTimer()
-		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir))
+		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir), false)
 	}()
 
 	for i := 0; i < c.N; i++ {
@@ -1057,7 +1057,7 @@ func (suite *DriverSuite) benchmarkListFiles(c *check.C, numFiles int64) {
 	parentDir := randomPath(8)
 	defer func() {
 		c.StopTimer()
-		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir))
+		suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir), false)
 	}()
 
 	for i := int64(0); i < numFiles; i++ {
@@ -1096,7 +1096,7 @@ func (suite *DriverSuite) benchmarkDeleteFiles(c *check.C, numFiles int64) {
 		c.StartTimer()
 
 		// This is the operation we're benchmarking
-		err := suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir))
+		err := suite.StorageDriver.Delete(suite.ctx, firstPart(parentDir), false)
 		c.Assert(err, check.IsNil)
 	}
 }

--- a/registry/storage/garbagecollect_test.go
+++ b/registry/storage/garbagecollect_test.go
@@ -311,7 +311,7 @@ func TestGCWithMissingManifests(t *testing.T) {
 	}
 
 	_manifestsPath := path.Dir(revPath)
-	err = d.Delete(ctx, _manifestsPath)
+	err = d.Delete(ctx, _manifestsPath, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -423,7 +423,7 @@ func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (er
 			return err
 		}
 
-		err = lbs.blobStore.driver.Delete(ctx, blobLinkPath)
+		err = lbs.blobStore.driver.Delete(ctx, blobLinkPath, false)
 		if err != nil {
 			switch err := err.(type) {
 			case driver.PathNotFoundError:

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -39,7 +39,7 @@ func PurgeUploads(ctx context.Context, driver storageDriver.StorageDriver, older
 			logrus.Infof("Upload files in %s have older date (%s) than purge date (%s).  Removing upload directory.",
 				uploadData.containingDir, uploadData.startedAt, olderThan)
 			if actuallyDelete {
-				err = driver.Delete(ctx, uploadData.containingDir)
+				err = driver.Delete(ctx, uploadData.containingDir, false)
 			}
 			if err == nil {
 				deleted = append(deleted, uploadData.containingDir)

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -147,7 +147,7 @@ func TestPurgeMissingStartedAt(t *testing.T) {
 		_, file := path.Split(filePath)
 
 		if file == "startedat" {
-			if err := fs.Delete(ctx, filePath); err != nil {
+			if err := fs.Delete(ctx, filePath, false); err != nil {
 				t.Fatalf("Unable to delete startedat file: %s", filePath)
 			}
 		}

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -112,7 +112,7 @@ func (ts *tagStore) Untag(ctx context.Context, tag string) error {
 		return err
 	}
 
-	return ts.blobStore.driver.Delete(ctx, tagPath)
+	return ts.blobStore.driver.Delete(ctx, tagPath, false)
 }
 
 // linkedBlobStore returns the linkedBlobStore for the named tag, allowing one

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -42,7 +42,7 @@ func (v Vacuum) RemoveBlob(dgst string) error {
 
 	dcontext.GetLogger(v.ctx).Infof("Deleting blob: %s", blobPath)
 
-	err = v.driver.Delete(v.ctx, blobPath)
+	err = v.driver.Delete(v.ctx, blobPath, false)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (v Vacuum) RemoveManifest(name string, dgst digest.Digest, tags []string) e
 			}
 		}
 		dcontext.GetLogger(v.ctx).Infof("deleting manifest tag reference: %s", tagsPath)
-		err = v.driver.Delete(v.ctx, tagsPath)
+		err = v.driver.Delete(v.ctx, tagsPath, false)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func (v Vacuum) RemoveManifest(name string, dgst digest.Digest, tags []string) e
 		return err
 	}
 	dcontext.GetLogger(v.ctx).Infof("deleting manifest: %s", manifestPath)
-	return v.driver.Delete(v.ctx, manifestPath)
+	return v.driver.Delete(v.ctx, manifestPath, false)
 }
 
 // RemoveRepository removes a repository directory from the
@@ -93,7 +93,7 @@ func (v Vacuum) RemoveRepository(repoName string) error {
 	}
 	repoDir := path.Join(rootForRepository, repoName)
 	dcontext.GetLogger(v.ctx).Infof("Deleting repo: %s", repoDir)
-	err = v.driver.Delete(v.ctx, repoDir)
+	err = v.driver.Delete(v.ctx, repoDir, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We've been deploying the  registry with a Swift storage backend and, like some other folks, we ran into the "timeout expired while waiting for segments" problem (e.g. https://github.com/docker/distribution/issues/1013, https://github.com/docker/distribution/issues/2188). I'm aware of Swift's eventual consistency, but I had a hard time believing that containers in generally healthy cluster could lag for such a long time.

After reviewing Swift's logs I realized that in every case the missing segments were deleted by the registry itself immediately after it created them. Although swift.Move is invoked before this to place the blob into its final location, this is done with a copy and delete, because [Swift has no move or rename operations](https://bugs.launchpad.net/swift/+bug/1606415).

Due to Swift's eventual consistency the object is occasionally still visible in its old location when the registry is recursively removing the temporary upload files. swift.Move handles DLOs by just copying the X-Object-Manifest header to the new object (otherwise it would have to download and reupload the segments!) which means there can be (and sometimes are) two different objects referring to the same segments, one of which is then deleted, segments and all, by swift.Delete, leaving the other object alone and segmentless, and the registry vainly waiting for them to appear, which they never will.

This PR addresses this by adding a "committing" parameter to .Delete and setting it  during blobwriter.Commit so that swift.Delete knows not to delete segments for any DLOs it sees.

I've been testing with a repository of 755 blobs and 135 tags, and with this change applied and multiple runs of pushing the whole lot into an empty registry, I've been unable to reproduce the problem, whereas previously a few layers would always fail to upload. I've also deleted all of my test client's docker images and confirmed that everything downloads again.