### PR TITLE
fix: disable DisableHTMLEscape on logrus json logging

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -277,7 +277,8 @@ func configureLogging(ctx context.Context, config *configuration.Configuration) 
 	switch formatter {
 	case "json":
 		log.SetFormatter(&log.JSONFormatter{
-			TimestampFormat: time.RFC3339Nano,
+			TimestampFormat:   time.RFC3339Nano,
+			DisableHTMLEscape: true,
 		})
 	case "text":
 		log.SetFormatter(&log.TextFormatter{


### PR DESCRIPTION
Fixes #3363

Without this, we emit illegal json logs, the user-agent
ends up as:

```
"http.request.useragent": "docker/19.03.4 go/go1.12.10 git-commit/9013bf583a kernel/5.10.10-051010-generic os/linux arch/amd64 UpstreamClient(Docker-Client/19.03.4 \(linux\))"
```

which is not valid according to [spec](https://www.json.org/json-en.html)

specifically, string: "<any codepoint except " or \ or control>*"

Signed-off-by: Don Bowman <don@agilicus.com>