### PR TITLE
Fix typo in digest string grammar definition

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -334,7 +334,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 


### PR DESCRIPTION
The _algorithm_ should be full letters range (possibly mistake from copy&paste part of  _hex_?).