### PR TITLE
Update Manifest interface to distinguish between blob and manifeset references

### DIFF
--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -123,6 +123,16 @@ type ManifestList struct {
 // References returns the distribution descriptors for the referenced image
 // manifests.
 func (m ManifestList) References() []distribution.Descriptor {
+	return m.ManifestReferences()
+}
+
+// BlobReferences returns blob descriptors referenced by this manifest.
+func (sm ManifestList) BlobReferences() []distribution.Descriptor {
+	return nil
+}
+
+// ManifestReferences returns manifest descriptors referenced by this manifest.
+func (m ManifestList) ManifestReferences() []distribution.Descriptor {
 	dependencies := make([]distribution.Descriptor, len(m.Manifests))
 	for i := range m.Manifests {
 		dependencies[i] = m.Manifests[i].Descriptor

--- a/manifest/manifestlist/manifestlist_test.go
+++ b/manifest/manifestlist/manifestlist_test.go
@@ -105,9 +105,9 @@ func TestManifestList(t *testing.T) {
 		t.Fatalf("manifests are different after unmarshaling: %v != %v", unmarshalled, *deserialized)
 	}
 
-	references := deserialized.References()
+	references := deserialized.ManifestReferences()
 	if len(references) != 2 {
-		t.Fatalf("unexpected number of references: %d", len(references))
+		t.Fatalf("unexpected number of manifest references: %d", len(references))
 	}
 	for i := range references {
 		platform := manifestDescriptors[i].Platform
@@ -119,12 +119,17 @@ func TestManifestList(t *testing.T) {
 			Variant:      platform.Variant,
 		}
 		if !reflect.DeepEqual(references[i].Platform, expectedPlatform) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+			t.Fatalf("unexpected value %d returned by ManifestReferences: %v", i, references[i])
 		}
 		references[i].Platform = nil
 		if !reflect.DeepEqual(references[i], manifestDescriptors[i].Descriptor) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+			t.Fatalf("unexpected value %d returned by ManifestReferences: %v", i, references[i])
 		}
+	}
+
+	references = deserialized.BlobReferences()
+	if len(references) != 0 {
+		t.Fatal("BlobReferences() did not return empty array")
 	}
 }
 
@@ -254,9 +259,9 @@ func TestOCIImageIndex(t *testing.T) {
 		t.Fatalf("manifests are different after unmarshaling: %v != %v", unmarshalled, *deserialized)
 	}
 
-	references := deserialized.References()
+	references := deserialized.ManifestReferences()
 	if len(references) != 3 {
-		t.Fatalf("unexpected number of references: %d", len(references))
+		t.Fatalf("unexpected number of manifest references: %d", len(references))
 	}
 	for i := range references {
 		platform := manifestDescriptors[i].Platform
@@ -268,12 +273,17 @@ func TestOCIImageIndex(t *testing.T) {
 			Variant:      platform.Variant,
 		}
 		if !reflect.DeepEqual(references[i].Platform, expectedPlatform) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+			t.Fatalf("unexpected value %d returned by ManifestReferences: %v", i, references[i])
 		}
 		references[i].Platform = nil
 		if !reflect.DeepEqual(references[i], manifestDescriptors[i].Descriptor) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
+			t.Fatalf("unexpected value %d returned by ManifestReferences: %v", i, references[i])
 		}
+	}
+
+	references = deserialized.BlobReferences()
+	if len(references) != 0 {
+		t.Fatal("BlobReferences() did not return empty array")
 	}
 }
 

--- a/manifest/ocischema/builder.go
+++ b/manifest/ocischema/builder.go
@@ -97,11 +97,31 @@ func (mb *Builder) Build(ctx context.Context) (distribution.Manifest, error) {
 
 // AppendReference adds a reference to the current ManifestBuilder.
 func (mb *Builder) AppendReference(d distribution.Describable) error {
+	return mb.AppendBlobReference(d)
+}
+
+// AppendBlobReference adds a blob reference to the current ManifestBuilder
+func (mb *Builder) AppendBlobReference(d distribution.Describable) error {
 	mb.layers = append(mb.layers, d.Descriptor())
 	return nil
 }
 
+// AppendManifestReference adds a reference to the current ManifestBuilder
+func (mb *Builder) AppendManifestReference(d distribution.Describable) error {
+	return errors.New("cannot add manifest reference to ocischema manifest")
+}
+
 // References returns the current references added to this builder.
 func (mb *Builder) References() []distribution.Descriptor {
+	return mb.BlobReferences()
+}
+
+// BlobReferences returns the current blob references added to this builder
+func (mb *Builder) BlobReferences() []distribution.Descriptor {
 	return mb.layers
+}
+
+// ManifestReferences returns the current manifest references added to this builder
+func (mb *Builder) ManifestReferences() []distribution.Descriptor {
+	return nil
 }

--- a/manifest/ocischema/builder_test.go
+++ b/manifest/ocischema/builder_test.go
@@ -129,8 +129,8 @@ func TestBuilder(t *testing.T) {
 	builder := NewManifestBuilder(bs, imgJSON, annotations)
 
 	for _, d := range descriptors {
-		if err := builder.AppendReference(d); err != nil {
-			t.Fatalf("AppendReference returned error: %v", err)
+		if err := builder.AppendBlobReference(d); err != nil {
+			t.Fatalf("AppendBlobReference returned error: %v", err)
 		}
 	}
 
@@ -165,9 +165,14 @@ func TestBuilder(t *testing.T) {
 		t.Fatalf("unexpected size in target: %d", target.Size)
 	}
 
-	references := manifest.References()
+	references := manifest.BlobReferences()
 	expected := append([]distribution.Descriptor{manifest.Target()}, descriptors...)
 	if !reflect.DeepEqual(references, expected) {
-		t.Fatal("References() does not match the descriptors added")
+		t.Fatal("BlobReferences() does not match the descriptors added")
+	}
+
+	references = manifest.ManifestReferences()
+	if len(references) != 0 {
+		t.Fatal("ManifestReferences() did not return empty array")
 	}
 }

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -54,10 +54,20 @@ type Manifest struct {
 
 // References returns the descriptors of this manifests references.
 func (m Manifest) References() []distribution.Descriptor {
+	return m.BlobReferences()
+}
+
+// BlobReferences returns blob descriptors referenced by this manifest.
+func (m Manifest) BlobReferences() []distribution.Descriptor {
 	references := make([]distribution.Descriptor, 0, 1+len(m.Layers))
 	references = append(references, m.Config)
 	references = append(references, m.Layers...)
 	return references
+}
+
+// ManifestReferences returns manifest descriptors referenced by this manifest.
+func (m Manifest) ManifestReferences() []distribution.Descriptor {
+	return nil
 }
 
 // Target returns the target of this manifest.

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -116,13 +116,13 @@ func TestManifest(t *testing.T) {
 		t.Fatalf("unexpected annotation in target: %s", target.Annotations["apple"])
 	}
 
-	references := deserialized.References()
+	references := deserialized.BlobReferences()
 	if len(references) != 2 {
-		t.Fatalf("unexpected number of references: %d", len(references))
+		t.Fatalf("unexpected number of blob references: %d", len(references))
 	}
 
 	if !reflect.DeepEqual(references[0], target) {
-		t.Fatalf("first reference should be target: %v != %v", references[0], target)
+		t.Fatalf("first blob reference should be target: %v != %v", references[0], target)
 	}
 
 	// Test the second reference
@@ -137,6 +137,11 @@ func TestManifest(t *testing.T) {
 	}
 	if references[1].Annotations["lettuce"] != "wrap" {
 		t.Fatalf("unexpected annotation in reference: %s", references[1].Annotations["lettuce"])
+	}
+
+	references = deserialized.ManifestReferences()
+	if len(references) != 0 {
+		t.Fatal("ManifetReferences() did not return empty array")
 	}
 }
 

--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -210,8 +210,8 @@ func TestConfigBuilder(t *testing.T) {
 	builder := NewConfigManifestBuilder(bs, pk, ref, []byte(imgJSON))
 
 	for _, d := range descriptors {
-		if err := builder.AppendReference(d); err != nil {
-			t.Fatalf("AppendReference returned error: %v", err)
+		if err := builder.AppendBlobReference(d); err != nil {
+			t.Fatalf("AppendBlobReference returned error: %v", err)
 		}
 	}
 

--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -140,6 +140,11 @@ func (sm *SignedManifest) UnmarshalJSON(b []byte) error {
 
 // References returns the descriptors of this manifests references
 func (sm SignedManifest) References() []distribution.Descriptor {
+	return sm.BlobReferences()
+}
+
+// BlobReferences returns blob descriptors referenced by this manifest.
+func (sm SignedManifest) BlobReferences() []distribution.Descriptor {
 	dependencies := make([]distribution.Descriptor, len(sm.FSLayers))
 	for i, fsLayer := range sm.FSLayers {
 		dependencies[i] = distribution.Descriptor{
@@ -150,6 +155,11 @@ func (sm SignedManifest) References() []distribution.Descriptor {
 
 	return dependencies
 
+}
+
+// ManifestReferences returns manifest descriptors referenced by this manifest.
+func (sm SignedManifest) ManifestReferences() []distribution.Descriptor {
+	return nil
 }
 
 // MarshalJSON returns the contents of raw. If Raw is nil, marshals the inner

--- a/manifest/schema1/reference_builder.go
+++ b/manifest/schema1/reference_builder.go
@@ -56,6 +56,11 @@ func (mb *referenceManifestBuilder) Build(ctx context.Context) (distribution.Man
 
 // AppendReference adds a reference to the current ManifestBuilder
 func (mb *referenceManifestBuilder) AppendReference(d distribution.Describable) error {
+	return mb.AppendBlobReference(d)
+}
+
+// AppendBlobReference adds a blob reference to the current ManifestBuilder
+func (mb *referenceManifestBuilder) AppendBlobReference(d distribution.Describable) error {
 	r, ok := d.(Reference)
 	if !ok {
 		return fmt.Errorf("unable to add non-reference type to v1 builder")
@@ -68,8 +73,18 @@ func (mb *referenceManifestBuilder) AppendReference(d distribution.Describable) 
 
 }
 
+// AppendManifestReference adds a reference to the current ManifestBuilder
+func (mb *referenceManifestBuilder) AppendManifestReference(d distribution.Describable) error {
+	return errors.New("cannot add manifest reference to schema1 manifest")
+}
+
 // References returns the current references added to this builder
 func (mb *referenceManifestBuilder) References() []distribution.Descriptor {
+	return mb.BlobReferences()
+}
+
+// BlobReferences returns the current blob references added to this builder
+func (mb *referenceManifestBuilder) BlobReferences() []distribution.Descriptor {
 	refs := make([]distribution.Descriptor, len(mb.Manifest.FSLayers))
 	for i := range mb.Manifest.FSLayers {
 		layerDigest := mb.Manifest.FSLayers[i].BlobSum
@@ -78,6 +93,11 @@ func (mb *referenceManifestBuilder) References() []distribution.Descriptor {
 		refs[i] = ref.Descriptor()
 	}
 	return refs
+}
+
+// ManifestReferences returns the current manifest references added to this builder
+func (mb *referenceManifestBuilder) ManifestReferences() []distribution.Descriptor {
+	return nil
 }
 
 // Reference describes a manifest v2, schema version 1 dependency.

--- a/manifest/schema1/reference_builder_test.go
+++ b/manifest/schema1/reference_builder_test.go
@@ -70,24 +70,29 @@ func TestReferenceBuilder(t *testing.T) {
 		t.Fatal("Expected error building zero length manifest")
 	}
 
-	err = b.AppendReference(r1)
+	err = b.AppendBlobReference(r1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = b.AppendReference(r2)
+	err = b.AppendBlobReference(r2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	refs := b.References()
+	refs := b.BlobReferences()
 	if len(refs) != 2 {
-		t.Fatalf("Unexpected reference count : %d != %d", 2, len(refs))
+		t.Fatalf("Unexpected blob reference count : %d != %d", 2, len(refs))
 	}
 
 	// Ensure ordering
 	if refs[0].Digest != r2.Digest {
 		t.Fatalf("Unexpected reference : %v", refs[0])
+	}
+
+	refs = b.ManifestReferences()
+	if len(refs) != 0 {
+		t.Fatalf("Manifest reference array not empty")
 	}
 
 	m, err := b.Build(context.Background())

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -169,7 +169,7 @@ func TestBuilder(t *testing.T) {
 	builder := NewManifestBuilder(bs, MediaTypeImageConfig, imgJSON)
 
 	for _, d := range descriptors {
-		if err := builder.AppendReference(d); err != nil {
+		if err := builder.AppendBlobReference(d); err != nil {
 			t.Fatalf("AppendReference returned error: %v", err)
 		}
 	}
@@ -202,9 +202,14 @@ func TestBuilder(t *testing.T) {
 		t.Fatalf("unexpected size in target: %d", target.Size)
 	}
 
-	references := manifest.References()
+	references := manifest.BlobReferences()
 	expected := append([]distribution.Descriptor{manifest.Target()}, descriptors...)
 	if !reflect.DeepEqual(references, expected) {
-		t.Fatal("References() does not match the descriptors added")
+		t.Fatal("BlobReferences() does not match the descriptors added")
+	}
+
+	references = manifest.ManifestReferences()
+	if len(references) != 0 {
+		t.Fatal("ManifetReferences() should return an empty array")
 	}
 }

--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -73,10 +73,20 @@ type Manifest struct {
 
 // References returns the descriptors of this manifests references.
 func (m Manifest) References() []distribution.Descriptor {
+	return m.BlobReferences()
+}
+
+// BlobReferences returns blob descriptors referenced by this manifest.
+func (m Manifest) BlobReferences() []distribution.Descriptor {
 	references := make([]distribution.Descriptor, 0, 1+len(m.Layers))
 	references = append(references, m.Config)
 	references = append(references, m.Layers...)
 	return references
+}
+
+// ManifestReferences returns manifest descriptors referenced by this manifest.
+func (m Manifest) ManifestReferences() []distribution.Descriptor {
+	return nil
 }
 
 // Target returns the target of this manifest.

--- a/manifest/schema2/manifest_test.go
+++ b/manifest/schema2/manifest_test.go
@@ -97,13 +97,13 @@ func TestManifest(t *testing.T) {
 		t.Fatalf("unexpected size in target: %d", target.Size)
 	}
 
-	references := deserialized.References()
+	references := deserialized.BlobReferences()
 	if len(references) != 2 {
-		t.Fatalf("unexpected number of references: %d", len(references))
+		t.Fatalf("unexpected number of blob references: %d", len(references))
 	}
 
 	if !reflect.DeepEqual(references[0], target) {
-		t.Fatalf("first reference should be target: %v != %v", references[0], target)
+		t.Fatalf("first blob reference should be target: %v != %v", references[0], target)
 	}
 
 	// Test the second reference
@@ -115,6 +115,11 @@ func TestManifest(t *testing.T) {
 	}
 	if references[1].Size != 153263 {
 		t.Fatalf("unexpected size in reference: %d", references[0].Size)
+	}
+
+	references = deserialized.ManifestReferences()
+	if len(references) != 0 {
+		t.Fatalf("manifest references should be empty")
 	}
 }
 


### PR DESCRIPTION
Updates the Manifest and ManifestBuilder to distinguish between blob and manifest references. Uses this new interface to fix the garbage collection logic to do a proper transitive closure on references so that untagged sub manifests referenced by (tagged) manifest lists do not get removed even if remove-untagged is given to the garbage collector.

PR implementing the proposal in https://github.com/distribution/distribution/issues/3401

Resolves https://github.com/distribution/distribution/issues/3178