### PR TITLE
Add s3 driver optimizations

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1235,8 +1235,8 @@ func (w *writer) Write(p []byte) (int, error) {
 				Bucket:   aws.String(w.driver.Bucket),
 				Key:      aws.String(w.key),
 				UploadId: aws.String(w.uploadID),
-			}); aerr != nil {
-				return 0, fmt.Errorf("failed to complete upload: %v: abort error: %v", err, aerr)
+			}); aErr != nil {
+				return 0, fmt.Errorf("failed to complete upload: %v: abort error: %v", err, aErr)
 			}
 			return 0, err
 		}

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -365,7 +365,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	return New(params)
 }
 
-// getParameterAsInt64 converts paramaters[name] to an int64 value (using
+// getParameterAsInt64 converts parameters[name] to an int64 value (using
 // defaultt if nil), verifies it is no smaller than min, and returns it.
 func getParameterAsInt64(parameters map[string]interface{}, name string, defaultt int64, min int64, max int64) (int64, error) {
 	rv := defaultt


### PR DESCRIPTION
This PR brings several optimizations for S3 storage driver:
* makes sure file descriptors are closed when done working with
* preallocates slices when possible
* avoids unnecessary write byte slices reallocations by preallocating fixed-length byte buffers
* avoids leaving unnecessary memory garbage for GC to clean by doing ^^
* makes sure we don't leak any goroutines when making a multipart copy by waiting for all of them to finish

Signed-off-by: Milos Gajdos <milosgajdos83@gmail.com>