### PR TITLE
return an empty slice instead of an error in tagStore.All when s3 path is not exist

### DIFF
--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -36,7 +36,7 @@ func (ts *tagStore) All(ctx context.Context) ([]string, error) {
 	if err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
-			return tags, distribution.ErrRepositoryUnknown{Name: ts.repository.Named().Name()}
+			return tags, nil
 		default:
 			return tags, err
 		}


### PR DESCRIPTION
Scene: We delete the tags in the _tags directory under S3, and then use gc to clear the image, but we found that because there is no real directory in s3, after deleting all tags in the _tags directory, the _tags directory no longer exists. gc will report an error
I don't think it's reasonable, so this pr is to solve this situation