### PR TITLE
Change should to must in v2 spec

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -220,7 +220,7 @@ image. It's the direct replacement for the schema-1 manifest.
     - **`urls`** *array*
 
         Provides a list of URLs from which the content may be fetched. Content
-        should be verified against the `digest` and `size`. This field is
+        must be verified against the `digest` and `size`. This field is
         optional and uncommon.
 
 ## Example Image Manifest


### PR DESCRIPTION
We found some examples of manifests with URLs specififed that did
not provide a digest or size. This breaks the security model by allowing
the content to change, as it no longer provides a Merkle tree. This
was not intended, so explicitly disallow by tightening wording.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>