### PR TITLE
Expose regex helper functions

### DIFF
--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -14,19 +14,19 @@ var (
 	// supporting repeated dash was added. Additionally double underscore is
 	// now allowed as a separator to loosen the restriction for previously
 	// supported names.
-	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+	SeparatorRegexp = match(`(?:[._]|__|[-]*)`)
 
 	// nameComponentRegexp restricts registry path component names to start
 	// with at least one letter or number, with following parts able to be
 	// separated by one period, one or two underscore and multiple dashes.
-	nameComponentRegexp = expression(
+	NameComponentRegexp = expression(
 		alphaNumericRegexp,
 		optional(repeated(separatorRegexp, alphaNumericRegexp)))
 
 	// domainComponentRegexp restricts the registry domain component of a
 	// repository name to start with a component as defined by DomainRegexp
 	// and followed by an optional port.
-	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+	DomainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
 	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
@@ -42,14 +42,14 @@ var (
 
 	// anchoredTagRegexp matches valid tag names, anchored at the start and
 	// end of the matched string.
-	anchoredTagRegexp = anchored(TagRegexp)
+	AnchoredTagRegexp = anchored(TagRegexp)
 
 	// DigestRegexp matches valid digests.
 	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
 
 	// anchoredDigestRegexp matches valid digests, anchored at the start and
 	// end of the matched string.
-	anchoredDigestRegexp = anchored(DigestRegexp)
+	AnchoredDigestRegexp = anchored(DigestRegexp)
 
 	// NameRegexp is the format for the name component of references. The
 	// regexp has capturing groups for the domain and name part omitting
@@ -61,7 +61,7 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = anchored(
+	AnchoredNameRegexp = anchored(
 		optional(capture(DomainRegexp), literal(`/`)),
 		capture(nameComponentRegexp,
 			optional(repeated(literal(`/`), nameComponentRegexp))))
@@ -85,20 +85,20 @@ var (
 
 	// anchoredIdentifierRegexp is used to check or match an
 	// identifier value, anchored at start and end of string.
-	anchoredIdentifierRegexp = anchored(IdentifierRegexp)
+	AnchoredIdentifierRegexp = anchored(IdentifierRegexp)
 
 	// anchoredShortIdentifierRegexp is used to check if a value
 	// is a possible identifier prefix, anchored at start and end
 	// of string.
-	anchoredShortIdentifierRegexp = anchored(ShortIdentifierRegexp)
+	AnchoredShortIdentifierRegexp = anchored(ShortIdentifierRegexp)
 )
 
 // match compiles the string to a regular expression.
-var match = regexp.MustCompile
+var Match = regexp.MustCompile
 
 // literal compiles s into a literal regular expression, escaping any regexp
 // reserved characters.
-func literal(s string) *regexp.Regexp {
+func Literal(s string) *regexp.Regexp {
 	re := match(regexp.QuoteMeta(s))
 
 	if _, complete := re.LiteralPrefix(); !complete {
@@ -110,7 +110,7 @@ func literal(s string) *regexp.Regexp {
 
 // expression defines a full expression, where each regular expression must
 // follow the previous.
-func expression(res ...*regexp.Regexp) *regexp.Regexp {
+func Expression(res ...*regexp.Regexp) *regexp.Regexp {
 	var s string
 	for _, re := range res {
 		s += re.String()
@@ -121,27 +121,27 @@ func expression(res ...*regexp.Regexp) *regexp.Regexp {
 
 // optional wraps the expression in a non-capturing group and makes the
 // production optional.
-func optional(res ...*regexp.Regexp) *regexp.Regexp {
+func Optional(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(group(expression(res...)).String() + `?`)
 }
 
 // repeated wraps the regexp in a non-capturing group to get one or more
 // matches.
-func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+func Repeated(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(group(expression(res...)).String() + `+`)
 }
 
 // group wraps the regexp in a non-capturing group.
-func group(res ...*regexp.Regexp) *regexp.Regexp {
+func Group(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(`(?:` + expression(res...).String() + `)`)
 }
 
 // capture wraps the expression in a capturing group.
-func capture(res ...*regexp.Regexp) *regexp.Regexp {
+func Capture(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(`(` + expression(res...).String() + `)`)
 }
 
 // anchored anchors the regular expression by adding start and end delimiters.
-func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+func Anchored(res ...*regexp.Regexp) *regexp.Regexp {
 	return match(`^` + expression(res...).String() + `$`)
 }


### PR DESCRIPTION
Currently, external users who wish to use the regex provided in reference/regex.go must reimplement many of the regex helpers defined in the file to perform many of the same operations. To DRY code, it would be useful to publicly expose all of the helpers and intermediate regex steps in the file. 