### PR TITLE
export anchored tag and digest regular expression

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -269,7 +269,7 @@ func WithName(name string) (Named, error) {
 // WithTag combines the name from "name" and the tag from "tag" to form a
 // reference incorporating both the name and the tag.
 func WithTag(name Named, tag string) (NamedTagged, error) {
-	if !anchoredTagRegexp.MatchString(tag) {
+	if !AnchoredTagRegexp.MatchString(tag) {
 		return nil, ErrTagInvalidFormat
 	}
 	var repo repository
@@ -295,7 +295,7 @@ func WithTag(name Named, tag string) (NamedTagged, error) {
 // WithDigest combines the name from "name" and the digest from "digest" to form
 // a reference incorporating both the name and the digest.
 func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
-	if !anchoredDigestRegexp.MatchString(digest.String()) {
+	if !AnchoredDigestRegexp.MatchString(digest.String()) {
 		return nil, ErrDigestInvalidFormat
 	}
 	var repo repository

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -40,16 +40,16 @@ var (
 	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
 	TagRegexp = match(`[\w][\w.-]{0,127}`)
 
-	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// AnchoredTagRegexp matches valid tag names, anchored at the start and
 	// end of the matched string.
-	anchoredTagRegexp = anchored(TagRegexp)
+	AnchoredTagRegexp = anchored(TagRegexp)
 
 	// DigestRegexp matches valid digests.
 	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
 
-	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// AnchoredDigestRegexp matches valid digests, anchored at the start and
 	// end of the matched string.
-	anchoredDigestRegexp = anchored(DigestRegexp)
+	AnchoredDigestRegexp = anchored(DigestRegexp)
 
 	// NameRegexp is the format for the name component of references. The
 	// regexp has capturing groups for the domain and name part omitting


### PR DESCRIPTION
Exported two regular expressions, `anchoredTagRegexp` and `anchoredDigestRegexp`.

Sometimes people want to validate if a string is a tag or digest, then they can refer to this directly.