### PR TITLE
OCI: POST request with digest and blob should yield 201

### DIFF
--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -151,7 +151,7 @@ func (buh *blobUploadHandler) PatchBlobData(w http.ResponseWriter, r *http.Reque
 
 // PostBlobData writes upload data to a blob.
 func (buh *blobUploadHandler) PostBlobData(w http.ResponseWriter, r *http.Request) {
-	if r.FormValue("digest") != "" && r.ContentLength > 0 {
+	if r.FormValue("digest") != "" {
 		buh.BlobUploadComplete(w, r)
 	} else {
 		buh.StartBlobUpload(w, r)


### PR DESCRIPTION
fixes https://github.com/docker/distribution/issues/3230 OCI Conformance: POST request with digest and blob should yield a 201

This addresses a couple compliance failures mentioned in #3203 by adding a new function, `PostBlobData`, that dispatches to different handler functions depending on the contents of the `digest` query parameter and whether or not the POST request has a non-zero content length.