### PR TITLE
Fix: Avoid a false type assertion in the inmemory driver

### DIFF
--- a/registry/storage/driver/inmemory/mfs.go
+++ b/registry/storage/driver/inmemory/mfs.go
@@ -244,11 +244,16 @@ func (d *dir) delete(p string) error {
 		return errNotExists
 	}
 
-	if _, ok := parent.(*dir).children[filename]; !ok {
+	parentDir, ok := parent.(*dir)
+	if !ok {
+		return errIsNotDir
+	}
+
+	if _, ok := parentDir.children[filename]; !ok {
 		return errNotExists
 	}
 
-	delete(parent.(*dir).children, filename)
+	delete(parentDir.children, filename)
 	return nil
 }
 


### PR DESCRIPTION
This issue was discovered by the following fuzzer:
https://github.com/cncf/cncf-fuzzing/blob/main/projects/distribution/inmemory_fuzzer.go#L24

Reproducing
To reproduce this issue, download the Minimized Testcase from the OSS-fuzz report, and follow the steps here: https://google.github.io/oss-fuzz/advanced-topics/reproducing/

Signed-off-by: Milos Gajdos <milosgajdos83@gmail.com>