### PR TITLE
[2.8] Release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,22 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Build artifacts
+        uses: docker/bake-action@v1
+        with:
+          targets: artifact-all
+      -
+        name: Move artifacts
+        run: |
+          mv ./bin/**/* ./bin/
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: registry
+          path: ./bin/*
+          if-no-files-found: error
+      -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
@@ -63,3 +79,15 @@ jobs:
             ${{ steps.meta.outputs.bake-file }}
           targets: image-all
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+      -
+        name: GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          files: |
+            bin/*.tar.gz
+            bin/*.zip
+            bin/*.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN --mount=type=bind,rw \
     --files="LICENSE" \
     --files="README.md"
 
+FROM scratch AS artifacts
+COPY --from=build /out/*.tar.gz /
+COPY --from=build /out/*.zip /
+COPY --from=build /out/*.sha256 /
+
 FROM scratch AS binary
 COPY --from=build /usr/local/bin/registry* /
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,6 +12,23 @@ target "binary" {
   output = ["./bin"]
 }
 
+target "artifact" {
+  target = "artifacts"
+  output = ["./bin"]
+}
+
+target "artifact-all" {
+  inherits = ["artifact"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x"
+  ]
+}
+
 target "image" {
   inherits = ["docker-metadata-action"]
 }


### PR DESCRIPTION
follow-up #3565

As discussed with @milosgajdos, we might need to also publish artifacts to GitHub Release like it's already done on the main branch. Will look like this:

![image](https://user-images.githubusercontent.com/1951866/149896295-50d8a4ea-cac9-47d0-a9f6-fb882333f55f.png)

![image](https://user-images.githubusercontent.com/1951866/149896267-4388a1d5-7753-43d7-8e83-bad0749522b2.png)

```shell
# create the artifact matching your current platform in ./bin
docker buildx bake artifact

# create artifacts for many platforms in ./bin
docker buildx bake artifact-all
```

Waiting for inputs from maintainers so keeping in draft for now.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>