### PR TITLE
Add option to exclude some digests from deletion

### DIFF
--- a/registry/root.go
+++ b/registry/root.go
@@ -19,6 +19,7 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
+	GCCmd.Flags().StringVarP(&excludeFile, "exclude-file", "e", "", "when delete-untagged, keep digests that are present in this file (one digest per line)")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 
@@ -38,6 +39,7 @@ var RootCmd = &cobra.Command{
 
 var dryRun bool
 var removeUntagged bool
+var excludeFile string
 
 // GCCmd is the cobra command that corresponds to the garbage-collect subcommand
 var GCCmd = &cobra.Command{
@@ -80,6 +82,7 @@ var GCCmd = &cobra.Command{
 		err = storage.MarkAndSweep(ctx, driver, registry, storage.GCOpts{
 			DryRun:         dryRun,
 			RemoveUntagged: removeUntagged,
+			ExcludeFile:    excludeFile,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to garbage collect: %v", err)

--- a/registry/root.go
+++ b/registry/root.go
@@ -19,7 +19,7 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
-	GCCmd.Flags().StringVarP(&excludeFile, "exclude-file", "e", "", "when delete-untagged, keep digests that are present in this file (one digest per line)")
+	GCCmd.Flags().StringVarP(&excludeFile, "exclude-file", "e", "", "exclude digests from being deleted (one digest per line)")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -54,7 +54,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	if opts.ExcludeFile != "" {
 		excludeFile, err := os.Open(opts.ExcludeFile)
 		if err != nil {
-			return fmt.Errorf("unable to open exlude file")
+			return fmt.Errorf("unable to open exclude file")
 		}
 		defer excludeFile.Close()
 		scanner := bufio.NewScanner(excludeFile)


### PR DESCRIPTION
/closes #3035 

New option to garbage collect :
```
-e, --exclude-file string   exclude digests from being deleted (one digest per line)
```

We can provide a file that contains one digest per line.
When garbage collect runs, if the digest os is present in file, garbage collecte ignore it.

See my linked issue for the use case

To test it, I do

Push 2 different digest on the same final tag
```
docker pull alpine:3.8@sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209
docker tag alpine:3.8@sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209 localhost:5000/alpine
docker push localhost:5000/alpine

docker pull alpine:3.9@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a
docker tag alpine:3.9@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a localhost:5000/alpine
docker push localhost:5000/alpine
```

1. Garbage collect without options delete nothing : 
```
garbage-collect /etc/docker/registry/config.yml
alpine
alpine: marking manifest sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209 
alpine: marking blob sha256:dac7051149965716b0acdcab16380b5f4ab6f2a1565c86ed5f651e954d1e615c
alpine: marking blob sha256:c87736221ed0bcaa60b8e92a19bec2284899ef89226f2a07968677cf59e637a4
alpine: marking manifest sha256:bf1684a6e3676389ec861c602e97f27b03f14178e5bc3f70dce198f9f160cce9 
alpine: marking blob sha256:055936d3920576da37aa9bc460d70c5f212028bda1c08c0879aedf03d7a66ea1
alpine: marking blob sha256:e7c96db7181be991f19a9fb6975cdbbd73c65f4a2681348e63a141a2192a5f10

6 blobs marked, 0 blobs and 0 manifests eligible for deletion
```

2. Garbage collect with delete-untagged and exclude
tells us that a digest is exclude, and delete nothing
```
cat /digests.exclude
sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209
```
```
garbage-collect -m -e /digests.exclude /etc/docker/registry/config.yml
alpine
manifest excluded from deletion: sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209
alpine: excluding blob sha256:dac7051149965716b0acdcab16380b5f4ab6f2a1565c86ed5f651e954d1e615c
alpine: excluding blob sha256:c87736221ed0bcaa60b8e92a19bec2284899ef89226f2a07968677cf59e637a4
alpine: marking manifest sha256:bf1684a6e3676389ec861c602e97f27b03f14178e5bc3f70dce198f9f160cce9 
alpine: marking blob sha256:055936d3920576da37aa9bc460d70c5f212028bda1c08c0879aedf03d7a66ea1
alpine: marking blob sha256:e7c96db7181be991f19a9fb6975cdbbd73c65f4a2681348e63a141a2192a5f10

3 blobs marked, 0 blobs and 0 manifests eligible for deletion
```

3. Garbage collect with delete-untagged without exclude
```
garbage-collect -m /etc/docker/registry/config.yml
alpine
manifest eligible for deletion: sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209
alpine: marking manifest sha256:bf1684a6e3676389ec861c602e97f27b03f14178e5bc3f70dce198f9f160cce9 
alpine: marking blob sha256:055936d3920576da37aa9bc460d70c5f212028bda1c08c0879aedf03d7a66ea1
alpine: marking blob sha256:e7c96db7181be991f19a9fb6975cdbbd73c65f4a2681348e63a141a2192a5f10
INFO[0000] deleting manifest tag reference: /docker/registry/v2/repositories/alpine/_manifests/tags/latest/index/sha256/899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209  go.version=go1.12.12 instance.id=1c7b4719-c1bb-4837-a0e4-87a74bab0752 service=container_registry
INFO[0000] deleting manifest: /docker/registry/v2/repositories/alpine/_manifests/revisions/sha256/899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209  go.version=go1.12.12 instance.id=1c7b4719-c1bb-4837-a0e4-87a74bab0752 service=container_registry

3 blobs marked, 3 blobs and 1 manifests eligible for deletion
blob eligible for deletion: sha256:dac7051149965716b0acdcab16380b5f4ab6f2a1565c86ed5f651e954d1e615c
INFO[0000] Deleting blob: /docker/registry/v2/blobs/sha256/da/dac7051149965716b0acdcab16380b5f4ab6f2a1565c86ed5f651e954d1e615c  go.version=go1.12.12 instance.id=1c7b4719-c1bb-4837-a0e4-87a74bab0752 service=container_registry
blob eligible for deletion: sha256:899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209
INFO[0000] Deleting blob: /docker/registry/v2/blobs/sha256/89/899a03e9816e5283edba63d71ea528cd83576b28a7586cf617ce78af5526f209  go.version=go1.12.12 instance.id=1c7b4719-c1bb-4837-a0e4-87a74bab0752 service=container_registry
blob eligible for deletion: sha256:c87736221ed0bcaa60b8e92a19bec2284899ef89226f2a07968677cf59e637a4
INFO[0000] Deleting blob: /docker/registry/v2/blobs/sha256/c8/c87736221ed0bcaa60b8e92a19bec2284899ef89226f2a07968677cf59e637a4  go.version=go1.12.12 instance.id=1c7b4719-c1bb-4837-a0e4-87a74bab0752 service=container_registry
```