### PR TITLE
add application-credential auth support for swift storage driver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,9 @@ storage:
   swift:
     username: username
     password: password
+    applicationcredentialid: myid
+    applicationcredentialname: mycred
+    applicationcredentialsecret: mysecret
     authurl: https://storage.myprovider.com/auth/v1.0 or https://storage.myprovider.com/v2.0 or https://storage.myprovider.com/v3/auth
     tenant: tenantname
     tenantid: tenantid

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -59,27 +59,30 @@ var readAfterWriteWait = 200 * time.Millisecond
 
 // Parameters A struct that encapsulates all of the driver parameters after all values have been set
 type Parameters struct {
-	Username            string
-	Password            string
-	AuthURL             string
-	Tenant              string
-	TenantID            string
-	Domain              string
-	DomainID            string
-	TenantDomain        string
-	TenantDomainID      string
-	TrustID             string
-	Region              string
-	AuthVersion         int
-	Container           string
-	Prefix              string
-	EndpointType        string
-	InsecureSkipVerify  bool
-	ChunkSize           int
-	SecretKey           string
-	AccessKey           string
-	TempURLContainerKey bool
-	TempURLMethods      []string
+	Username                    string
+	Password                    string
+	ApplicationCredentialID     string
+	ApplicationCredentialName   string
+	ApplicationCredentialSecret string
+	AuthURL                     string
+	Tenant                      string
+	TenantID                    string
+	Domain                      string
+	DomainID                    string
+	TenantDomain                string
+	TenantDomainID              string
+	TrustID                     string
+	Region                      string
+	AuthVersion                 int
+	Container                   string
+	Prefix                      string
+	EndpointType                string
+	InsecureSkipVerify          bool
+	ChunkSize                   int
+	SecretKey                   string
+	AccessKey                   string
+	TempURLContainerKey         bool
+	TempURLMethods              []string
 }
 
 // swiftInfo maps the JSON structure returned by Swift /info endpoint
@@ -159,11 +162,15 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	}
 
 	if params.Username == "" {
-		return nil, fmt.Errorf("no username parameter provided")
+		if params.ApplicationCredentialID == "" && params.ApplicationCredentialName == "" {
+			return nil, fmt.Errorf("no username or application-credential provided")
+		}
 	}
 
 	if params.Password == "" {
-		return nil, fmt.Errorf("no password parameter provided")
+		if params.ApplicationCredentialID == "" {
+			return nil, fmt.Errorf("no password or application-credential-secret parameter provided")
+		}
 	}
 
 	if params.AuthURL == "" {
@@ -190,23 +197,26 @@ func New(params Parameters) (*Driver, error) {
 	}
 
 	ct := &swift.Connection{
-		UserName:       params.Username,
-		ApiKey:         params.Password,
-		AuthUrl:        params.AuthURL,
-		Region:         params.Region,
-		AuthVersion:    params.AuthVersion,
-		UserAgent:      "distribution/" + version.Version,
-		Tenant:         params.Tenant,
-		TenantId:       params.TenantID,
-		Domain:         params.Domain,
-		DomainId:       params.DomainID,
-		TenantDomain:   params.TenantDomain,
-		TenantDomainId: params.TenantDomainID,
-		TrustId:        params.TrustID,
-		EndpointType:   swift.EndpointType(params.EndpointType),
-		Transport:      transport,
-		ConnectTimeout: 60 * time.Second,
-		Timeout:        15 * 60 * time.Second,
+		UserName:                    params.Username,
+		ApiKey:                      params.Password,
+		ApplicationCredentialId:     params.ApplicationCredentialID,
+		ApplicationCredentialName:   params.ApplicationCredentialName,
+		ApplicationCredentialSecret: params.ApplicationCredentialSecret,
+		AuthUrl:                     params.AuthURL,
+		Region:                      params.Region,
+		AuthVersion:                 params.AuthVersion,
+		UserAgent:                   "distribution/" + version.Version,
+		Tenant:                      params.Tenant,
+		TenantId:                    params.TenantID,
+		Domain:                      params.Domain,
+		DomainId:                    params.DomainID,
+		TenantDomain:                params.TenantDomain,
+		TenantDomainId:              params.TenantDomainID,
+		TrustId:                     params.TrustID,
+		EndpointType:                swift.EndpointType(params.EndpointType),
+		Transport:                   transport,
+		ConnectTimeout:              60 * time.Second,
+		Timeout:                     15 * 60 * time.Second,
 	}
 	err := ct.Authenticate()
 	if err != nil {

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -23,25 +23,28 @@ var swiftDriverConstructor func(prefix string) (*Driver, error)
 
 func init() {
 	var (
-		username              = os.Getenv("SWIFT_USERNAME")
-		password              = os.Getenv("SWIFT_PASSWORD")
-		authURL               = os.Getenv("SWIFT_AUTH_URL")
-		tenant                = os.Getenv("SWIFT_TENANT_NAME")
-		tenantID              = os.Getenv("SWIFT_TENANT_ID")
-		domain                = os.Getenv("SWIFT_DOMAIN_NAME")
-		domainID              = os.Getenv("SWIFT_DOMAIN_ID")
-		tenantDomain          = os.Getenv("SWIFT_DOMAIN_NAME")
-		tenantDomainID        = os.Getenv("SWIFT_DOMAIN_ID")
-		trustID               = os.Getenv("SWIFT_TRUST_ID")
-		container             = os.Getenv("SWIFT_CONTAINER_NAME")
-		region                = os.Getenv("SWIFT_REGION_NAME")
-		AuthVersion, _        = strconv.Atoi(os.Getenv("SWIFT_AUTH_VERSION"))
-		endpointType          = os.Getenv("SWIFT_ENDPOINT_TYPE")
-		insecureSkipVerify, _ = strconv.ParseBool(os.Getenv("SWIFT_INSECURESKIPVERIFY"))
-		secretKey             = os.Getenv("SWIFT_SECRET_KEY")
-		accessKey             = os.Getenv("SWIFT_ACCESS_KEY")
-		containerKey, _       = strconv.ParseBool(os.Getenv("SWIFT_TEMPURL_CONTAINERKEY"))
-		tempURLMethods        = strings.Split(os.Getenv("SWIFT_TEMPURL_METHODS"), ",")
+		username                    = os.Getenv("SWIFT_USERNAME")
+		password                    = os.Getenv("SWIFT_PASSWORD")
+		applicationCredentialID     = os.Getenv("SWIFT_APPLICATIONCREDENTIALID")
+		applicationCredentialName   = os.Getenv("SWIFT_APPLICATIONCREDENTIALNAME")
+		applicationCredentialSecret = os.Getenv("SWIFT_APPLICATIONCREDENTIALSECRET")
+		authURL                     = os.Getenv("SWIFT_AUTH_URL")
+		tenant                      = os.Getenv("SWIFT_TENANT_NAME")
+		tenantID                    = os.Getenv("SWIFT_TENANT_ID")
+		domain                      = os.Getenv("SWIFT_DOMAIN_NAME")
+		domainID                    = os.Getenv("SWIFT_DOMAIN_ID")
+		tenantDomain                = os.Getenv("SWIFT_DOMAIN_NAME")
+		tenantDomainID              = os.Getenv("SWIFT_DOMAIN_ID")
+		trustID                     = os.Getenv("SWIFT_TRUST_ID")
+		container                   = os.Getenv("SWIFT_CONTAINER_NAME")
+		region                      = os.Getenv("SWIFT_REGION_NAME")
+		AuthVersion, _              = strconv.Atoi(os.Getenv("SWIFT_AUTH_VERSION"))
+		endpointType                = os.Getenv("SWIFT_ENDPOINT_TYPE")
+		insecureSkipVerify, _       = strconv.ParseBool(os.Getenv("SWIFT_INSECURESKIPVERIFY"))
+		secretKey                   = os.Getenv("SWIFT_SECRET_KEY")
+		accessKey                   = os.Getenv("SWIFT_ACCESS_KEY")
+		containerKey, _             = strconv.ParseBool(os.Getenv("SWIFT_TEMPURL_CONTAINERKEY"))
+		tempURLMethods              = strings.Split(os.Getenv("SWIFT_TEMPURL_METHODS"), ",")
 
 		swiftServer *swifttest.SwiftServer
 		err         error
@@ -67,6 +70,9 @@ func init() {
 		parameters := Parameters{
 			username,
 			password,
+			applicationCredentialID,
+			applicationCredentialName,
+			applicationCredentialSecret,
 			authURL,
 			tenant,
 			tenantID,


### PR DESCRIPTION
This add the ability to authenticate the Swift storage driver using keystone application credentials (by id/name).