### PR TITLE
Relax filesystem driver folder permissions to 0777 (cont)

### DIFF
--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -260,7 +260,7 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 		return storagedriver.PathNotFoundError{Path: sourcePath}
 	}
 
-	if err := os.MkdirAll(path.Dir(dest), 0755); err != nil {
+	if err := os.MkdirAll(path.Dir(dest), 0777); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There was a previous PR relaxing the filsystem driver permissions
for files and folders to 0666 and 0777 respectively [1][2], but it was
incomplete. This is required to get the registry to honor the umask
value.

[1] https://github.com/docker/distribution/pull/1304/
[2] https://github.com/docker/distribution/issues/1295

Signed-off-by: Stefan Nica <snica@suse.com>