### PR TITLE
Add docker image release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build release image and push to hub
+name: Release docker image
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Build release image and push to hub
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    name: Build and publish docker image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDTAGS: "include_oss include_gcs"
+      CGO_ENABLED: 1
+      GO111MODULE: "auto"
+      GOPATH: ${{ github.workspace }}
+      GOOS: linux
+      COMMIT_RANGE: ${{ github.event_name == 'pull_request' && format('{0}..{1}',github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('{0}..{1}', github.event.before, github.event.after) }}
+
+    steps:
+      - name: Get git tag
+        id: get_git_tag
+        run: echo ::set-output name=git_tag::${GITHUB_REF#refs/tags/}
+
+      - name: Verify git tag
+        env:
+          GIT_TAG: ${{ steps.get_git_tag.outputs.git_tag }}
+        # NOTE: this is a simple Regexp, following the current versioning scheme
+        # In ideal world we should use this monstrosity:
+        # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        run: |
+          [[ ${GIT_TAG} =~ ^v[0-9]+.[0-9]+.[0-9]+ ]]
+
+      - name: Check out source code
+        if: ${{ success() }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.get_git_tag.outputs.git_tag }}
+
+      - name: Set image tag
+        env:
+          GIT_TAG: ${{ steps.get_git_tag.outputs.git_tag }}
+        id: get_image_tag
+        run: echo ::set-output name=docker_tag::${GIT_TAG}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        if: ${{ success() }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: distribution/distribution:{{ steps.get_image_tag.outputs.docker_tag }}


### PR DESCRIPTION
The secrets used in this workflow have been manually added by me to GitHub secrets on this repo. They will be changed once we sort out Docker Hub accounts and tokens, but the current creds work fine for pushing images to Docker Hub.

The idea is when we tag a release the image is automatically built from the tag ref and pushed to Docker Hub.

Signed-off-by: Milos Gajdos <milosgajdos83@gmail.com>