### PR TITLE
[2.8] Release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: build
+
+on:
+  push:
+    branches:
+      - 'release/*'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  DOCKERHUB_SLUG: distribution/distribution
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.DOCKERHUB_SLUG }}
+          ### versioning strategy
+          ### push semver tag v2.9.0 on main (default branch)
+          # distribution/distribution:2.9.0
+          # distribution/distribution:latest
+          ### push semver tag v2.8.0 on release/2.8 branch
+          # distribution/distribution:2.8.0
+          ### push on main
+          # distribution/distribution:edge
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=pr
+          # don't create latest tag on release/2.x
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.title=Distribution
+            org.opencontainers.image.description=The toolkit to pack, ship, store, and deliver container content
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build image
+        uses: docker/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-all
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,40 @@
-FROM golang:1.16-alpine AS build
+# syntax=docker/dockerfile:1.3
 
+ARG GO_VERSION=1.16
+ARG GORELEASER_XX_VERSION=1.2.5
+
+FROM --platform=$BUILDPLATFORM crazymax/goreleaser-xx:${GORELEASER_XX_VERSION} AS goreleaser-xx
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS base
+COPY --from=goreleaser-xx / /
+RUN apk add --no-cache file git
+WORKDIR /go/src/github.com/docker/distribution
+
+FROM base AS build
 ENV GO111MODULE=auto
-ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
-ENV BUILDTAGS include_oss include_gcs
+ENV CGO_ENABLED=0
+ARG TARGETPLATFORM
+ARG PKG="github.com/distribution/distribution"
+ARG BUILDTAGS="include_oss include_gcs"
+RUN --mount=type=bind,rw \
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=target=/go/pkg/mod,type=cache \
+  goreleaser-xx --debug \
+    --name="registry" \
+    --dist="/out" \
+    --main="./cmd/registry" \
+    --flags="-v" \
+    --ldflags="-s -w -X '$PKG/version.Version={{.Version}}' -X '$PKG/version.Revision={{.Commit}}' -X '$PKG/version.Package=$PKG'" \
+    --tags="$BUILDTAGS" \
+    --files="LICENSE" \
+    --files="README.md"
 
-ARG GOOS=linux
-ARG GOARCH=amd64
-ARG GOARM=6
+FROM scratch AS binary
+COPY --from=build /usr/local/bin/registry* /
 
-RUN set -ex \
-    && apk add --no-cache make git file
-
-WORKDIR $DISTRIBUTION_DIR
-COPY . $DISTRIBUTION_DIR
-RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
-
-FROM alpine
+FROM alpine:3.14
+RUN apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
-COPY --from=build /go/src/github.com/docker/distribution/bin/registry /bin/registry
+COPY --from=build /usr/local/bin/registry /bin/registry
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,34 @@
+group "default" {
+  targets = ["image-local"]
+}
+
+// Special target: https://github.com/docker/metadata-action#bake-definition
+target "docker-metadata-action" {
+  tags = ["registry:local"]
+}
+
+target "binary" {
+  target = "binary"
+  output = ["./bin"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x"
+  ]
+}


### PR DESCRIPTION
follow-up https://github.com/distribution/distribution/pull/3552

degraded backport of https://github.com/distribution/distribution/pull/3315 to be able to trigger a release on `release/2.8` branch without artifacts releasing.

cc @milosgajdos @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>