### PR TITLE
fix the /v2/_catalog n parameter description

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -5450,7 +5450,7 @@ The following parameters should be specified on the request:
 
 |Name|Kind|Description|
 |----|----|-----------|
-|`n`|query|Limit the number of entries in each response. It not present, all entries will be returned.|
+|`n`|query|Limit the number of entries in each response. It not present, 100 entries will be returned.|
 |`last`|query|Result set will include values lexically after last.|
 
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -99,7 +99,7 @@ var (
 		{
 			Name:        "n",
 			Type:        "integer",
-			Description: "Limit the number of entries in each response. It not present, all entries will be returned.",
+			Description: "Limit the number of entries in each response. It not present, 100 entries will be returned.",
 			Format:      "<integer>",
 			Required:    false,
 		},


### PR DESCRIPTION
If `n` is not present only 100 entries returned