### PR TITLE
Garbage collect: first enumerate blobs, then mark

### DIFF
--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -34,10 +34,22 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		return fmt.Errorf("unable to convert Namespace to RepositoryEnumerator")
 	}
 
+	// enumerate blobs
+	emit("enumerating blobs in registry")
+	blobService := registry.Blobs()
+	blobSet := make(map[digest.Digest]struct{})
+	err := blobService.Enumerate(ctx, func(dgst digest.Digest) error {
+		blobSet[dgst] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error enumerating blobs: %v", err)
+	}
+
 	// mark
 	markSet := make(map[digest.Digest]struct{})
 	manifestArr := make([]ManifestDel, 0)
-	err := repositoryEnumerator.Enumerate(ctx, func(repoName string) error {
+	err = repositoryEnumerator.Enumerate(ctx, func(repoName string) error {
 		emit(repoName)
 
 		var err error
@@ -124,18 +136,13 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 			}
 		}
 	}
-	blobService := registry.Blobs()
 	deleteSet := make(map[digest.Digest]struct{})
-	err = blobService.Enumerate(ctx, func(dgst digest.Digest) error {
-		// check if digest is in markSet. If not, delete it!
+	for dgst := range blobSet {
 		if _, ok := markSet[dgst]; !ok {
 			deleteSet[dgst] = struct{}{}
 		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("error enumerating blobs: %v", err)
 	}
+
 	emit("\n%d blobs marked, %d blobs and %d manifests eligible for deletion", len(markSet), len(deleteSet), len(manifestArr))
 	for dgst := range deleteSet {
 		emit("blob eligible for deletion: %s", dgst)


### PR DESCRIPTION
This request fixes the issue of blobs being deleted during GC if a tag was pushed after it had been marked.

If we swap the order of GC phases, i.e. enumerating blobs first, then even if a new push occurs during long-running 'mark' phase, we will not delete those new pushed blobs, because we haven't enumerated them.

I think that it is quite simple solution to the old problem, maybe even too simple to not have a pitfall of some kind. I will be happy if someone reviews this and highlights any issues.