### PR TITLE
fix typemapping for uploadpurging config by env

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -132,7 +132,15 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		if v, ok := mc["uploadpurging"]; ok {
 			purgeConfig, ok = v.(map[interface{}]interface{})
 			if !ok {
-				panic("uploadpurging config key must contain additional keys")
+				tmpPurgeConfig, ok := v.(map[string]interface{})
+				if !ok {
+					panic("uploadpurging config key must contain additional keys")
+				}
+
+				purgeConfig = map[interface{}]interface{}{}
+				for k, v := range tmpPurgeConfig {
+					purgeConfig[k] = v
+				}
 			}
 		}
 		if v, ok := mc["readonly"]; ok {


### PR DESCRIPTION
fixes #1736.

using single env-vars for configuring uploadpurging, the config is received as `map[string]interface{}` instead of needed `map[interface{}]interface{}`.

this pr add's annother type-assertion and conversion to make the config more resilient.