### PR TITLE
ci: use proper git ref for versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ WORKDIR /src
 FROM base AS build
 ENV GO111MODULE=auto
 ENV CGO_ENABLED=0
+# GIT_REF is used by goreleaser-xx to handle the proper git ref when available.
+# It will fallback to the working tree info if empty and use "git tag --points-at"
+# or "git describe" to define the version info.
+ARG GIT_REF
 ARG TARGETPLATFORM
 ARG PKG="github.com/distribution/distribution/v3"
 ARG BUILDTAGS="include_oss include_gcs"
@@ -28,7 +32,7 @@ RUN --mount=type=bind,target=/src,rw \
     --files="LICENSE" \
     --files="README.md"
 
-FROM scratch AS artifacts
+FROM scratch AS artifact
 COPY --from=build /out/*.tar.gz /
 COPY --from=build /out/*.zip /
 COPY --from=build /out/*.sha256 /

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,15 @@
+// GITHUB_REF is the actual ref that triggers the workflow
+// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+variable "GITHUB_REF" {
+  default = ""
+}
+
+target "_common" {
+  args = {
+    GIT_REF = GITHUB_REF
+  }
+}
+
 group "default" {
   targets = ["image-local"]
 }
@@ -8,12 +20,14 @@ target "docker-metadata-action" {
 }
 
 target "binary" {
+  inherits = ["_common"]
   target = "binary"
   output = ["./bin"]
 }
 
 target "artifact" {
-  target = "artifacts"
+  inherits = ["_common"]
+  target = "artifact"
   output = ["./bin"]
 }
 
@@ -30,7 +44,7 @@ target "artifact-all" {
 }
 
 target "image" {
-  inherits = ["docker-metadata-action"]
+  inherits = ["_common", "docker-metadata-action"]
 }
 
 target "image-local" {


### PR DESCRIPTION
Discussed with @milosgajdos. Yesterday while releasing `v2.8.0` tag, version was still `v2.8.0-beta.1` because of the current working tree info. This PR solves that behavior in our CI by using the actual ref that triggers the workflow using the [`GITHUB_REF` env var](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables).

Can be tested with:

```shell
GITHUB_REF=refs/tags/v5.0.0 docker buildx bake
```

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>