### PR TITLE
fix image cache incompletely

### DIFF
--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -130,14 +130,19 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 	inflight[dgst] = struct{}{}
 	mu.Unlock()
 
+	// storeLocalCtx will be independent with ctx, because ctx it used to fetch remote image.
+	// There would be a situation, that is pulling remote bytes ends before pbs.storeLocal( 'Copy', 'Commit' ...)
+	// Then the registry fails to cache the layer, even though the layer had been served to client.
+	storeLocalCtx, cancel := context.WithCancel(context.Background())
 	go func(dgst digest.Digest) {
-		if err := pbs.storeLocal(ctx, dgst); err != nil {
-			dcontext.GetLogger(ctx).Errorf("Error committing to storage: %s", err.Error())
+		defer cancel()
+		if err := pbs.storeLocal(storeLocalCtx, dgst); err != nil {
+			dcontext.GetLogger(storeLocalCtx).Errorf("Error committing to storage: %s", err.Error())
 		}
 
 		blobRef, err := reference.WithDigest(pbs.repositoryName, dgst)
 		if err != nil {
-			dcontext.GetLogger(ctx).Errorf("Error creating reference: %s", err)
+			dcontext.GetLogger(storeLocalCtx).Errorf("Error creating reference: %s", err)
 			return
 		}
 
@@ -146,6 +151,7 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 
 	_, err = pbs.copyContent(ctx, dgst, w)
 	if err != nil {
+		cancel()
 		return err
 	}
 	return nil


### PR DESCRIPTION
ref: https://github.com/distribution/distribution/issues/3438
I found there are some changes after v2.7.1. That is the context will be passed into http request. It may be closed before commit layer into  local cache.
<img width="813" alt="截屏2022-01-14 下午7 34 19" src="https://user-images.githubusercontent.com/38838049/149509204-ee5d611b-37e7-4f95-9ac8-b454273aa1a8.png">

solved before:
<img width="1248" alt="截屏2022-01-14 下午7 28 00" src="https://user-images.githubusercontent.com/38838049/149509246-f981dd32-634b-40a2-b67c-4544ba5e7026.png">

solved:
<img width="1146" alt="截屏2022-01-14 下午7 26 23" src="https://user-images.githubusercontent.com/38838049/149509290-92331d01-ae67-49b2-835a-70bb90d6e323.png">
