### PR TITLE
Always allow swift tempurlcontainerkey and tempurlmethods overrides

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -79,7 +79,7 @@ type Parameters struct {
 	ChunkSize           int
 	SecretKey           string
 	AccessKey           string
-	TempURLContainerKey bool
+	TempURLContainerKey *bool
 	TempURLMethods      []string
 }
 
@@ -243,8 +243,19 @@ func New(params Parameters) (*Driver, error) {
 			}
 		}
 	} else {
-		d.TempURLContainerKey = params.TempURLContainerKey
 		d.TempURLMethods = params.TempURLMethods
+	}
+
+	// always accept the user-provided tempurlmethods option
+	if params.TempURLMethods != nil {
+		d.TempURLMethods = params.TempURLMethods
+	}
+
+	// always accept the user-provided tempurlcontainerkey option
+	if params.TempURLContainerKey != nil {
+		d.TempURLContainerKey = *params.TempURLContainerKey
+	} else {
+		d.TempURLContainerKey = false
 	}
 
 	if len(d.TempURLMethods) > 0 {

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -104,7 +104,7 @@ func init() {
 			defaultChunkSize,
 			secretKey,
 			accessKey,
-			containerKey,
+			&containerKey,
 			tempURLMethods,
 		}
 


### PR DESCRIPTION
This allows for user-provided tempurlcontainerkey and tempurlmethods to always take precedence over the swift API's `/info` endpoint. This also preserves the original behavior of falling back (to `false` and `nil` respectively) if they are unspecified _and_ the `/info` endpoint fails.
 
Fixes #2653