### PR TITLE
OCI: verify digest and check blob presence when put manifest

### DIFF
--- a/registry/storage/ocimanifesthandler_test.go
+++ b/registry/storage/ocimanifesthandler_test.go
@@ -3,12 +3,14 @@ package storage
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -35,6 +37,15 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 		Digest:    "sha256:463435349086340864309863409683460843608348608934092322395278926a",
 		Size:      6323,
 		MediaType: v1.MediaTypeImageLayerNonDistributableGzip,
+	}
+
+	emptyLayer := distribution.Descriptor{
+		Digest: "",
+	}
+
+	emptyGzipLayer := distribution.Descriptor{
+		Digest:    "",
+		MediaType: v1.MediaTypeImageLayerGzip,
 	}
 
 	template := ocischema.Manifest{
@@ -107,6 +118,26 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 			[]string{"https://foo/bar"},
 			nil,
 		},
+		{
+			emptyLayer,
+			[]string{"https://foo/empty"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			emptyLayer,
+			[]string{},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			emptyGzipLayer,
+			[]string{"https://foo/empty"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			emptyGzipLayer,
+			[]string{},
+			digest.ErrDigestInvalidFormat,
+		},
 	}
 
 	for _, c := range cases {
@@ -134,5 +165,170 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 		if err != c.Err {
 			t.Errorf("%#v: expected %v, got %v", l, c.Err, err)
 		}
+	}
+}
+
+func TestVerifyOCIManifestBlobLayerAndConfig(t *testing.T) {
+	ctx := context.Background()
+	inmemoryDriver := inmemory.New()
+	registry := createRegistry(t, inmemoryDriver,
+		ManifestURLsAllowRegexp(regexp.MustCompile("^https?://foo")),
+		ManifestURLsDenyRegexp(regexp.MustCompile("^https?://foo/nope")))
+
+	repo := makeRepository(t, registry, strings.ToLower(t.Name()))
+	manifestService := makeManifestService(t, repo)
+
+	config, err := repo.Blobs(ctx).Put(ctx, v1.MediaTypeImageConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layer, err := repo.Blobs(ctx).Put(ctx, v1.MediaTypeImageLayerGzip, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := ocischema.Manifest{
+		Versioned: manifest.Versioned{
+			SchemaVersion: 2,
+			MediaType:     v1.MediaTypeImageManifest,
+		},
+	}
+
+	checkFn := func(m ocischema.Manifest, rerr error) {
+		dm, err := ocischema.FromStruct(m)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = manifestService.Put(ctx, dm)
+		if verr, ok := err.(distribution.ErrManifestVerification); ok {
+			// Extract the first error
+			if len(verr) == 2 {
+				if _, ok = verr[1].(distribution.ErrManifestBlobUnknown); ok {
+					err = verr[0]
+				}
+			} else if len(verr) == 1 {
+				err = verr[0]
+			}
+		}
+		if err != rerr {
+			t.Errorf("%#v: expected %v, got %v", m, rerr, err)
+		}
+	}
+
+	type testcase struct {
+		Desc distribution.Descriptor
+		URLs []string
+		Err  error
+	}
+
+	layercases := []testcase{
+		// empty media type
+		{
+			distribution.Descriptor{},
+			[]string{"http://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		// unknown media type, but blob is present
+		{
+			distribution.Descriptor{
+				Digest: layer.Digest,
+			},
+			nil,
+			nil,
+		},
+		{
+			distribution.Descriptor{
+				Digest: layer.Digest,
+			},
+			[]string{"http://foo/bar"},
+			nil,
+		},
+		// gzip layer, but invalid digest
+		{
+			distribution.Descriptor{
+				MediaType: v1.MediaTypeImageLayerGzip,
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: v1.MediaTypeImageLayerGzip,
+			},
+			[]string{"https://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: v1.MediaTypeImageLayerGzip,
+				Digest:    digest.Digest("invalid"),
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		// normal uploaded gzip layer
+		{
+			layer,
+			nil,
+			nil,
+		},
+		{
+			layer,
+			[]string{"https://foo/bar"},
+			nil,
+		},
+	}
+
+	for _, c := range layercases {
+		m := template
+		m.Config = config
+
+		l := c.Desc
+		l.URLs = c.URLs
+
+		m.Layers = []distribution.Descriptor{l}
+
+		checkFn(m, c.Err)
+	}
+
+	configcases := []testcase{
+		// valid config
+		{
+			config,
+			nil,
+			nil,
+		},
+		// invalid digest
+		{
+			distribution.Descriptor{
+				MediaType: v1.MediaTypeImageConfig,
+			},
+			[]string{"https://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: v1.MediaTypeImageConfig,
+				Digest:    digest.Digest("invalid"),
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+	}
+
+	for _, c := range configcases {
+		m := template
+		m.Config = c.Desc
+		m.Config.URLs = c.URLs
+
+		checkFn(m, c.Err)
 	}
 }

--- a/registry/storage/schema2manifesthandler_test.go
+++ b/registry/storage/schema2manifesthandler_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/distribution/distribution/v3"
@@ -9,6 +10,7 @@ import (
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
+	"github.com/opencontainers/go-digest"
 )
 
 func TestVerifyManifestForeignLayer(t *testing.T) {
@@ -34,6 +36,10 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 		Digest:    "sha256:463435349086340864309863409683460843608348608934092322395278926a",
 		Size:      6323,
 		MediaType: schema2.MediaTypeForeignLayer,
+	}
+
+	emptyLayer := distribution.Descriptor{
+		Digest: "",
 	}
 
 	template := schema2.Manifest{
@@ -107,6 +113,16 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 			[]string{"https://foo/bar"},
 			nil,
 		},
+		{
+			emptyLayer,
+			[]string{"https://foo/empty"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			emptyLayer,
+			[]string{},
+			digest.ErrDigestInvalidFormat,
+		},
 	}
 
 	for _, c := range cases {
@@ -132,5 +148,170 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 		if err != c.Err {
 			t.Errorf("%#v: expected %v, got %v", l, c.Err, err)
 		}
+	}
+}
+
+func TestVerifyManifestBlobLayerAndConfig(t *testing.T) {
+	ctx := context.Background()
+	inmemoryDriver := inmemory.New()
+	registry := createRegistry(t, inmemoryDriver,
+		ManifestURLsAllowRegexp(regexp.MustCompile("^https?://foo")),
+		ManifestURLsDenyRegexp(regexp.MustCompile("^https?://foo/nope")))
+
+	repo := makeRepository(t, registry, strings.ToLower(t.Name()))
+	manifestService := makeManifestService(t, repo)
+
+	config, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeImageConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layer, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeLayer, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := schema2.Manifest{
+		Versioned: manifest.Versioned{
+			SchemaVersion: 2,
+			MediaType:     schema2.MediaTypeManifest,
+		},
+	}
+
+	checkFn := func(m schema2.Manifest, rerr error) {
+		dm, err := schema2.FromStruct(m)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = manifestService.Put(ctx, dm)
+		if verr, ok := err.(distribution.ErrManifestVerification); ok {
+			// Extract the first error
+			if len(verr) == 2 {
+				if _, ok = verr[1].(distribution.ErrManifestBlobUnknown); ok {
+					err = verr[0]
+				}
+			} else if len(verr) == 1 {
+				err = verr[0]
+			}
+		}
+		if err != rerr {
+			t.Errorf("%#v: expected %v, got %v", m, rerr, err)
+		}
+	}
+
+	type testcase struct {
+		Desc distribution.Descriptor
+		URLs []string
+		Err  error
+	}
+
+	layercases := []testcase{
+		// empty media type
+		{
+			distribution.Descriptor{},
+			[]string{"http://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		// unknown media type, but blob is present
+		{
+			distribution.Descriptor{
+				Digest: layer.Digest,
+			},
+			nil,
+			nil,
+		},
+		{
+			distribution.Descriptor{
+				Digest: layer.Digest,
+			},
+			[]string{"http://foo/bar"},
+			nil,
+		},
+		// gzip layer, but invalid digest
+		{
+			distribution.Descriptor{
+				MediaType: schema2.MediaTypeLayer,
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: schema2.MediaTypeLayer,
+			},
+			[]string{"https://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: schema2.MediaTypeLayer,
+				Digest:    digest.Digest("invalid"),
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+		// normal uploaded gzip layer
+		{
+			layer,
+			nil,
+			nil,
+		},
+		{
+			layer,
+			[]string{"https://foo/bar"},
+			nil,
+		},
+	}
+
+	for _, c := range layercases {
+		m := template
+		m.Config = config
+
+		l := c.Desc
+		l.URLs = c.URLs
+
+		m.Layers = []distribution.Descriptor{l}
+
+		checkFn(m, c.Err)
+	}
+
+	configcases := []testcase{
+		// valid config
+		{
+			config,
+			nil,
+			nil,
+		},
+		// invalid digest
+		{
+			distribution.Descriptor{
+				MediaType: schema2.MediaTypeImageConfig,
+			},
+			[]string{"https://foo/bar"},
+			digest.ErrDigestInvalidFormat,
+		},
+		{
+			distribution.Descriptor{
+				MediaType: schema2.MediaTypeImageConfig,
+				Digest:    digest.Digest("invalid"),
+			},
+			nil,
+			digest.ErrDigestInvalidFormat,
+		},
+	}
+
+	for _, c := range configcases {
+		m := template
+		m.Config = c.Desc
+		m.Config.URLs = c.URLs
+
+		checkFn(m, c.Err)
 	}
 }


### PR DESCRIPTION

    According to OCI image spec, the descriptor's digest field is required.
    For the normal config/layer blobs, the valivation should check the
    presence of the blob when put manifest.

    REF: https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md

    Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>
    Signed-off-by: Wei Fu <fuweid89@gmail.com>

cc @dmcgowan @thaJeztah 