### PR TITLE
Fix typo for image digest regular expression in spec

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -334,7 +334,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -334,7 +334,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 


### PR DESCRIPTION
In the registry spec, the regular expression provided for the algorithm portion of an image digest appears to be wrong. The expression `/[A-Fa-f0-9_+.-]+/` will not even match `sha256`. I believe the intent here was to match any alphanumeric character instead.