### PR TITLE
Add new parameter accelerate to S3 storage driver.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
-    s3accelerate: false
+    accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid
@@ -423,7 +423,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
-    s3accelerate: false
+    accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
+    s3accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid
@@ -422,6 +423,7 @@ storage:
     secretkey: awssecretkey
     region: us-west-1
     regionendpoint: http://myobjects.local
+    s3accelerate: false
     bucket: bucketname
     encrypt: true
     keyid: mykeyid

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -104,6 +104,7 @@ type DriverParameters struct {
 	ObjectACL                   string
 	SessionToken                string
 	UseDualStack                bool
+	S3Accelerate                bool
 }
 
 func init() {
@@ -377,6 +378,23 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 
 	sessionToken := ""
 
+	s3accelerateBool := false
+	s3accelerate := parameters["s3accelerate"]
+	switch s3accelerate := s3accelerate.(type) {
+	case string:
+		b, err := strconv.ParseBool(s3accelerate)
+		if err != nil {
+			return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+		}
+		s3accelerateBool = b
+	case bool:
+		s3accelerateBool = s3accelerate
+	case nil:
+		// do nothing
+	default:
+		return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+	}
+
 	params := DriverParameters{
 		fmt.Sprint(accessKey),
 		fmt.Sprint(secretKey),
@@ -399,6 +417,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		objectACL,
 		fmt.Sprint(sessionToken),
 		useDualStackBool,
+		s3accelerateBool,
 	}
 
 	return New(params)
@@ -456,6 +475,10 @@ func New(params DriverParameters) (*Driver, error) {
 	if params.RegionEndpoint != "" {
 		awsConfig.WithS3ForcePathStyle(true)
 		awsConfig.WithEndpoint(params.RegionEndpoint)
+	}
+
+	if params.S3Accelerate {
+		awsConfig.WithS3UseAccelerate(true)
 	}
 
 	awsConfig.WithRegion(params.Region)

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -477,10 +477,7 @@ func New(params DriverParameters) (*Driver, error) {
 		awsConfig.WithEndpoint(params.RegionEndpoint)
 	}
 
-	if params.S3Accelerate {
-		awsConfig.WithS3UseAccelerate(true)
-	}
-
+	awsConfig.WithS3UseAccelerate(params.S3Accelerate)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
 	if params.UseDualStack {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -104,7 +104,7 @@ type DriverParameters struct {
 	ObjectACL                   string
 	SessionToken                string
 	UseDualStack                bool
-	S3Accelerate                bool
+	Accelerate                  bool
 }
 
 func init() {
@@ -378,21 +378,21 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 
 	sessionToken := ""
 
-	s3accelerateBool := false
-	s3accelerate := parameters["s3accelerate"]
-	switch s3accelerate := s3accelerate.(type) {
+	accelerateBool := false
+	accelerate := parameters["accelerate"]
+	switch accelerate := accelerate.(type) {
 	case string:
-		b, err := strconv.ParseBool(s3accelerate)
+		b, err := strconv.ParseBool(accelerate)
 		if err != nil {
-			return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+			return nil, fmt.Errorf("the accelerate parameter should be a boolean")
 		}
-		s3accelerateBool = b
+		accelerateBool = b
 	case bool:
-		s3accelerateBool = s3accelerate
+		accelerateBool = accelerate
 	case nil:
 		// do nothing
 	default:
-		return nil, fmt.Errorf("The s3accelerate parameter should be a boolean")
+		return nil, fmt.Errorf("the accelerate parameter should be a boolean")
 	}
 
 	params := DriverParameters{
@@ -417,7 +417,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		objectACL,
 		fmt.Sprint(sessionToken),
 		useDualStackBool,
-		s3accelerateBool,
+		accelerateBool,
 	}
 
 	return New(params)
@@ -477,7 +477,7 @@ func New(params DriverParameters) (*Driver, error) {
 		awsConfig.WithEndpoint(params.RegionEndpoint)
 	}
 
-	awsConfig.WithS3UseAccelerate(params.S3Accelerate)
+	awsConfig.WithS3UseAccelerate(params.Accelerate)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
 	if params.UseDualStack {

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -44,7 +44,7 @@ func init() {
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 	useDualStack := os.Getenv("S3_USE_DUALSTACK")
 	combineSmallPart := os.Getenv("MULTIPART_COMBINE_SMALL_PART")
-	s3accelerate := os.Getenv("S3_ACCELERATE")
+	accelerate := os.Getenv("S3_ACCELERATE")
 	if err != nil {
 		panic(err)
 	}
@@ -96,9 +96,9 @@ func init() {
 			}
 		}
 
-		s3accelerateBool := true
-		if s3accelerate != "" {
-			s3accelerateBool, err = strconv.ParseBool(s3accelerate)
+		accelerateBool := true
+		if accelerate != "" {
+			accelerateBool, err = strconv.ParseBool(accelerate)
 			if err != nil {
 				return nil, err
 			}
@@ -126,7 +126,7 @@ func init() {
 			objectACL,
 			sessionToken,
 			useDualStackBool,
-			s3accelerateBool,
+			accelerateBool,
 		}
 
 		return New(parameters)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -44,6 +44,7 @@ func init() {
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 	useDualStack := os.Getenv("S3_USE_DUALSTACK")
 	combineSmallPart := os.Getenv("MULTIPART_COMBINE_SMALL_PART")
+	s3accelerate := os.Getenv("S3_ACCELERATE")
 	if err != nil {
 		panic(err)
 	}
@@ -86,9 +87,18 @@ func init() {
 		if useDualStack != "" {
 			useDualStackBool, err = strconv.ParseBool(useDualStack)
 		}
+
 		multipartCombineSmallPart := true
 		if combineSmallPart != "" {
 			multipartCombineSmallPart, err = strconv.ParseBool(combineSmallPart)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		s3accelerateBool := true
+		if s3accelerate != "" {
+			s3accelerateBool, err = strconv.ParseBool(s3accelerate)
 			if err != nil {
 				return nil, err
 			}
@@ -116,6 +126,7 @@ func init() {
 			objectACL,
 			sessionToken,
 			useDualStackBool,
+			s3accelerateBool,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Rebase of https://github.com/docker/distribution/pull/2166 due to inactivity

Original PR comment:
I've added an optional parameter to enable S3 Transfer acceleration for the S3 storage driver. Thank you very much for considering the change.

If s3accelerate is set to true then we turn on S3 Transfer Acceleration via the AWS SDK. It defaults to false since this is an opt-in feature on the S3 bucket.

Signed-off-by: Kirat Singh <kirat.singh@wsq.io>