### PR TITLE
Added storagedriver Walk opts & fix S3 Walk performance issues

### DIFF
--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -112,7 +112,7 @@ func (bs *blobStore) Enumerate(ctx context.Context, ingester func(dgst digest.Di
 		}
 
 		return ingester(digest)
-	})
+	}, driver.WalkWithStopOnErrSkipDir(true))
 }
 
 // path returns the canonical path for the blob identified by digest. The blob

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -361,8 +361,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 // directDescendants will find direct descendants (blobs or virtual containers)

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -228,7 +228,7 @@ func (base *Base) URLFor(ctx context.Context, path string, options map[string]in
 }
 
 // Walk wraps Walk of underlying storage driver.
-func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
+func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
 	ctx, done := dcontext.WithTrace(ctx)
 	defer done("%s.Walk(%q)", base.Name(), path)
 
@@ -236,5 +236,5 @@ func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn)
 		return storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
 	}
 
-	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f))
+	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f, opts...))
 }

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -291,8 +291,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 // fullPath returns the absolute path of a key within the Driver's storage.

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -837,8 +837,8 @@ func (d *driver) URLFor(context context.Context, path string, options map[string
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 func startSession(client *http.Client, bucket string, name string) (uri string, err error) {

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -246,8 +246,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 type writer struct {

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -491,8 +491,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 func (d *driver) ossPath(path string) string {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -32,6 +32,32 @@ func (version Version) Minor() uint {
 // CurrentVersion is the current storage driver Version.
 const CurrentVersion Version = "0.1"
 
+// WalkOptions are options for Walk
+type WalkOptions struct {
+	// StopOnErrSkipDir mutates the default Walk behavior to stop whenever ErrSkipDir is returned
+	// by the callback fn, regardless if the callback fileInfo is a directory.
+	StopOnErrSkipDir bool
+}
+
+// WalkOpt is a functional setter for WalkOptions
+type WalkOpt func(*WalkOptions)
+
+// ToWalkOptions converts a slice of WalkOpt to WalkOptions
+func ToWalkOptions(opts ...WalkOpt) WalkOptions {
+	walkOpts := WalkOptions{}
+	for _, opt := range opts {
+		opt(&walkOpts)
+	}
+	return walkOpts
+}
+
+// WalkWithStopOnErrSkipDir functionally sets WalkOptions.StopOnErrSkipDir
+func WalkWithStopOnErrSkipDir(b bool) WalkOpt {
+	return func(options *WalkOptions) {
+		options.StopOnErrSkipDir = b
+	}
+}
+
 // StorageDriver defines methods that a Storage Driver must implement for a
 // filesystem-like key/value object storage. Storage Drivers are automatically
 // registered via an internal registration mechanism, and generally created
@@ -89,7 +115,7 @@ type StorageDriver interface {
 	// If the returned error from the WalkFn is ErrSkipDir and fileInfo refers
 	// to a directory, the directory will not be entered and Walk
 	// will continue the traversal.  If fileInfo refers to a normal file, processing stops
-	Walk(ctx context.Context, path string, f WalkFn) error
+	Walk(ctx context.Context, path string, f WalkFn, opts ...WalkOpt) error
 }
 
 // FileWriter provides an abstraction for an opened writable file-like object in

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -659,8 +659,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, opts ...storagedriver.WalkOpt) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, opts...)
 }
 
 func (d *driver) swiftPath(path string) string {

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -272,7 +272,7 @@ func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingestor func(digest.
 		}
 
 		return nil
-	})
+	}, driver.WalkWithStopOnErrSkipDir(true))
 }
 
 func (lbs *linkedBlobStore) mount(ctx context.Context, sourceRepo reference.Named, dgst digest.Digest, sourceStat *distribution.Descriptor) (distribution.Descriptor, error) {


### PR DESCRIPTION
These changes were motivated by discussion in https://github.com/distribution/distribution/pull/3480 after @byumov pointed out that my previous changes to the storagedriver.Walk S3 implementation gave horrific performance for operations like `v2/_catalog` for larger registries. 

I hope to address both my original performance concerns and new ones by adding much needed functional options to `storagedriver::Walk` which can be used to educate an optimal Walk implementation, depending on the context in which it's used. 

@milosgajdos @waynr 