### PR TITLE
add documentation how to access pull-through proxy stats

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -913,10 +913,16 @@ access to the debug endpoint is locked down in a production environment.
 The `debug` section takes a single required `addr` parameter, which specifies
 the `HOST:PORT` on which the debug server should accept connections.
 
+If the registry is configured as a pull-through cache, the `debug` server can be used
+to access proxy statistics. These statistics are exposed at `/debug/vars` in JSON format.
+
 ## `prometheus`
 
 The `prometheus` option defines whether the prometheus metrics is enable, as well
 as the path to access the metrics.
+
+>**NONE**: The prometheus metrics do **not** cover pull-through cache statistics.
+> Proxy statistics are exposed via `expvar` only.
 
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -921,7 +921,7 @@ to access proxy statistics. These statistics are exposed at `/debug/vars` in JSO
 The `prometheus` option defines whether the prometheus metrics is enable, as well
 as the path to access the metrics.
 
->**NONE**: The prometheus metrics do **not** cover pull-through cache statistics.
+>**NOTE**: The prometheus metrics do **not** cover pull-through cache statistics.
 > Proxy statistics are exposed via `expvar` only.
 
 | Parameter | Required | Description                                           |


### PR DESCRIPTION
Adds minimal documentation how to access pull-through cache stats exposed by `expvar` as discussed in https://github.com/distribution/distribution/issues/3407