### PR TITLE
Make GH workflows job names unique

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  run:
+  run-conformance-test:
     runs-on: ubuntu-latest
     steps:
       - name: set up docker

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  run:
+  run-e2e-test:
     runs-on: ubuntu-latest
     steps:
       - name: set up docker

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,7 +5,7 @@ on:
   - push
 
 jobs:
-  build:
+  scan-license:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Make workflow jobs unique so we can manage which ones are required to pass the build.

Signed-off-by: Milos Gajdos <milosgajdos83@gmail.com>