### PR TITLE
slight refactor of layerInfoCache

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -160,35 +160,11 @@ type Configuration struct {
 	// registry events are dispatched.
 	Notifications Notifications `yaml:"notifications,omitempty"`
 
+	RedisDBs struct {
+		LayerInfoCache Redis `yaml:"layerinfocache,omitempty"`
+	}
+
 	// Redis configures the redis pool available to the registry webapp.
-	Redis struct {
-		// Addr specifies the the redis instance available to the application.
-		Addr string `yaml:"addr,omitempty"`
-
-		// Password string to use when making a connection.
-		Password string `yaml:"password,omitempty"`
-
-		// DB specifies the database to connect to on the redis instance.
-		DB int `yaml:"db,omitempty"`
-
-		DialTimeout  time.Duration `yaml:"dialtimeout,omitempty"`  // timeout for connect
-		ReadTimeout  time.Duration `yaml:"readtimeout,omitempty"`  // timeout for reads of data
-		WriteTimeout time.Duration `yaml:"writetimeout,omitempty"` // timeout for writes of data
-
-		// Pool configures the behavior of the redis connection pool.
-		Pool struct {
-			// MaxIdle sets the maximum number of idle connections.
-			MaxIdle int `yaml:"maxidle,omitempty"`
-
-			// MaxActive sets the maximum number of connections that should be
-			// opened before blocking a connection request.
-			MaxActive int `yaml:"maxactive,omitempty"`
-
-			// IdleTimeout sets the amount time to wait before closing
-			// inactive connections.
-			IdleTimeout time.Duration `yaml:"idletimeout,omitempty"`
-		} `yaml:"pool,omitempty"`
-	} `yaml:"redis,omitempty"`
 
 	Health Health `yaml:"health,omitempty"`
 
@@ -239,6 +215,36 @@ type Configuration struct {
 			Classes []string `yaml:"classes"`
 		} `yaml:"repository,omitempty"`
 	} `yaml:"policy,omitempty"`
+}
+
+// Redis configures a redis pool.
+type Redis struct {
+	// Addr specifies the the redis instance available to the application.
+	Addr string `yaml:"addr,omitempty"`
+
+	// Password string to use when making a connection.
+	Password string `yaml:"password,omitempty"`
+
+	// DB specifies the database to connect to on the redis instance.
+	DB int `yaml:"db,omitempty"`
+
+	DialTimeout  time.Duration `yaml:"dialtimeout,omitempty"`  // timeout for connect
+	ReadTimeout  time.Duration `yaml:"readtimeout,omitempty"`  // timeout for reads of data
+	WriteTimeout time.Duration `yaml:"writetimeout,omitempty"` // timeout for writes of data
+
+	// Pool configures the behavior of the redis connection pool.
+	Pool struct {
+		// MaxIdle sets the maximum number of idle connections.
+		MaxIdle int `yaml:"maxidle,omitempty"`
+
+		// MaxActive sets the maximum number of connections that should be
+		// opened before blocking a connection request.
+		MaxActive int `yaml:"maxactive,omitempty"`
+
+		// IdleTimeout sets the amount time to wait before closing
+		// inactive connections.
+		IdleTimeout time.Duration `yaml:"idletimeout,omitempty"`
+	} `yaml:"pool,omitempty"`
 }
 
 // LogHook is composed of hook Level and Type.


### PR DESCRIPTION
I'm working to address https://github.com/docker/distribution/issues/3141 and while this PR doesn't do that yet, I thought I would submit it separate from the planned work to test the waters and get early feedback on my refactor here.

What I'm trying to accomplish here is to make it possible to initialize multiple redis pools in order to enable users to either specify different redis endpoints entirely or just different databases within the same redis instance in order to logically separate different usage domains. The idea being that in order to address number #3141 I will add a second `redis.Pool` field to `registry/handlers.App` that will be specifically used for handling HTTP request handling cache requirements.

And alternative I considered was to leave `Configuration.Redis` as-is except for removing the `DB` field and moving that to `Configuration.RedisDBs.LayerInfoCache` and adding additional database indices there.