### PR TITLE
Add godev workflow

### DIFF
--- a/.github/workflows/godev.yml
+++ b/.github/workflows/godev.yml
@@ -1,0 +1,25 @@
+# Workflow used to make a request to proxy.golang.org to refresh cache on https://pkg.go.dev/github.com/distribution/distribution
+# when a released of distribution is produced
+name: godev
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Call pkg.go.dev
+        run: |
+          go get github.com/${GITHUB_REPOSITORY}@${GITHUB_REF#refs/tags/}
+        env:
+          GO111MODULE: on
+          GOPROXY: https://proxy.golang.org

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Project, and VMware Harbor Registry.
 <img src="https://www.docker.com/sites/default/files/oyster-registry-3.png" width=200px/>
 
 [![Build Status](https://github.com/distribution/distribution/workflows/CI/badge.svg?branch=main&event=push)](https://github.com/distribution/distribution/actions?query=workflow%3ACI)
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/distribution/distribution)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/distribution/distribution)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
 [![codecov](https://codecov.io/gh/distribution/distribution/branch/main/graph/badge.svg)](https://codecov.io/gh/distribution/distribution)
 


### PR DESCRIPTION
Workflow used to make a request to proxy.golang.org to refresh cache on https://pkg.go.dev/github.com/distribution/distribution when a released of distribution is produced.

cc. @arkodg @milosgajdos

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>