### PR TITLE
retry for certain time during s3.Move

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -695,7 +695,19 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 	if err := d.copy(ctx, sourcePath, destPath); err != nil {
 		return err
 	}
-	return d.Delete(ctx, sourcePath)
+	attempt := 30
+	attemptRelay := 1000 // relay 500ms before next attempt
+	var err error
+	for i := 0; i < attempt; i++ {
+		err = d.Delete(ctx, sourcePath)
+		if err != nil {
+			time.Sleep(time.Duration(attemptRelay))
+			continue
+		} else {
+			break
+		}
+	}
+	return err
 }
 
 // copy copies an object stored at sourcePath to destPath.


### PR DESCRIPTION
Occasionally s3.delete would fail, resulting #1948 , this hack can fix this issue, but it's relatively rough and dirty. Hope someone could tell why is this happening.

Also, you can try this out using my pathced image
```
docker pull ghcr.io/leoquote/registry:2.7.1-s3-hack
```