### PR TITLE
docs/spec/manifest-v2-2.md: fix ARM variant

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -107,7 +107,7 @@ image manifest based on the Content-Type returned in the HTTP response.
         - **`variant`** *string*
 
             The optional variant field specifies a variant of the CPU, for
-            example `armv6l` to specify a particular CPU variant of the ARM CPU.
+            example `v6` to specify a particular CPU variant of the ARM CPU.
 
         - **`features`** *array*
 


### PR DESCRIPTION
The correct `vairant` string for ARM v6 is "v6", not "armv6l".

There is no known implementation that actually uses "armv6l".

See the discussion in https://github.com/opencontainers/image-spec/pull/817#discussion_r568107546

