### PR TITLE
optimize: disable insecure cipher suites

### DIFF
--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -76,7 +76,6 @@ func (sbs statsBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, 
 }
 
 func (sbs statsBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-
 	sbsMu.Lock()
 	sbs.stats["stat"]++
 	sbsMu.Unlock()

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -135,7 +135,10 @@ func TestGetCipherSuite(t *testing.T) {
 		)
 	}
 
-	resp, err = getCipherSuites([]string{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_128_GCM_SHA256"})
+	resp, err = getCipherSuites([]string{
+		"TLS_RSA_WITH_AES_128_CBC_SHA",
+		"TLS_AES_128_GCM_SHA256",
+	})
 	if err != nil || len(resp) != 2 ||
 		resp[0] != tls.TLS_RSA_WITH_AES_128_CBC_SHA || resp[1] != tls.TLS_AES_128_GCM_SHA256 {
 		t.Errorf("expected cipher suites %q, got %q",
@@ -147,6 +150,22 @@ func TestGetCipherSuite(t *testing.T) {
 	_, err = getCipherSuites([]string{"TLS_RSA_WITH_AES_128_CBC_SHA", "bad_input"})
 	if err == nil {
 		t.Error("did not return expected error about unknown cipher suite")
+	}
+
+	var insecureCipherSuites = []string{
+		"TLS_RSA_WITH_RC4_128_SHA",
+		"TLS_RSA_WITH_AES_128_CBC_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+	}
+
+	for _, suite := range insecureCipherSuites {
+		_, err = getCipherSuites([]string{suite})
+		if err == nil {
+			t.Errorf("Unexpected insecure cipher suite: %s", suite)
+		}
 	}
 }
 

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -46,7 +46,7 @@ func TestPurgeGather(t *testing.T) {
 	fs, ctx := testUploadFS(t, uploadCount, "test-repo", time.Now())
 	uploadData, errs := getOutstandingUploads(ctx, fs)
 	if len(errs) != 0 {
-		t.Errorf("Unexepected errors: %q", errs)
+		t.Errorf("Unexpected errors: %q", errs)
 	}
 	if len(uploadData) != uploadCount {
 		t.Errorf("Unexpected upload file count: %d != %d", uploadCount, len(uploadData))


### PR DESCRIPTION
### background
github code scan detects the insecure configurations of distribution.

### solution
This commit removes the following cipher suites that are known to be insecure:

TLS_RSA_WITH_RC4_128_SHA
TLS_RSA_WITH_AES_128_CBC_SHA256
TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
TLS_ECDHE_RSA_WITH_RC4_128_SHA
TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256

And this commit deletes the tlsVersions of tls1.0 and tls1.1. The tls1.2 is the minimal supported tls version for creating a safer tls configuration.

Signed-off-by: baojiangnan <baojn1998@163.com>