### PR TITLE
Remove duplicate code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-## Docker Distribution Community Code of Conduct
-
-Docker Distribution follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # distribution/distribution Project Governance
 
-Docker distribution abides by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Distribution [Code of Conduct](./CODE-OF-CONDUCT.md) can be found here.
 
 For specific guidance on practical contribution steps please
 see our [CONTRIBUTING.md](./CONTRIBUTING.md) guide.


### PR DESCRIPTION
Fill in the code of conduct rather than linking to CNCF code of conduct to list available escalation points related to this project.