### PR TITLE
updatefrequency should not be saved into duration

### DIFF
--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -127,7 +127,7 @@ func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, o
 			if err != nil {
 				return nil, fmt.Errorf("invalid updatefrequency: %s", err)
 			}
-			duration = updateFreq
+			updateFrequency = updateFreq
 		}
 	}
 


### PR DESCRIPTION
When updatefrequency is set and is a string, its value should be saved into updateFrequency, and it shouldn't override duration.