### PR TITLE
Fix bug in parsing domain from repository reference

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -90,7 +90,7 @@ func ParseDockerRef(ref string) (Named, error) {
 // needs to be already validated before.
 func splitDockerDomain(name string) (domain, remainder string) {
 	i := strings.IndexRune(name, '/')
-	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost" && strings.ToLower(name[:i]) == name[:i]) {
 		domain, remainder = defaultDomain, name
 	} else {
 		domain, remainder = name[:i], name[i+1:]

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -28,6 +28,8 @@ func TestValidateReferenceName(t *testing.T) {
 		// when specified with a hostname, it removes the ambiguity from about
 		// whether the value is an identifier or repository name
 		"docker.io/1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+		"Docker/docker",
+		"DOCKER/docker",
 	}
 	invalidRepoNames := []string{
 		"https://github.com/docker/docker",
@@ -228,6 +230,20 @@ func TestParseRepositoryInfo(t *testing.T) {
 			FullName:      "docker.io/store/foo/bar",
 			AmbiguousName: "",
 			Domain:        "docker.io",
+		},
+		{
+			RemoteName:    "bar",
+			FamiliarName:  "Foo/bar",
+			FullName:      "Foo/bar",
+			AmbiguousName: "",
+			Domain:        "Foo",
+		},
+		{
+			RemoteName:    "bar",
+			FamiliarName:  "FOO/bar",
+			FullName:      "FOO/bar",
+			AmbiguousName: "",
+			Domain:        "FOO",
 		},
 	}
 


### PR DESCRIPTION
`regexp.DomainRegexp` matches mixed-case and uppercase strings without `.` as well. For example, in `/v2/SAMPLE/reponame/manifests/latest`, the route handler would match `SAMPLE` as `regexp.DomainRegexp` and `reponame` as `regexp.nameComponentRegexp`. To parse the normalized name, an uppercase or mixed-case string should be considered a valid domain.

Fixes #2858
Redis cache enabled path invokes `ParseNormalizedName` which produces an error because rather than matching `TESTNAME` to the domain like the router does, it matches `TESTNAME/reponame` to the name component.