### PR TITLE
[backport release/2.7] Registry - make minimum TLS version user configurable

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -108,6 +108,9 @@ type Configuration struct {
 			// A file may contain multiple CA certificates encoded as PEM
 			ClientCAs []string `yaml:"clientcas,omitempty"`
 
+			// Specifies the lowest TLS version allowed
+			MinimumTLS string `yaml:"minimumtls,omitempty"`
+
 			// LetsEncrypt is used to configuration setting up TLS through
 			// Let's Encrypt instead of manually specifying certificate and
 			// key. If a TLS certificate is specified, the Let's Encrypt

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -83,6 +83,7 @@ var configStruct = Configuration{
 			Certificate string   `yaml:"certificate,omitempty"`
 			Key         string   `yaml:"key,omitempty"`
 			ClientCAs   []string `yaml:"clientcas,omitempty"`
+			MinimumTLS  string   `yaml:"minimumtls,omitempty"`
 			LetsEncrypt struct {
 				CacheFile string   `yaml:"cachefile,omitempty"`
 				Email     string   `yaml:"email,omitempty"`
@@ -105,6 +106,7 @@ var configStruct = Configuration{
 			Certificate string   `yaml:"certificate,omitempty"`
 			Key         string   `yaml:"key,omitempty"`
 			ClientCAs   []string `yaml:"clientcas,omitempty"`
+			MinimumTLS  string   `yaml:"minimumtls,omitempty"`
 			LetsEncrypt struct {
 				CacheFile string   `yaml:"cachefile,omitempty"`
 				Email     string   `yaml:"email,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -782,6 +782,7 @@ http:
     clientcas:
       - /path/to/ca.pem
       - /path/to/another/ca.pem
+    minimumtls: tls1.0
     letsencrypt:
       cachefile: /path/to/cache-file
       email: emailused@letsencrypt.com
@@ -818,8 +819,9 @@ and proxy connections to the registry server.
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
 | `certificate` | yes  | Absolute path to the x509 certificate file.           |
-| `key`     | yes      | Absolute path to the x509 private key file.           |
-| `clientcas` | no     | An array of absolute paths to x509 CA files.          |
+| `key`         | yes  | Absolute path to the x509 private key file.           |
+| `clientcas`   | no   | An array of absolute paths to x509 CA files.          |
+| `minimumtls`  | no   | Minimum TLS version allowed (tls1.0, tls1.1, tls1.2). Defaults to tls1.0 |
 
 ### `letsencrypt`
 


### PR DESCRIPTION
Signed-off-by: J. Gregory Rebholz <gregrebholz@gmail.com>