### PR TITLE
fix: api.md Content-Type syntax error

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -3359,7 +3359,7 @@ POST /v2/<name>/blobs/uploads/?digest=<digest>
 Host: <registry host>
 Authorization: <scheme> <token>
 Content-Length: <length of blob>
-Content-Type: application/octect-stream
+Content-Type: application/octet-stream
 
 <binary data>
 ```


### PR DESCRIPTION
Initiate Monolithic Blob Upload API Content-Type syntax error