### PR TITLE
Adding Steve Lasker as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13,6 +13,7 @@
 "milosgajdos","Milos Gajdos","milos_gajdos@docker.com"
 "waynr","Wayne Warren","wwarren@digitalocean.com"
 "wy65701436","Wang Yan","wangyan@vmware.com"
+"stevelasker","Steve Lasker","steve.lasker@microsoft.com"
 #
 # REVIEWERS
 # GitHub ID, Name, Email address


### PR DESCRIPTION
Per distribution call, adding Steve Lasker as a maintainer to help with OCI and Notary collaboration.
Signed-off-by: Steve Lasker <stevenlasker@hotmail.com>