### PR TITLE
Prepare for v2.8.0 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -30,3 +30,17 @@ Helen Xie <xieyulin821@harmonycloud.cn> Helen-xie <xieyulin821@harmonycloud.cn>
 Mike Brown <brownwm@us.ibm.com> Mike Brown <mikebrow@users.noreply.github.com>
 Manish Tomar <manish.tomar@docker.com> Manish Tomar <manishtomar@users.noreply.github.com>
 Sakeven Jiang <jc5930@sina.cn> sakeven <jc5930@sina.cn>
+Milos Gajdos <milosgajdos83@gmail.com> Milos Gajdos <milosgajdos@users.noreply.github.com>
+Derek McGowan <derek@mcgstyle.net> Derek McGowa <dmcgowan@users.noreply.github.com>
+Adrian Plata <adrian.plata@docker.com> Adrian Plata <@users.noreply.github.com>
+Sebastiaan van Stijn <github@gone.nl> Sebastiaan van Stijn <thaJeztah@users.noreply.github.com>
+Vishesh Jindal <vishesh92@gmail.com> Vishesh Jindal <vishesh92@users.noreply.github.com>
+Wang Yan <wangyan@vmware.com> Wang Yan <wy65701436@users.noreply.github.com>
+Chris Patterson <chrispat@github.com> Chris Patterson <chrispat@users.noreply.github.com>
+Eohyung Lee <liquidnuker@gmail.com> Eohyung Lee <leoh0@users.noreply.github.com>
+João Pereira <484633+joaodrp@users.noreply.github.com>
+Smasherr <soundcracker@gmail.com> Smasherr <Smasherr@users.noreply.github.com>
+Thomas Berger <loki@lokis-chaos.de> Thomas Berger <tbe@users.noreply.github.com>
+Samuel Karp <skarp@amazon.com> Samuel Karp <samuelkarp@users.noreply.github.com>
+Justin Cormack <justin.cormack@docker.com>
+sayboras <sayboras@yahoo.com>

--- a/releases/v2.8.0.toml
+++ b/releases/v2.8.0.toml
@@ -13,8 +13,8 @@ preface = """\
 The 2.8.0 registry release has been a long time overdue.
 This is the last 2.x release. No further active development will continue on
 2.x branch. Security vulnerability patches to 2.x might be considered, but
-all active development will be focussed on v3 release due next year.
-This release thus includes a security vulnerability fix along
+all active development will be focussed on v3 release due in 2022.
+This release includes a security vulnerability fix along
 with a few minor bug fixes and improvemnts in documentation and CI.
 
 See changelog below for full list of changes.

--- a/releases/v2.8.0.toml
+++ b/releases/v2.8.0.toml
@@ -1,0 +1,55 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "registry"
+github_repo = "distribution/distribution"
+
+# previous release
+previous = "v2.7.1"
+
+pre_release = false
+
+preface = """\
+The 2.8.0 registry release has been a long time overdue.
+This is the last 2.x release. No further active development will continue on
+2.x branch. Security vulnerability patches to 2.x might be considered, but
+all active development will be focussed on v3 release due next year.
+This release thus includes a security vulnerability fix along
+with a few minor bug fixes and improvemnts in documentation and CI.
+
+See changelog below for full list of changes.
+
+### Bugfixes
+* Close the io.ReadCloser from storage driver [#3370](https://github.com/distribution/distribution/pull/3370)
+* Remove empty Content-Type header [#3297](https://github.com/distribution/distribution/pull/3297)
+* Make ipfilteredby not required in cloudfront storage middleware [#3088](https://github.com/distribution/distribution/pull/3088)
+
+### Features
+* Add reference.ParseDockerRef utility function [#3002](https://github.com/distribution/distribution/pull/3002)
+
+### CI build
+* First draft of actions based ci [#3347](https://github.com/distribution/distribution/pull/3347)
+* Fix vndr and check [#3001](https://github.com/distribution/distribution/pull/3001)
+* Improve code quality by adding linter checks [#3385](https://github.com/distribution/distribution/pull/3385)
+
+### Documentation
+* Add redirect for old URL [#3197](https://github.com/distribution/distribution/pull/3197)
+* Fix broken table [#3073](https://github.com/distribution/distribution/pull/3073)
+* Adding deprecated schema v1 instructions [#2987](https://github.com/distribution/distribution/pull/2987)
+* Change should to must in v2 spec ([#3495](https://github.com/distribution/distribution/pull/3495))
+
+### Storage drivers
+* S3 Driver: add support for ceph radosgw [#3119](https://github.com/distribution/distribution/pull/3119)
+
+### Security
+* Added flag for user configurable cipher suites [#3384](https://github.com/distribution/distribution/pull/3384)
+* Address [CVE-2020-26160](https://github.com/advisories/GHSA-w73w-5m7g-f7qc) by replacing vulnerable third-party depedency[#3466](https://github.com/distribution/distribution/pull/3466)
+* Replace math rand with crypto rand [#3531](https://github.com/distribution/distribution/pull/3531)
+* Address [CVE-2021-41190](https://github.com/advisories/GHSA-mc8v-mgrf-8f4m) by validating document type before unmarshal [GHSA-77vh-xpmg-72qh](https://github.com/distribution/distribution-ghsa-qq97-vm5h-rrhg/pull/2)
+
+### Dependency Changes
+* github.com/dgrijalva/jwt-go           -> github.com/golang-jwt/jwt.git # v3.2.2        (a601269ab70c -> 4bbdd8ac624f)
+* github.com/opencontainers/image-spec  -> github.com/opencontainers/image-spec # v1.0.2 (ab7389ef9f50 -> 67d2d5658fe0)
+
+Previous release can be found at [v2.7.1](https://github.com/distribution/distribution/releases/tag/v2.7.1)
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.7.1+unknown"
+var Version = "v2.8.0+unknown"
 
 // Revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.8.0+unknown"
+var Version = "v2.8.0-beta.1+unknown"
 
 // Revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.


### PR DESCRIPTION
This PR contains release notes and version bump for `2.8.0` release.
This will be the last `v2.x` release -- no future development should be expected on `v2.x` branch; all focus will be on getting a `v3` release out next year.

The reasons why we've decided to go with `v2.8.0` release rather than with a patch release (`v2.7.2`) as originally intended in #3380 is that #3384 technically introduces a new feature that warrants a minor release.