### PR TITLE
Option to configure proxy cache TTL

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -636,6 +636,9 @@ type Proxy struct {
 
 	// Password of the hub user
 	Password string `yaml:"password"`
+
+	// Remove cached manifest or blob from storage after this time expires. Removal is disabled if this is 0.
+	TTL time.Duration `yaml:"ttl"`
 }
 
 // Parse parses an input configuration yaml document into a Configuration struct

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1118,6 +1118,7 @@ is unsupported.
 | `remoteurl`| yes     | The URL for the repository on Docker Hub.             |
 | `username` | no      | The username registered with Docker Hub which has access to the repository. |
 | `password` | no      | The password used to authenticate to Docker Hub using the username specified in `username`. |
+| `ttl`      | no      | Expire proxy cache configured in "storage" after this time. Cache expiration is disabled if not provided.  |
 
 
 To enable pulling private repositories (e.g. `batman/robin`) specify the

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/docker/distribution"
 	dcontext "github.com/docker/distribution/context"
@@ -18,6 +19,7 @@ type proxyBlobStore struct {
 	localStore     distribution.BlobStore
 	remoteStore    distribution.BlobService
 	scheduler      *scheduler.TTLExpirationScheduler
+	ttl            time.Duration
 	repositoryName reference.Named
 	authChallenger authChallenger
 }
@@ -141,7 +143,10 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 
-		pbs.scheduler.AddBlob(blobRef, repositoryTTL)
+		if pbs.scheduler != nil {
+			pbs.scheduler.AddBlob(blobRef, pbs.ttl)
+		}
+
 	}(dgst)
 
 	_, err = pbs.copyContent(ctx, dgst, w)

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -222,6 +222,7 @@ func populate(t *testing.T, te *testEnv, blobCount, size, numUnique int) {
 	te.inRemote = inRemote
 	te.numUnique = numUnique
 }
+
 func TestProxyStoreGet(t *testing.T) {
 	te := makeTestEnv(t, "foo/bar")
 
@@ -254,7 +255,18 @@ func TestProxyStoreGet(t *testing.T) {
 	if (*remoteStats)["get"] != 1 {
 		t.Errorf("Unexpected remote get count")
 	}
+}
 
+func TestProxyStoreGetWithoutScheduler(t *testing.T) {
+	te := makeTestEnv(t, "foo/bar")
+	te.store.scheduler = nil
+
+	populate(t, te, 1, 10, 1)
+
+	_, err := te.store.Get(te.ctx, te.inRemote[0].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestProxyStoreStat(t *testing.T) {

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -11,15 +11,13 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// todo(richardscothern): from cache control header or config
-const repositoryTTL = 24 * 7 * time.Hour
-
 type proxyManifestStore struct {
 	ctx             context.Context
 	localManifests  distribution.ManifestService
 	remoteManifests distribution.ManifestService
 	repositoryName  reference.Named
 	scheduler       *scheduler.TTLExpirationScheduler
+	ttl             time.Duration
 	authChallenger  authChallenger
 }
 
@@ -77,7 +75,10 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 			return nil, err
 		}
 
-		pms.scheduler.AddManifest(repoBlob, repositoryTTL)
+		if pms.scheduler != nil {
+			pms.scheduler.AddManifest(repoBlob, pms.ttl)
+		}
+
 		// Ensure the manifest blob is cleaned up
 		//pms.scheduler.AddBlob(blobRef, repositoryTTL)
 

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -273,3 +273,24 @@ func TestProxyManifests(t *testing.T) {
 	}
 
 }
+
+func TestProxyManifestsWithoutScheduler(t *testing.T) {
+	name := "foo/bar"
+	env := newManifestStoreTestEnv(t, name, "latest")
+	env.manifests.scheduler = nil
+
+	ctx := context.Background()
+	exists, err := env.manifests.Exists(ctx, env.manifestDigest)
+	if err != nil {
+		t.Fatalf("Error checking existence")
+	}
+	if !exists {
+		t.Errorf("Unexpected non-existent manifest")
+	}
+
+	// Get - should succeed without scheduler
+	_, err = env.manifests.Get(ctx, env.manifestDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
@@ -24,6 +25,7 @@ import (
 type proxyingRegistry struct {
 	embedded       distribution.Namespace // provides local registry functionality
 	scheduler      *scheduler.TTLExpirationScheduler
+	ttl            time.Duration
 	remoteURL      url.URL
 	authChallenger authChallenger
 }
@@ -36,61 +38,65 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}
 
 	v := storage.NewVacuum(ctx, driver)
-	s := scheduler.New(ctx, driver, "/scheduler-state.json")
-	s.OnBlobExpire(func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
 
-		repo, err := registry.Repository(ctx, r)
+	var s *scheduler.TTLExpirationScheduler
+	if config.TTL != 0 {
+		s = scheduler.New(ctx, driver, "/scheduler-state.json")
+		s.OnBlobExpire(func(ref reference.Reference) error {
+			var r reference.Canonical
+			var ok bool
+			if r, ok = ref.(reference.Canonical); !ok {
+				return fmt.Errorf("unexpected reference type : %T", ref)
+			}
+
+			repo, err := registry.Repository(ctx, r)
+			if err != nil {
+				return err
+			}
+
+			blobs := repo.Blobs(ctx)
+
+			// Clear the repository reference and descriptor caches
+			err = blobs.Delete(ctx, r.Digest())
+			if err != nil {
+				return err
+			}
+
+			err = v.RemoveBlob(r.Digest().String())
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		s.OnManifestExpire(func(ref reference.Reference) error {
+			var r reference.Canonical
+			var ok bool
+			if r, ok = ref.(reference.Canonical); !ok {
+				return fmt.Errorf("unexpected reference type : %T", ref)
+			}
+
+			repo, err := registry.Repository(ctx, r)
+			if err != nil {
+				return err
+			}
+
+			manifests, err := repo.Manifests(ctx)
+			if err != nil {
+				return err
+			}
+			err = manifests.Delete(ctx, r.Digest())
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+
+		err = s.Start()
 		if err != nil {
-			return err
+			return nil, err
 		}
-
-		blobs := repo.Blobs(ctx)
-
-		// Clear the repository reference and descriptor caches
-		err = blobs.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-
-		err = v.RemoveBlob(r.Digest().String())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	s.OnManifestExpire(func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		manifests, err := repo.Manifests(ctx)
-		if err != nil {
-			return err
-		}
-		err = manifests.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-
-	err = s.Start()
-	if err != nil {
-		return nil, err
 	}
 
 	cs, err := configureAuth(config.Username, config.Password, config.RemoteURL)
@@ -101,6 +107,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	return &proxyingRegistry{
 		embedded:  registry,
 		scheduler: s,
+		ttl:       config.TTL,
 		remoteURL: *remoteURL,
 		authChallenger: &remoteAuthChallenger{
 			remoteURL: *remoteURL,
@@ -161,6 +168,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			localStore:     localRepo.Blobs(ctx),
 			remoteStore:    remoteRepo.Blobs(ctx),
 			scheduler:      pr.scheduler,
+			ttl:            pr.ttl,
 			repositoryName: name,
 			authChallenger: pr.authChallenger,
 		},
@@ -170,6 +178,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			remoteManifests: remoteManifests,
 			ctx:             ctx,
 			scheduler:       pr.scheduler,
+			ttl:             pr.ttl,
 			authChallenger:  pr.authChallenger,
 		},
 		name: name,


### PR DESCRIPTION
Currently when registry is run as proxy it tries to cleanup unused blobs from its cache after 7 days which is hard-coded. This PR makes that value configurable. One can disable caching using this option. This allows one to temporarily mitigate
https://github.com/docker/distribution/issues/2367 bug.