### PR TITLE
replace swift temp url method after validating method supported or not

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -616,12 +616,6 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 		}
 	}
 
-	if methodString == "HEAD" {
-		// A "HEAD" request on a temporary URL is allowed if the
-		// signature was generated with "GET", "POST" or "PUT"
-		methodString = "GET"
-	}
-
 	supported := false
 	for _, method := range d.TempURLMethods {
 		if method == methodString {
@@ -641,6 +635,12 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 		if ok {
 			expiresTime = et
 		}
+	}
+
+	if methodString == "HEAD" {
+		// A "HEAD" request on a temporary URL is allowed if the
+		// signature was generated with "GET", "POST" or "PUT"
+		methodString = "GET"
 	}
 
 	tempURL := d.Conn.ObjectTempUrl(d.Container, d.swiftPath(path), d.SecretKey, methodString, expiresTime)


### PR DESCRIPTION
Currently, the `HEAD` method is converted to `GET` to be compatible with HP Cloud, as in HP Cloud, a "HEAD" on a temporary URL is allowed only if the signature was generated with "GET" or "POST". More details see according [PR](https://github.com/docker/distribution/pull/1114).

However, the converting code snippet is before the validating code snippet, which will cause the `HEAD` method cannot be disabled separately through configuration. So we can move down the converting code snippet after validating code snippet and before computing signature.