### PR TITLE
Fix panic during uploads purge (fixes #2908)

### DIFF
--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -61,7 +61,6 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	var errors []error
 	uploads := make(map[string]uploadData)
 
-	inUploadDir := false
 	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return uploads, append(errors, err)
@@ -70,14 +69,9 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	err = driver.Walk(ctx, root, func(fileInfo storageDriver.FileInfo) error {
 		filePath := fileInfo.Path()
 		_, file := path.Split(filePath)
-		if file[0] == '_' {
+		if strings.HasPrefix(file, "_") && fileInfo.IsDir() && file != "_uploads" {
 			// Reserved directory
-			inUploadDir = (file == "_uploads")
-
-			if fileInfo.IsDir() && !inUploadDir {
-				return storageDriver.ErrSkipDir
-			}
-
+			return storageDriver.ErrSkipDir
 		}
 
 		uuid, isContainingDir := uuidFromPath(filePath)


### PR DESCRIPTION
During the upload purge the registry panics in the `getOutstandingUploads` function (cf: #2908).

When the `filePath` ends with a "/", the line `_, file := path.Split(filePath)` sets file to an empty string, the later `if file[0] == '_'` triggers a `panic: runtime error: index out of range`

I fixed that using `strings.HasPrefix` instead.