### PR TITLE
Make redirect middleware can use path

### DIFF
--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	pathutil "path"
+	"path"
 
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	storagemiddleware "github.com/docker/distribution/registry/storage/driver/middleware"
@@ -42,11 +42,11 @@ func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[st
 	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host, basePath: u.Path}, nil
 }
 
-func (r *redirectStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+func (r *redirectStorageMiddleware) URLFor(ctx context.Context, urlPath string, options map[string]interface{}) (string, error) {
 	if r.basePath != "" {
-		path = pathutil.Join(r.basePath, path)
+		urlPath = path.Join(r.basePath, urlPath)
 	}
-	u := &url.URL{Scheme: r.scheme, Host: r.host, Path: path}
+	u := &url.URL{Scheme: r.scheme, Host: r.host, Path: urlPath}
 	return u.String(), nil
 }
 

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	pathutil "path"
 
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	storagemiddleware "github.com/docker/distribution/registry/storage/driver/middleware"
@@ -11,9 +12,9 @@ import (
 
 type redirectStorageMiddleware struct {
 	storagedriver.StorageDriver
-	scheme string
-	host   string
-	path   string
+	scheme   string
+	host     string
+	basePath string
 }
 
 var _ storagedriver.StorageDriver = &redirectStorageMiddleware{}
@@ -38,12 +39,12 @@ func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[st
 		return nil, fmt.Errorf("no host specified for redirect baseurl")
 	}
 
-	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host, path: u.Path}, nil
+	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host, basePath: u.Path}, nil
 }
 
 func (r *redirectStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	if r.path != "" {
-		path = r.path + path
+	if r.basePath != "" {
+		path = pathutil.Join(r.basePath, path)
 	}
 	u := &url.URL{Scheme: r.scheme, Host: r.host, Path: path}
 	return u.String(), nil

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -13,6 +13,7 @@ type redirectStorageMiddleware struct {
 	storagedriver.StorageDriver
 	scheme string
 	host   string
+	path   string
 }
 
 var _ storagedriver.StorageDriver = &redirectStorageMiddleware{}
@@ -37,10 +38,13 @@ func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[st
 		return nil, fmt.Errorf("no host specified for redirect baseurl")
 	}
 
-	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host}, nil
+	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host, path: u.Path}, nil
 }
 
 func (r *redirectStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	if r.path != "" {
+		path = r.path + path
+	}
 	u := &url.URL{Scheme: r.scheme, Host: r.host, Path: path}
 	return u.String(), nil
 }

--- a/registry/storage/driver/middleware/redirect/middleware_test.go
+++ b/registry/storage/driver/middleware/redirect/middleware_test.go
@@ -57,3 +57,46 @@ func (s *MiddlewareSuite) TestHTTP(c *check.C) {
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "http://example.com/morty/data")
 }
+
+func (s *MiddlewareSuite) TestPath(c *check.C) {
+	// basePath: end with no slash
+	options := make(map[string]interface{})
+	options["baseurl"] = "https://example.com/path"
+	middleware, err := newRedirectStorageMiddleware(nil, options)
+	c.Assert(err, check.Equals, nil)
+
+	m, ok := middleware.(*redirectStorageMiddleware)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(m.scheme, check.Equals, "https")
+	c.Assert(m.host, check.Equals, "example.com")
+	c.Assert(m.basePath, check.Equals, "/path")
+
+	// call URLFor() with no leading slash
+	url, err := middleware.URLFor(context.TODO(), "morty/data", nil)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
+	// call URLFor() with leading slash
+	url, err = middleware.URLFor(context.TODO(), "/morty/data", nil)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
+
+	// basePath: end with slash
+	options["baseurl"] = "https://example.com/path/"
+	middleware, err = newRedirectStorageMiddleware(nil, options)
+	c.Assert(err, check.Equals, nil)
+
+	m, ok = middleware.(*redirectStorageMiddleware)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(m.scheme, check.Equals, "https")
+	c.Assert(m.host, check.Equals, "example.com")
+	c.Assert(m.basePath, check.Equals, "/path/")
+
+	// call URLFor() with no leading slash
+	url, err = middleware.URLFor(context.TODO(), "morty/data", nil)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
+	// call URLFor() with leading slash
+	url, err = middleware.URLFor(context.TODO(), "/morty/data", nil)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
+}


### PR DESCRIPTION
This patch enable us to use path in redirect middleware.

Currently, redirect middleware respects only scheme and host.
But actually our S3-Compatible storage needs this features for redirect to object storage endpoint.
and I believe this should be useful also for other users.

Related: #3022 