### PR TITLE
Bump Golang to `1.15`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.*
+        go-version: 1.15.*
 
     - name: Dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG GO_VERSION=1.13.8
+ARG GO_VERSION=1.15
 
-FROM golang:${GO_VERSION}-alpine3.11 AS build
+FROM golang:${GO_VERSION}-alpine3.12 AS build
 
 ENV DISTRIBUTION_DIR /go/src/github.com/distribution/distribution
 ENV BUILDTAGS include_oss include_gcs
@@ -18,7 +18,7 @@ WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
 
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN set -ex \
     && apk add --no-cache ca-certificates

--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -60,7 +60,7 @@ to the 1.0 registry. Requests from newer clients will route to the 2.0 registry.
 		$ docker-compose build
 		registryv1 uses an image, skipping
 		Building registryv2...
-		Step 0 : FROM golang:1.4
+		Step 0 : FROM golang:1.15
 		
 		...
 		

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/distribution/distribution/v3
 
-go 1.12
+go 1.15
 
 require (
 	github.com/Azure/azure-sdk-for-go v16.2.1+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,16 +1,20 @@
 # cloud.google.com/go v0.34.0
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-sdk-for-go v16.2.1+incompatible
+## explicit
 github.com/Azure/azure-sdk-for-go/storage
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-autorest v10.8.1+incompatible
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/adal
 github.com/Azure/go-autorest/autorest/azure
 github.com/Azure/go-autorest/autorest/date
 # github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
+## explicit
 github.com/Shopify/logrus-bugsnag
 # github.com/aws/aws-sdk-go v1.34.9
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -57,56 +61,84 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
+# github.com/bitly/go-simplejson v0.5.0
+## explicit
+# github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
+## explicit
 # github.com/bshuster-repo/logrus-logstash-hook v1.0.0
+## explicit
 github.com/bshuster-repo/logrus-logstash-hook
 # github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd
+## explicit
 github.com/bugsnag/bugsnag-go
 github.com/bugsnag/bugsnag-go/errors
 # github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b
+## explicit
 github.com/bugsnag/osext
 # github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0
+## explicit
 github.com/bugsnag/panicwrap
 # github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba
+## explicit
 github.com/denverdino/aliyungo/cdn/auth
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/oss
 github.com/denverdino/aliyungo/util
 # github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c
+## explicit
 github.com/dgrijalva/jwt-go
+# github.com/dnaeon/go-vcr v1.0.1
+## explicit
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
+## explicit
 github.com/docker/go-events
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1
+## explicit
 github.com/docker/libtrust
 # github.com/felixge/httpsnoop v1.0.1
 github.com/felixge/httpsnoop
 # github.com/golang/protobuf v1.3.2
 github.com/golang/protobuf/proto
 # github.com/gomodule/redigo v1.8.2
+## explicit
 github.com/gomodule/redigo/redis
 # github.com/gorilla/handlers v1.5.1
+## explicit
 github.com/gorilla/handlers
 # github.com/gorilla/mux v1.8.0
+## explicit
 github.com/gorilla/mux
 # github.com/inconshreveable/mousetrap v1.0.0
+## explicit
 github.com/inconshreveable/mousetrap
 # github.com/jmespath/go-jmespath v0.3.0
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences
+# github.com/kr/pretty v0.1.0
+## explicit
 # github.com/marstr/guid v1.1.0
+## explicit
 github.com/marstr/guid
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/mapstructure v1.1.2
+## explicit
 github.com/mitchellh/mapstructure
+# github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f
+## explicit
 # github.com/ncw/swift v1.0.47
+## explicit
 github.com/ncw/swift
 github.com/ncw/swift/swifttest
 # github.com/opencontainers/go-digest v1.0.0
+## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.1
+## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/prometheus/client_golang v1.1.0
@@ -123,20 +155,28 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 # github.com/satori/go.uuid v1.2.0
+## explicit
 github.com/satori/go.uuid
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v0.0.3
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3
+## explicit
 github.com/spf13/pflag
 # github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43
+## explicit
 github.com/yvasiyarov/go-metrics
 # github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50
+## explicit
 github.com/yvasiyarov/gorelic
 # github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f
+## explicit
 github.com/yvasiyarov/newrelic_platform_go
 # golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
+## explicit
 golang.org/x/crypto/acme
 golang.org/x/crypto/acme/autocert
 golang.org/x/crypto/bcrypt
@@ -151,6 +191,7 @@ golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -165,6 +206,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff
+## explicit
 google.golang.org/api/gensupport
 google.golang.org/api/googleapi
 google.golang.org/api/googleapi/internal/uritemplates
@@ -181,11 +223,13 @@ google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
 # google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8
+## explicit
 google.golang.org/cloud
 google.golang.org/cloud/internal
 google.golang.org/cloud/internal/opts
 google.golang.org/cloud/storage
 # google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/codes
 google.golang.org/grpc/credentials
@@ -196,6 +240,8 @@ google.golang.org/grpc/naming
 google.golang.org/grpc/peer
 google.golang.org/grpc/transport
 # gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789
+## explicit
 gopkg.in/check.v1
 # gopkg.in/yaml.v2 v2.2.2
+## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
This PR pumps Golang version to [1.15](https://golang.org/doc/go1.15), as well as Linux Alpine to [3.12](https://alpinelinux.org/posts/Alpine-3.12.0-released.html) because there is no other version that comes with Golang 1.15. See here for details: https://hub.docker.com/_/golang?tab=tags&page=1&name=1.15-alpine