### PR TITLE
Fuzzing: Add 3 fuzzers

### DIFF
--- a/configuration/fuzz.go
+++ b/configuration/fuzz.go
@@ -1,0 +1,16 @@
+// +build gofuzz
+
+package configuration
+
+import (
+	"bytes"
+)
+
+// ParserFuzzer implements a fuzzer that targets Parser()
+// Export before building
+// nolint:deadcode
+func parserFuzzer(data []byte) int {
+	rd := bytes.NewReader(data)
+	_, _ = Parse(rd)
+	return 1
+}

--- a/reference/fuzz.go
+++ b/reference/fuzz.go
@@ -1,0 +1,12 @@
+// +build gofuzz
+
+package reference
+
+// fuzzParseNormalizedNamed implements a fuzzer
+// that targets ParseNormalizedNamed
+// Export before building the fuzzer.
+// nolint:deadcode
+func fuzzParseNormalizedNamed(data []byte) int {
+	_, _ = ParseNormalizedNamed(string(data))
+	return 1
+}

--- a/registry/api/v2/fuzz.go
+++ b/registry/api/v2/fuzz.go
@@ -1,0 +1,12 @@
+// +build gofuzz
+
+package v2
+
+// FuzzParseForwardedHeader implements a fuzzer
+// that targets parseForwardedHeader
+// Export before building
+// nolint:deadcode
+func fuzzParseForwardedHeader(data []byte) int {
+	_, _, _ = parseForwardedHeader(string(data))
+	return 1
+}

--- a/script/oss_fuzz_build.sh
+++ b/script/oss_fuzz_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+sed 's/parserFuzzer/ParserFuzzer/g' -i ./configuration/fuzz.go
+sed 's/fuzzParseNormalizedNamed/FuzzParseNormalizedNamed/g' -i ./reference/fuzz.go
+sed 's/fuzzParseForwardedHeader/FuzzParseForwardedHeader/g' -i ./registry/api/v2/fuzz.go
+
+compile_go_fuzzer github.com/distribution/distribution/v3/configuration ParserFuzzer parser_fuzzer
+compile_go_fuzzer github.com/distribution/distribution/v3/reference FuzzParseNormalizedNamed fuzz_parsed_normalized_named
+compile_go_fuzzer github.com/distribution/distribution/v3/registry/api/v2 FuzzParseForwardedHeader fuzz_parse_forwarded_header


### PR DESCRIPTION
This PR adds 3 fuzzers for Distribution and a build script to run the fuzzers continuously through OSS-fuzz.

A PR has also been set up on the OSS-fuzz side to integrate Distribution: https://github.com/google/oss-fuzz/pull/6014. Two of the fuzzers that were committed on the OSS-fuzz side are moved upstream in this PR and a third fuzzer is added.

Once this PR gets merged, I will amend the changes on OSS-fuzz to invoke the build script in this PR.

For those unfamiliar with fuzzing and/or OSS-fuzz: Fuzzing (or fuzz testing) is a way of testing software whereby pseudo-random data is passed to a target application with the goal of finding bugs and vulnerabilities. It has been useful in finding bugs, including security-critical bugs, in many open source Go projects to date. Some can be found here, https://github.com/dvyukov/go-fuzz#trophies and others include [this CVE](https://groups.google.com/g/kubernetes-announce/c/ALL9s73E5ck/m/4yHe8J-PBAAJ) in Kubernetes and [this CVE](https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM/m/fLguyiM2CAAJ) in the Go standard library found by fuzzing Go-ethereum.

OSS-fuzz is a free service offered by Google into which critical open source projects can integrate and have their fuzzers run continuously. If any bugs are found, maintainers will get notified with an email containing a link to a detailed bug reports.
The fuzzers in this PR are all implemented by way of [go-fuzz](https://github.com/dvyukov/go-fuzz) which is the Golang engine supported by OSS-fuzz.
To complete the OSS-fuzz PR, at least one maintainers email address is needed for bug reports.

Other projects integrated into OSS-fuzz include Kubernetes, runC and containerd.