### PR TITLE
New setting HTTP.rootRedirectUrl

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -89,6 +89,10 @@ type Configuration struct {
 		// receives a stop signal
 		DrainTimeout time.Duration `yaml:"draintimeout,omitempty"`
 
+		// URL to 302 Redirect in case a browser accesses / of the repository
+		// If this setting is missing, it will return an empty HTTP 200 message
+		RootRedirectURL string `yaml:"rootredirecturl,omitempty"`
+
 		// TLS instructs the http server to listen with a TLS configuration.
 		// This only support simple tls configuration with a cert and key.
 		// Mostly, this is useful for testing situations or simple deployments

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -72,14 +72,15 @@ var configStruct = Configuration{
 		},
 	},
 	HTTP: struct {
-		Addr         string        `yaml:"addr,omitempty"`
-		Net          string        `yaml:"net,omitempty"`
-		Host         string        `yaml:"host,omitempty"`
-		Prefix       string        `yaml:"prefix,omitempty"`
-		Secret       string        `yaml:"secret,omitempty"`
-		RelativeURLs bool          `yaml:"relativeurls,omitempty"`
-		DrainTimeout time.Duration `yaml:"draintimeout,omitempty"`
-		TLS          struct {
+		Addr            string        `yaml:"addr,omitempty"`
+		Net             string        `yaml:"net,omitempty"`
+		Host            string        `yaml:"host,omitempty"`
+		Prefix          string        `yaml:"prefix,omitempty"`
+		Secret          string        `yaml:"secret,omitempty"`
+		RelativeURLs    bool          `yaml:"relativeurls,omitempty"`
+		DrainTimeout    time.Duration `yaml:"draintimeout,omitempty"`
+		RootRedirectURL string        `yaml:"rootredirecturl,omitempty"`
+		TLS             struct {
 			Certificate string   `yaml:"certificate,omitempty"`
 			Key         string   `yaml:"key,omitempty"`
 			ClientCAs   []string `yaml:"clientcas,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,7 @@ http:
   secret: asecretforlocaldevelopment
   relativeurls: false
   draintimeout: 60s
+  rootredirecturl: https://url-with-info-about-my-repository.com/somepage.html
   tls:
     certificate: /path/to/x509/public
     key: /path/to/x509/private
@@ -789,6 +790,7 @@ http:
   secret: asecretforlocaldevelopment
   relativeurls: false
   draintimeout: 60s
+  rootredirecturl: https://url-with-info-about-my-repository.com/somepage.html
   tls:
     certificate: /path/to/x509/public
     key: /path/to/x509/private
@@ -820,6 +822,7 @@ registry.
 | `secret`  | no       | A random piece of data used to sign state that may be stored with the client to protect against tampering. For production environments you should generate a random piece of data using a cryptographically secure random generator. If you omit the secret, the registry will automatically generate a secret when it starts. **If you are building a cluster of registries behind a load balancer, you MUST ensure the secret is the same for all registries.**|
 | `relativeurls`| no    | If `true`,  the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL. **This option is not compatible with Docker 1.7 and earlier.**|
 | `draintimeout`| no    | Amount of time to wait for HTTP connections to drain before shutting down after registry receives SIGTERM signal|
+| `rootredirecturl`| no    |URL to 302 Redirect in case a browser accesses the root path (/) of the repository. If this setting is missing, the registry will return an empty HTTP 200 message|
 
 
 ### `tls`

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -372,7 +372,7 @@ func panicHandler(handler http.Handler) http.Handler {
 // for greater affect.
 func alive(path string, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == path {
+		if r.URL.Path == path && path != "/" {
 			w.Header().Set("Cache-Control", "no-cache")
 			w.WriteHeader(http.StatusOK)
 			return


### PR DESCRIPTION
It's kind of annoying that if one accesses the root URL of my docker repository (say `http://localhost:5000/`, one receives a boring HTTP 200 with an empty content.

This setting allows adds a new setting, `HTTP.rootRedirectUrl` that will instead return a 302 redirect to any given URL.

Of course the new setting is optional and one will have the same result as before if they don't use it.

With the setting:
```
* Rebuilt URL to: localhost:5000/
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET / HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 302 Found
< Content-Type: text/html; charset=utf-8
< Docker-Distribution-Api-Version: registry/2.0
< Location: https://www.someurl.com/
< Date: Mon, 13 May 2019 01:28:14 GMT
< Content-Length: 47
<
<a href="https://www.someurl.com/">Found</a>.

* Connection #0 to host localhost left intact
```
Without the setting:
```
* Rebuilt URL to: localhost:5000/
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET / HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Cache-Control: no-cache
< Docker-Distribution-Api-Version: registry/2.0
< Date: Mon, 13 May 2019 01:09:05 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact
```





