### PR TITLE
Incremental catalog iteration

### DIFF
--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -112,7 +112,7 @@ func (bs *blobStore) Enumerate(ctx context.Context, ingester func(dgst digest.Di
 		}
 
 		return ingester(digest)
-	})
+	}, "")
 }
 
 // path returns the canonical path for the blob identified by digest. The blob

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -43,7 +43,7 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 		}
 
 		return nil
-	})
+	}, last)
 
 	n = copy(repos, foundRepos)
 
@@ -66,7 +66,7 @@ func (reg *registry) Enumerate(ctx context.Context, ingester func(string) error)
 
 	err = reg.blobStore.driver.Walk(ctx, root, func(fileInfo driver.FileInfo) error {
 		return handleRepository(fileInfo, root, "", ingester)
-	})
+	}, "")
 
 	return err
 }

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -361,8 +361,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 // directDescendants will find direct descendants (blobs or virtual containers)

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -228,7 +228,7 @@ func (base *Base) URLFor(ctx context.Context, path string, options map[string]in
 }
 
 // Walk wraps Walk of underlying storage driver.
-func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
+func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
 	ctx, done := dcontext.WithTrace(ctx)
 	defer done("%s.Walk(%q)", base.Name(), path)
 
@@ -236,5 +236,5 @@ func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn)
 		return storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
 	}
 
-	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f))
+	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f, offset))
 }

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -291,8 +291,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 // fullPath returns the absolute path of a key within the Driver's storage.

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -836,8 +836,8 @@ func (d *driver) URLFor(context context.Context, path string, options map[string
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 func startSession(client *http.Client, bucket string, name string) (uri string, err error) {

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -246,8 +246,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 type writer struct {

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -490,8 +490,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 func (d *driver) ossPath(path string) string {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -917,7 +917,7 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn) error {
+func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn, offset string) error {
 	path := from
 	if !strings.HasSuffix(path, "/") {
 		path = path + "/"

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -192,7 +192,7 @@ func TestWalkEmptySubDirectory(t *testing.T) {
 	s3driver.Walk(context.Background(), "/testdir", func(fileInfo storagedriver.FileInfo) error {
 		bucketFiles = append(bucketFiles, fileInfo.Path())
 		return nil
-	})
+	}, "")
 
 	expected := []string{"/testdir/emptydir"}
 	if !reflect.DeepEqual(bucketFiles, expected) {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -89,7 +89,18 @@ type StorageDriver interface {
 	// If the returned error from the WalkFn is ErrSkipDir and fileInfo refers
 	// to a directory, the directory will not be entered and Walk
 	// will continue the traversal.  If fileInfo refers to a normal file, processing stops
-	Walk(ctx context.Context, path string, f WalkFn) error
+	//
+	// If offset is specified, Walk will try to start listing starting from the offset,
+	// but it is not guaranteed it will resume at the offset, and may start at an earlier
+	// point.
+	//
+	// Offset should be specified as relative to the path, for example:
+	// In the hierarchy:
+	// /files/apple/alpha
+	// /files/apple/beta
+	// /files/apple/charlie
+	// If path is /files, and you want the listing to be (beta, ...], then offset should be apple/beta.
+	Walk(ctx context.Context, path string, f WalkFn, offset string) error
 }
 
 // FileWriter provides an abstraction for an opened writable file-like object in

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -659,8 +659,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, offset string) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, offset)
 }
 
 func (d *driver) swiftPath(path string) string {

--- a/registry/storage/driver/walk_test.go
+++ b/registry/storage/driver/walk_test.go
@@ -37,7 +37,7 @@ func TestWalkFileRemoved(t *testing.T) {
 	err := WalkFallback(context.Background(), d, "", func(fileInfo FileInfo) error {
 		infos = append(infos, fileInfo)
 		return nil
-	})
+	}, "")
 	if len(infos) != 1 || infos[0].Path() != "zoidberg" {
 		t.Errorf(fmt.Sprintf("unexpected path set during walk: %s", infos))
 	}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -272,7 +272,7 @@ func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingestor func(digest.
 		}
 
 		return nil
-	})
+	}, "")
 }
 
 func (lbs *linkedBlobStore) mount(ctx context.Context, sourceRepo reference.Named, dgst digest.Digest, sourceStat *distribution.Descriptor) (distribution.Descriptor, error) {

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -103,7 +103,7 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 
 		uploads[uuid] = ud
 		return nil
-	})
+	}, "")
 
 	if err != nil {
 		errors = pushError(errors, root, err)

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -152,7 +152,7 @@ func TestPurgeMissingStartedAt(t *testing.T) {
 			}
 		}
 		return nil
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("Unexpected error during Walk: %s ", err.Error())
 	}


### PR DESCRIPTION
When dealing with lots of repositories it can be beneficial to have a
mechanism to iterate through the data in an interative or reentrant manner.
This introduces the idea of "offset", which says start iteration at a certain
point (offset, END] to enable this incremental listing behaviour.

This only implements this optimization for the S3 driver.