### PR TITLE
Update golangci-lint version and fix reports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - unconvert
     - gofmt
     - goimports
-    - golint
+    - revive
     - ineffassign
     - vet
     - unused

--- a/context/http.go
+++ b/context/http.go
@@ -246,9 +246,7 @@ func (ctx *muxVarsContext) Value(key interface{}) interface{} {
 			return ctx.vars
 		}
 
-		if strings.HasPrefix(keyStr, "vars.") {
-			keyStr = strings.TrimPrefix(keyStr, "vars.")
-		}
+		keyStr = strings.TrimPrefix(keyStr, "vars.")
 
 		if v, ok := ctx.vars[keyStr]; ok {
 			return v

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GOLANGCI_LINT_VERSION="v1.27.0"
+GOLANGCI_LINT_VERSION="v1.44.0"
 
 #
 # Install developer tools to $GOBIN (or $GOPATH/bin if unset)


### PR DESCRIPTION
This commit updates `golangci-lint` to `v1.44.0`.

It also removes deprecated [golint](https://github.com/golang/lint) in favour of [revive](https://github.com/mgechev/revive) linter.

Finally, it addresses an issue reported by linter: there is no need to check if a prefix contains a string, see `TrimFix` doc:

> // TrimPrefix returns s without the provided leading prefix string.
// If s doesn't start with prefix, s is returned unchanged.


Signed-off-by: Milos Gajdos <milosthegajdos@gmail.com>