### PR TITLE
[release/2.7 backport] Remove empty Content-Type header

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -736,7 +736,12 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 		return nil, err
 	}
 
-	resp, err := bs.client.Post(u, "", nil)
+	req, err := http.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := bs.client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
backport of https://github.com/docker/distribution/pull/3289
fixes https://github.com/docker/distribution/issues/3288
addresses https://github.com/moby/moby/issues/41621