### PR TITLE
scripts: remove unused md2man from dev-tools

### DIFF
--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 GOLANGCI_LINT_VERSION="v1.27.0"
-GO_MD2MAN_VERSION="v1.0.10"
 
 #
 # Install developer tools to $GOBIN (or $GOPATH/bin if unset)
@@ -14,4 +13,3 @@ export GO111MODULE=on
 # prevent updating go.mod of the project
 cd /tmp
 go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
-go get "github.com/cpuguy83/go-md2man@${GO_MD2MAN_VERSION}"


### PR DESCRIPTION
Looks like md2man was never used in the build scripts, but got added in commit dc49f84dcc64940628505390a7be3394e4314482 (https://github.com/docker/distribution/pull/2657), possibly due to the script being copy/pasted from another project that does use it.

While we may want to generate man-pages at some point in future, it looks like it's safe to remove for now.
