### PR TITLE
manifests: Return UNSUPPORTED when deleting manifests by tag

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -485,6 +485,11 @@ func (imh *manifestHandler) applyResourcePolicy(manifest distribution.Manifest) 
 func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 	dcontext.GetLogger(imh).Debug("DeleteImageManifest")
 
+	if imh.Tag != "" {
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeUnsupported)
+		return
+	}
+
 	manifests, err := imh.Repository.Manifests(imh)
 	if err != nil {
 		imh.Errors = append(imh.Errors, err)


### PR DESCRIPTION
The OCI distribution spec allows implementations to support deleting manifests by tag, but also permits returning the `UNSUPPORTED` error code for such requests. docker/distribution has never supported deleting manifests by tag, but previously returned `DIGEST_INVALID`.

The `Tag` and `Digest` fields of the `manifestHandler` are already correctly populated based on which kind of reference was given in the request URL. Return `UNSUPPORTED` if the `Tag` field is populated.

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>