### PR TITLE
[cherry pick]close the io.ReadCloser from storage driver

### DIFF
--- a/registry/storage/io.go
+++ b/registry/storage/io.go
@@ -18,6 +18,7 @@ func getContent(ctx context.Context, driver driver.StorageDriver, p string) ([]b
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 
 	return readAllLimited(r, maxBlobGetSize)
 }


### PR DESCRIPTION
Backport PR #3309 to release/2.7

Signed-off-by: Wang Yan <wangyan@vmware.com>