### PR TITLE
Populate the platform information when calling the References() method of manifest list

### DIFF
--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -126,6 +126,13 @@ func (m ManifestList) References() []distribution.Descriptor {
 	dependencies := make([]distribution.Descriptor, len(m.Manifests))
 	for i := range m.Manifests {
 		dependencies[i] = m.Manifests[i].Descriptor
+		dependencies[i].Platform = &v1.Platform{
+			Architecture: m.Manifests[i].Platform.Architecture,
+			OS:           m.Manifests[i].Platform.OS,
+			OSVersion:    m.Manifests[i].Platform.OSVersion,
+			OSFeatures:   m.Manifests[i].Platform.OSFeatures,
+			Variant:      m.Manifests[i].Platform.Variant,
+		}
 	}
 
 	return dependencies

--- a/manifest/manifestlist/manifestlist_test.go
+++ b/manifest/manifestlist/manifestlist_test.go
@@ -110,6 +110,18 @@ func TestManifestList(t *testing.T) {
 		t.Fatalf("unexpected number of references: %d", len(references))
 	}
 	for i := range references {
+		platform := manifestDescriptors[i].Platform
+		expectedPlatform := &v1.Platform{
+			Architecture: platform.Architecture,
+			OS:           platform.OS,
+			OSFeatures:   platform.OSFeatures,
+			OSVersion:    platform.OSVersion,
+			Variant:      platform.Variant,
+		}
+		if !reflect.DeepEqual(references[i].Platform, expectedPlatform) {
+			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+		}
+		references[i].Platform = nil
 		if !reflect.DeepEqual(references[i], manifestDescriptors[i].Descriptor) {
 			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
 		}
@@ -247,6 +259,18 @@ func TestOCIImageIndex(t *testing.T) {
 		t.Fatalf("unexpected number of references: %d", len(references))
 	}
 	for i := range references {
+		platform := manifestDescriptors[i].Platform
+		expectedPlatform := &v1.Platform{
+			Architecture: platform.Architecture,
+			OS:           platform.OS,
+			OSFeatures:   platform.OSFeatures,
+			OSVersion:    platform.OSVersion,
+			Variant:      platform.Variant,
+		}
+		if !reflect.DeepEqual(references[i].Platform, expectedPlatform) {
+			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+		}
+		references[i].Platform = nil
 		if !reflect.DeepEqual(references[i], manifestDescriptors[i].Descriptor) {
 			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
 		}


### PR DESCRIPTION
Populate the platform information when calling the References() method of manifest list

Signed-off-by: Wenkai Yin <yinw@vmware.com>