### PR TITLE
OCI: add content range handling in patch blob

### DIFF
--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -32,6 +32,17 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 	})
 
+	// ErrorCodeRangeInvalid is returned when uploading a blob if the provided
+	// content range is invalid.
+	ErrorCodeRangeInvalid = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:   "RANGE_INVALID",
+		Message: "invalid content range",
+		Description: `When a layer is uploaded, the provided range is checked
+		against the uploaded chunk. This error is returned if the range is
+		out of order.`,
+		HTTPStatusCode: http.StatusRequestedRangeNotSatisfiable,
+	})
+
 	// ErrorCodeNameInvalid is returned when the name in the manifest does not
 	// match the provided name.
 	ErrorCodeNameInvalid = errcode.Register(errGroup, errcode.ErrorDescriptor{

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/distribution/distribution/v3"
 	dcontext "github.com/distribution/distribution/v3/context"
@@ -133,7 +134,29 @@ func (buh *blobUploadHandler) PatchBlobData(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// TODO(dmcgowan): support Content-Range header to seek and write range
+	cr := r.Header.Get("Content-Range")
+	cl := r.Header.Get("Content-Length")
+	if cr != "" && cl != "" {
+		start, end, err := parseContentRange(cr)
+		if err != nil {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
+			return
+		}
+		if start > end || start != buh.Upload.Size() {
+			buh.Errors = append(buh.Errors, v2.ErrorCodeRangeInvalid)
+			return
+		}
+
+		clInt, err := strconv.ParseInt(cl, 10, 64)
+		if err != nil {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
+			return
+		}
+		if clInt != (end-start)+1 {
+			buh.Errors = append(buh.Errors, v2.ErrorCodeSizeInvalid)
+			return
+		}
+	}
 
 	if err := copyFullPayload(buh, w, r, buh.Upload, -1, "blob PATCH"); err != nil {
 		buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -3,8 +3,11 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 
 	dcontext "github.com/distribution/distribution/v3/context"
 )
@@ -63,4 +66,21 @@ func copyFullPayload(ctx context.Context, responseWriter http.ResponseWriter, r 
 	}
 
 	return nil
+}
+
+func parseContentRange(cr string) (int64, int64, error) {
+	ranges := strings.Split(cr, "-")
+	if len(ranges) != 2 {
+		return -1, -1, fmt.Errorf("invalid content range format, %s", cr)
+	}
+	start, err := strconv.ParseInt(ranges[0], 10, 64)
+	if err != nil {
+		return -1, -1, err
+	}
+	end, err := strconv.ParseInt(ranges[1], 10, 64)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	return start, end, nil
 }


### PR DESCRIPTION
Fixes #3141

1, return 416 for Out-of-order blob upload
2, return 400 for content length and content size mismatch

Signed-off-by: wang yan <wangyan@vmware.com>