### PR TITLE
update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,20 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_SLUG }}
+          ### versioning strategy
+          ### push semver tag v3.2.1 on main (default branch)
+          # distribution/distribution:3.2.1
+          # distribution/distribution:3.2
+          # distribution/distribution:3
+          # distribution/distribution:latest
+          ### push semver prelease tag v3.0.0-beta.1 on main (default branch)
+          # distribution/distribution:3.0.0-beta.1
+          ### push on main
+          # distribution/distribution:edge
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=ref,event=pr
             type=edge
           labels: |
@@ -81,5 +93,6 @@ jobs:
           files: |
             bin/*.tar.gz
             bin/*.zip
+            bin/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,12 @@ RUN --mount=type=bind,target=/src,rw \
 FROM scratch AS artifacts
 COPY --from=build /out/*.tar.gz /
 COPY --from=build /out/*.zip /
+COPY --from=build /out/*.sha256 /
 
 FROM scratch AS binary
 COPY --from=build /usr/local/bin/registry* /
 
-FROM alpine:3.14
+FROM alpine:3.15
 RUN apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=build /usr/local/bin/registry /bin/registry

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,10 +20,7 @@ target "artifact" {
 target "artifact-all" {
   inherits = ["artifact"]
   platforms = [
-    "darwin/amd64",
-    "darwin/arm64",
     "linux/amd64",
-    "linux/arm/v5",
     "linux/arm/v6",
     "linux/arm/v7",
     "linux/arm64",


### PR DESCRIPTION
follow-up https://github.com/distribution/distribution/pull/3568 to be aligned with https://github.com/distribution/distribution/releases/tag/v2.8.0-beta.1

also update base image to alpine 3.15 like the official image: https://github.com/docker/distribution-library-image/blob/c70c2acb365928f10bfc7706cc0f3f4d16f7427b/Dockerfile#L1

cc @thaJeztah @milosgajdos 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>