### PR TITLE
Propose two maintainers from Mirantis

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -6,10 +6,12 @@
 # GitHub ID, Name, Email address
 "chrispat","Chris Patterson","chrispat@github.com"
 "clarkbw","Bryan Clark","clarkbw@github.com"
+"corhere","Cory Snider","csnider@mirantis.com"
 "deleteriousEffect","Hayley Swimelar","hswimelar@gitlab.com"
 "heww","He Weiwei","hweiwei@vmware.com"
 "joaodrp","João Pereira","jpereira@gitlab.com"
 "justincormack","Justin Cormack","justin.cormack@docker.com"
+"squizzi","Kyle Squizzato","ksquizzato@mirantis.com"
 "milosgajdos","Milos Gajdos","milos_gajdos@docker.com"
 "waynr","Wayne Warren","wwarren@digitalocean.com"
 "wy65701436","Wang Yan","wangyan@vmware.com"


### PR DESCRIPTION
Mirantis Secure Registry (once Docker Trusted Registry) also uses
Distribution as its core code. Propose two maintainers from Mirantis
as Distribution maintainers.

cc @corhere @squizzi

Signed-off-by: Justin Cormack <justin@specialbusservice.com>