### PR TITLE
[release/2.7] update to go1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.*
+        go-version: 1.16.*
 
     - name: Dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1.11-alpine AS build
+FROM golang:1.16-alpine AS build
 
+ENV GO111MODULE=auto
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV BUILDTAGS include_oss include_gcs
 


### PR DESCRIPTION
relates to https://github.com/distribution/distribution/pull/3466, as the updated github.com/golang-jwt/jwt v3.2.2 requires to 1.15 or 1.16