### PR TITLE
Modify Error.Error() to add Detail field from HTTP response

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -114,7 +114,14 @@ func (e Error) ErrorCode() ErrorCode {
 
 // Error returns a human readable representation of the error.
 func (e Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code.Error(), e.Message)
+	var retstr string
+	retstr = fmt.Sprintf("%s: %s", e.Code.Error(), e.Message)
+	if e.Detail != nil {
+		if m, ok := e.Detail.(map[string]interface{}); ok {
+			retstr += fmt.Sprintf(": %s", m["message"])
+		}
+	}
+	return retstr
 }
 
 // WithDetail will return a new Error, based on the current one, but with


### PR DESCRIPTION
If present, 'detail' in the JSON response contains what may be
critical information for the user to resolve the problem.
See https://github.com/containers/image/issues/1234 for the
details in the context of podman.

Signed-off-by: Dan Mick <dmick@redhat.com>