### PR TITLE
Add mod time to registry blob descriptor

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -66,6 +66,10 @@ type Descriptor struct {
 	// Size in bytes of content.
 	Size int64 `json:"size,omitempty"`
 
+	// ModTime modification time for the file. For backends that
+	// don't have a modification time this may represent the creation time
+	ModTime time.Time
+
 	// Digest uniquely identifies the content. A byte stream can be verified
 	// against this digest.
 	Digest digest.Digest `json:"digest,omitempty"`

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -200,6 +200,7 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 		// for the specific repository.
 		MediaType: "application/octet-stream",
 		Digest:    dgst,
+		ModTime:   fi.ModTime(),
 	}, nil
 }
 


### PR DESCRIPTION
[(merged) PR digitalocean/docker-distribution ](https://github.com/digitalocean/docker-distribution/pull/15)
Expose object modified time to most accurately track when a blob was uploaded or replaced. 