### PR TITLE
Update to go 1.16, and run CI on 1.15.x and 1.16.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.15.x", "1.16.x"]
+        platform: ["ubuntu-latest"]
+    runs-on: ${{ matrix.platform }}
     env:
       DOCKER_BUILDTAGS: "include_oss include_gcs"
       CGO_ENABLED: 1
@@ -30,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.*
+        go-version: ${{ matrix.go-version }}
 
     - name: Dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-ARG GO_VERSION=1.15
+ARG GO_VERSION=1.16
 
-FROM golang:${GO_VERSION}-alpine3.12 AS build
+FROM golang:${GO_VERSION}-alpine3.14 AS build
 
+ENV GO111MODULE=auto
 ENV DISTRIBUTION_DIR /go/src/github.com/distribution/distribution
 ENV BUILDTAGS include_oss include_gcs
 
@@ -18,7 +19,7 @@ WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
 
-FROM alpine:3.12
+FROM alpine:3.14
 
 RUN set -ex \
     && apk add --no-cache ca-certificates

--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -60,7 +60,7 @@ to the 1.0 registry. Requests from newer clients will route to the 2.0 registry.
 		$ docker-compose build
 		registryv1 uses an image, skipping
 		Building registryv2...
-		Step 0 : FROM golang:1.15
+		Step 0 : FROM golang:1.16
 		
 		...
 		


### PR DESCRIPTION
corresponding PR for the 2.7 branch is https://github.com/distribution/distribution/pull/3472

fixes https://github.com/distribution/distribution/issues/3484