### PR TITLE
storage: Remove StorageDriver.GetContent

### DIFF
--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -24,10 +24,6 @@ type httpBlobUpload struct {
 	closed   bool
 }
 
-func (hbu *httpBlobUpload) Reader() (io.ReadCloser, error) {
-	panic("Not implemented")
-}
-
 func (hbu *httpBlobUpload) handleErrorResponse(resp *http.Response) error {
 	if resp.StatusCode == http.StatusNotFound {
 		return distribution.ErrBlobUploadUnknown

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -869,15 +869,6 @@ type mockErrorDriver struct {
 	returnErrs []mockErrorMapping
 }
 
-func (dr *mockErrorDriver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	for _, returns := range dr.returnErrs {
-		if strings.Contains(path, returns.pathMatch) {
-			return returns.content, returns.err
-		}
-	}
-	return nil, errors.New("Unknown storage error")
-}
-
 func TestGetManifestWithStorageError(t *testing.T) {
 	factory.Register("storagemanifesterror", &storageManifestErrDriverFactory{})
 	config := configuration.Configuration{

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -247,7 +247,7 @@ func (ttles *TTLExpirationScheduler) readState() error {
 		}
 	}
 
-	bytes, err := ttles.driver.GetContent(ttles.ctx, ttles.pathToStateFile)
+	bytes, err := driver.GetContent(ttles.ctx, ttles.driver, ttles.pathToStateFile)
 	if err != nil {
 		return err
 	}

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -28,7 +28,7 @@ func (bs *blobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error
 		return nil, err
 	}
 
-	p, err := getContent(ctx, bs.driver, bp)
+	p, err := driver.GetContent(ctx, bs.driver, bp)
 	if err != nil {
 		switch err.(type) {
 		case driver.PathNotFoundError:
@@ -139,7 +139,7 @@ func (bs *blobStore) link(ctx context.Context, path string, dgst digest.Digest) 
 
 // readlink returns the linked digest at path.
 func (bs *blobStore) readlink(ctx context.Context, path string) (digest.Digest, error) {
-	content, err := bs.driver.GetContent(ctx, path)
+	content, err := driver.GetContent(ctx, bs.driver, path)
 	if err != nil {
 		return "", err
 	}

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -378,29 +378,3 @@ func (bw *blobWriter) removeResources(ctx context.Context) error {
 
 	return nil
 }
-
-func (bw *blobWriter) Reader() (io.ReadCloser, error) {
-	// todo(richardscothern): Change to exponential backoff, i=0.5, e=2, n=4
-	try := 1
-	for try <= 5 {
-		_, err := bw.driver.Stat(bw.ctx, bw.path)
-		if err == nil {
-			break
-		}
-		switch err.(type) {
-		case storagedriver.PathNotFoundError:
-			dcontext.GetLogger(bw.ctx).Debugf("Nothing found on try %d, sleeping...", try)
-			time.Sleep(1 * time.Second)
-			try++
-		default:
-			return nil, err
-		}
-	}
-
-	readCloser, err := bw.driver.Reader(bw.ctx, bw.path, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return readCloser, nil
-}

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -52,7 +52,7 @@ func (bw *blobWriter) resumeDigest(ctx context.Context) error {
 		// No need to load any state, just reset the hasher.
 		h.(hash.Hash).Reset()
 	} else {
-		storedState, err := bw.driver.GetContent(ctx, hashStateMatch.path)
+		storedState, err := storagedriver.GetContent(ctx, bw.driver, hashStateMatch.path)
 		if err != nil {
 			return err
 		}

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -102,21 +102,6 @@ func (d *driver) Name() string {
 	return driverName
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	blobRef := d.client.GetContainerReference(d.container).GetBlobReference(path)
-	blob, err := blobRef.Get(nil)
-	if err != nil {
-		if is404(err) {
-			return nil, storagedriver.PathNotFoundError{Path: path}
-		}
-		return nil, err
-	}
-
-	defer blob.Close()
-	return ioutil.ReadAll(blob)
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
 	// max size for block blobs uploaded via single "Put Blob" for version after "2016-05-31"

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -90,21 +90,6 @@ func (base *Base) setDriverName(e error) error {
 	}
 }
 
-// GetContent wraps GetContent of underlying storage driver.
-func (base *Base) GetContent(ctx context.Context, path string) ([]byte, error) {
-	ctx, done := dcontext.WithTrace(ctx)
-	defer done("%s.GetContent(%q)", base.Name(), path)
-
-	if !storagedriver.PathRegexp.MatchString(path) {
-		return nil, storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
-	}
-
-	start := time.Now()
-	b, e := base.StorageDriver.GetContent(ctx, path)
-	storageAction.WithValues(base.Name(), "GetContent").UpdateSince(start)
-	return b, base.setDriverName(e)
-}
-
 // PutContent wraps PutContent of underlying storage driver.
 func (base *Base) PutContent(ctx context.Context, path string, content []byte) error {
 	ctx, done := dcontext.WithTrace(ctx)

--- a/registry/storage/driver/base/regulator.go
+++ b/registry/storage/driver/base/regulator.go
@@ -96,15 +96,6 @@ func (r *regulator) Name() string {
 	return r.StorageDriver.Name()
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-// This should primarily be used for small objects.
-func (r *regulator) GetContent(ctx context.Context, path string) ([]byte, error) {
-	r.enter()
-	defer r.exit()
-
-	return r.StorageDriver.GetContent(ctx, path)
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 // This should primarily be used for small objects.
 func (r *regulator) PutContent(ctx context.Context, path string, content []byte) error {

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -113,22 +112,6 @@ func New(params DriverParameters) *Driver {
 
 func (d *driver) Name() string {
 	return driverName
-}
-
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	rc, err := d.Reader(ctx, path, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer rc.Close()
-
-	p, err := ioutil.ReadAll(rc)
-	if err != nil {
-		return nil, err
-	}
-
-	return p, nil
 }
 
 // PutContent stores the []byte content at a location designated by "path".

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -122,12 +122,12 @@ func TestCommitEmpty(t *testing.T) {
 	if writer.Size() != 0 {
 		t.Fatalf("writer.Size: %d != 0", writer.Size())
 	}
-	readContents, err := driver.GetContent(ctx, filename)
+	readContents, err := storagedriver.GetContent(ctx, driver, filename)
 	if err != nil {
-		t.Fatalf("driver.GetContent: unexpected error: %v", err)
+		t.Fatalf("GetContent: unexpected error: %v", err)
 	}
 	if len(readContents) != 0 {
-		t.Fatalf("len(driver.GetContent(..)): %d != 0", len(readContents))
+		t.Fatalf("len(GetContent(..)): %d != 0", len(readContents))
 	}
 }
 
@@ -173,12 +173,12 @@ func TestCommit(t *testing.T) {
 	if writer.Size() != int64(len(contents)) {
 		t.Fatalf("writer.Size: %d != %d", writer.Size(), len(contents))
 	}
-	readContents, err := driver.GetContent(ctx, filename)
+	readContents, err := storagedriver.GetContent(ctx, driver, filename)
 	if err != nil {
-		t.Fatalf("driver.GetContent: unexpected error: %v", err)
+		t.Fatalf("GetContent: unexpected error: %v", err)
 	}
 	if len(readContents) != len(contents) {
-		t.Fatalf("len(driver.GetContent(..)): %d != %d", len(readContents), len(contents))
+		t.Fatalf("len(GetContent(..)): %d != %d", len(readContents), len(contents))
 	}
 }
 

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -68,20 +68,6 @@ func (d *driver) Name() string {
 	return driverName
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-
-	rc, err := d.reader(ctx, path, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer rc.Close()
-
-	return ioutil.ReadAll(rc)
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, p string, contents []byte) error {
 	d.mutex.Lock()

--- a/registry/storage/driver/io.go
+++ b/registry/storage/driver/io.go
@@ -1,19 +1,18 @@
-package storage
+package driver
 
 import (
 	"context"
 	"errors"
 	"io"
 	"io/ioutil"
-
-	"github.com/docker/distribution/registry/storage/driver"
 )
 
 const (
 	maxBlobGetSize = 4 << 20
 )
 
-func getContent(ctx context.Context, driver driver.StorageDriver, p string) ([]byte, error) {
+// GetContent reads the content at p with a limit
+func GetContent(ctx context.Context, driver StorageDriver, p string) ([]byte, error) {
 	r, err := driver.Reader(ctx, p, 0)
 	if err != nil {
 		return nil, err

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -240,15 +240,6 @@ func (d *driver) Name() string {
 	return driverName
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	content, err := d.Bucket.Get(d.ossPath(path))
-	if err != nil {
-		return nil, parseError(path, err)
-	}
-	return content, nil
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
 	return parseError(path, d.Bucket.Put(d.ossPath(path), contents, d.getContentType(), getPermissions(), d.getOptions()))

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -504,15 +504,6 @@ func (d *driver) Name() string {
 	return driverName
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	reader, err := d.Reader(ctx, path, 0)
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadAll(reader)
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
 	_, err := d.S3.PutObject(&s3.PutObjectInput{

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -308,7 +308,7 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 		t.Fatalf("unexpected error moving file: %v", err)
 	}
 
-	received, err := d.GetContent(ctx, destPath)
+	received, err := storagedriver.GetContent(ctx, d, destPath)
 	if err != nil {
 		t.Fatalf("unexpected error getting content: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 		t.Fatal("content differs")
 	}
 
-	_, err = d.GetContent(ctx, sourcePath)
+	_, err = storagedriver.GetContent(ctx, d, sourcePath)
 	switch err.(type) {
 	case storagedriver.PathNotFoundError:
 	default:

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -44,10 +44,6 @@ type StorageDriver interface {
 	// name, but drivers may provide other information here.
 	Name() string
 
-	// GetContent retrieves the content stored at "path" as a []byte.
-	// This should primarily be used for small objects.
-	GetContent(ctx context.Context, path string) ([]byte, error)
-
 	// PutContent stores the []byte content at a location designated by "path".
 	// This should primarily be used for small objects.
 	PutContent(ctx context.Context, path string, content []byte) error
@@ -106,8 +102,7 @@ type FileWriter interface {
 	Cancel() error
 
 	// Commit flushes all content written to this FileWriter and makes it
-	// available for future calls to StorageDriver.GetContent and
-	// StorageDriver.Reader.
+	// available for future calls to StorageDriver.Reader.
 	Commit() error
 }
 

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -302,15 +302,6 @@ func (d *driver) Name() string {
 	return driverName
 }
 
-// GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
-	content, err := d.Conn.ObjectGetBytes(d.Container, d.swiftPath(path))
-	if err == swift.ObjectNotFound {
-		return nil, storagedriver.PathNotFoundError{Path: path}
-	}
-	return content, err
-}
-
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
 	err := d.Conn.ObjectPutBytes(d.Container, d.swiftPath(path), contents, contentType)

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -123,7 +123,7 @@ func (suite *DriverSuite) TestValidPaths(c *check.C) {
 		defer suite.deletePath(c, firstPart(filename))
 		c.Assert(err, check.IsNil)
 
-		received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
+		received, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 		c.Assert(err, check.IsNil)
 		c.Assert(received, check.DeepEquals, contents)
 	}
@@ -166,7 +166,7 @@ func (suite *DriverSuite) TestInvalidPaths(c *check.C) {
 		c.Assert(err, check.FitsTypeOf, storagedriver.InvalidPathError{})
 		c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-		_, err = suite.StorageDriver.GetContent(suite.ctx, filename)
+		_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 		c.Assert(err, check.NotNil)
 		c.Assert(err, check.FitsTypeOf, storagedriver.InvalidPathError{})
 		c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -223,7 +223,7 @@ func (suite *DriverSuite) TestTruncate(c *check.C) {
 // TestReadNonexistent tests reading content from an empty path.
 func (suite *DriverSuite) TestReadNonexistent(c *check.C) {
 	filename := randomPath(32)
-	_, err := suite.StorageDriver.GetContent(suite.ctx, filename)
+	_, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -445,7 +445,7 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	err = writer.Close()
 	c.Assert(err, check.IsNil)
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
+	received, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 	c.Assert(err, check.IsNil)
 	c.Assert(received, check.DeepEquals, fullContents)
 }
@@ -524,11 +524,11 @@ func (suite *DriverSuite) TestMove(c *check.C) {
 	err = suite.StorageDriver.Move(suite.ctx, sourcePath, destPath)
 	c.Assert(err, check.IsNil)
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, destPath)
+	received, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, destPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(received, check.DeepEquals, contents)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, sourcePath)
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, sourcePath)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -554,11 +554,11 @@ func (suite *DriverSuite) TestMoveOverwrite(c *check.C) {
 	err = suite.StorageDriver.Move(suite.ctx, sourcePath, destPath)
 	c.Assert(err, check.IsNil)
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, destPath)
+	received, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, destPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(received, check.DeepEquals, sourceContents)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, sourcePath)
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, sourcePath)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -581,7 +581,7 @@ func (suite *DriverSuite) TestMoveNonexistent(c *check.C) {
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, destPath)
+	received, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, destPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(received, check.DeepEquals, contents)
 }
@@ -614,7 +614,7 @@ func (suite *DriverSuite) TestDelete(c *check.C) {
 	err = suite.StorageDriver.Delete(suite.ctx, filename)
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, filename)
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -687,31 +687,31 @@ func (suite *DriverSuite) TestDeleteFolder(c *check.C) {
 	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename1))
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename1))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename1))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename2))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename2))
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename3))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename3))
 	c.Assert(err, check.IsNil)
 
 	err = suite.StorageDriver.Delete(suite.ctx, dirname)
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename1))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename1))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename2))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename2))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename3))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename3))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
@@ -743,23 +743,23 @@ func (suite *DriverSuite) TestDeleteOnlyDeletesSubpaths(c *check.C) {
 	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, filename))
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, filename+"suffix"))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, filename+"suffix"))
 	c.Assert(err, check.IsNil)
 
 	err = suite.StorageDriver.Delete(suite.ctx, path.Join(dirname, dirname))
 	c.Assert(err, check.IsNil)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, dirname, filename))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, dirname, filename))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 
-	_, err = suite.StorageDriver.GetContent(suite.ctx, path.Join(dirname, dirname+"suffix", filename))
+	_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, path.Join(dirname, dirname+"suffix", filename))
 	c.Assert(err, check.IsNil)
 }
 
@@ -841,7 +841,7 @@ func (suite *DriverSuite) TestPutContentMultipleTimes(c *check.C) {
 	err = suite.StorageDriver.PutContent(suite.ctx, filename, contents)
 	c.Assert(err, check.IsNil)
 
-	readContents, err := suite.StorageDriver.GetContent(suite.ctx, filename)
+	readContents, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 	c.Assert(err, check.IsNil)
 	c.Assert(readContents, check.DeepEquals, contents)
 }
@@ -991,7 +991,7 @@ func (suite *DriverSuite) benchmarkPutGetFiles(c *check.C, size int64) {
 		err := suite.StorageDriver.PutContent(suite.ctx, filename, randomContents(size))
 		c.Assert(err, check.IsNil)
 
-		_, err = suite.StorageDriver.GetContent(suite.ctx, filename)
+		_, err = storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 		c.Assert(err, check.IsNil)
 	}
 }
@@ -1145,7 +1145,7 @@ func (suite *DriverSuite) writeReadCompare(c *check.C, filename string, contents
 	err := suite.StorageDriver.PutContent(suite.ctx, filename, contents)
 	c.Assert(err, check.IsNil)
 
-	readContents, err := suite.StorageDriver.GetContent(suite.ctx, filename)
+	readContents, err := storagedriver.GetContent(suite.ctx, suite.StorageDriver, filename)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(readContents, check.DeepEquals, contents)

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -186,7 +186,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 		return nil, err
 	}
 
-	startedAtBytes, err := lbs.blobStore.driver.GetContent(ctx, startedAtPath)
+	startedAtBytes, err := driver.GetContent(ctx, lbs.blobStore.driver, startedAtPath)
 	if err != nil {
 		switch err := err.(type) {
 		case driver.PathNotFoundError:

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -127,7 +127,7 @@ func uuidFromPath(path string) (string, bool) {
 // readStartedAtFile reads the date from an upload's startedAtFile
 func readStartedAtFile(driver storageDriver.StorageDriver, path string) (time.Time, error) {
 	// todo:(richardscothern) - pass in a context
-	startedAtBytes, err := driver.GetContent(context.Background(), path)
+	startedAtBytes, err := storageDriver.GetContent(context.Background(), driver, path)
 	if err != nil {
 		return time.Now(), err
 	}


### PR DESCRIPTION
There is no limit to the objects in the underlying storage, since they
might've been tampered with by a user. Therefore we should always do a
size-limited read when reading a path into memory.

* Move storage.getContent to driver.GetContent.
* Replace all use of StorageDriver.GetContent with driver.GetContent.

Fixes https://github.com/docker/distribution/issues/2994