### PR TITLE
Return 404 when getting blobs as manifests

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -70,10 +70,11 @@ func (err ErrManifestUnknown) Error() string {
 type ErrManifestUnknownRevision struct {
 	Name     string
 	Revision digest.Digest
+	Reason   error `json:"-"`
 }
 
 func (err ErrManifestUnknownRevision) Error() string {
-	return fmt.Sprintf("unknown manifest name=%s revision=%s", err.Name, err.Revision)
+	return fmt.Sprintf("unknown manifest name=%s revision=%s reason=%s", err.Name, err.Revision, err.Reason)
 }
 
 // ErrManifestUnverified is returned when the registry is unable to verify

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -17,6 +17,14 @@ import (
 // io.ReadSeeker along with its digest. An error is returned if there is a
 // problem generating valid content.
 func CreateRandomTarFile() (rs io.ReadSeeker, dgst digest.Digest, err error) {
+	fileSize := mrand.Int63n(1<<20) + 1<<20
+	return CreateFixedSizeRandomTarFile(fileSize)
+}
+
+// CreateFixedSizeRandomTarFile creates a random tarfile of fixed size,
+// returning it as an io.ReadSeeker along with its digest. An error is
+// returned if there is a problem generating valid content.
+func CreateFixedSizeRandomTarFile(fileSize int64) (rs io.ReadSeeker, dgst digest.Digest, err error) {
 	nFiles := mrand.Intn(10) + 10
 	target := &bytes.Buffer{}
 	wr := tar.NewWriter(target)
@@ -33,8 +41,6 @@ func CreateRandomTarFile() (rs io.ReadSeeker, dgst digest.Digest, err error) {
 	}
 
 	for fileNumber := 0; fileNumber < nFiles; fileNumber++ {
-		fileSize := mrand.Int63n(1<<20) + 1<<20
-
 		header.Name = fmt.Sprint(fileNumber)
 		header.Size = fileSize
 


### PR DESCRIPTION
It's possible to use the digest of an image config or layer when
getting a manifest by digest, this was causing a 500 (internal server
error) because they do not unmarshal as a manifest properly. Instead
return 404 because there is no manifest with that digest.

Signed-off-by: Bracken Dawson <abdawson@gmail.com>