### PR TITLE
Skip deleting blob if it doesn't already exist (GC).

### DIFF
--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -144,6 +144,10 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		}
 		err = vacuum.RemoveBlob(string(dgst))
 		if err != nil {
+			if _, ok := err.(driver.PathNotFoundError); ok {
+				emit("skip deleting blob %s: %v", dgst, err)
+				continue
+			}
 			return fmt.Errorf("failed to delete blob %s: %v", dgst, err)
 		}
 	}


### PR DESCRIPTION
Our internal distribution has an error when GC.

```
failed to garbage collect: failed to delete blob sha256:95e929640ddfa42b86b2fdf1a488fb8d4baa186a1407a554ac3532a9770ec00c: filesystem: Path not found: /docker/registry/v2/blobs/sha256/95/95e929640ddfa42b86b2fdf1a488fb8d4baa186a1407a554ac3532a9770ec00c
```

This PATH existed in the backup immediately before GC execution.

In other words, inconsistency occurred during GC execution.

I don't know the cause, but we can avoid this problem by skipping if blob doesn't already exist.

## updated
> I don't know the cause, but we can avoid this problem by skipping if blob doesn't already exist.

I (We) found the cause.
We executed GC with `nohup`, because GC tasks a lot of time.
At that time,  it seems that We accidentally ran the process twice.

However, whatever the cause, there is no need to occur an error trying to remove a blob that has already disappeared.

Signed-off-by: cappyzawa <cappyzawa@yahoo.ne.jp>