### PR TITLE
Prepare for v2.8.1 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -44,3 +44,6 @@ Thomas Berger <loki@lokis-chaos.de> Thomas Berger <tbe@users.noreply.github.com>
 Samuel Karp <skarp@amazon.com> Samuel Karp <samuelkarp@users.noreply.github.com>
 Justin Cormack <justin.cormack@docker.com>
 sayboras <sayboras@yahoo.com>
+CrazyMax <github@crazymax.dev>
+CrazyMax <github@crazymax.dev> <1951866+crazy-max@users.noreply.github.com>
+CrazyMax <github@crazymax.dev> <crazy-max@users.noreply.github.com>

--- a/releases/v2.8.1.toml
+++ b/releases/v2.8.1.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "registry"
+github_repo = "distribution/distribution"
+
+# previous release
+previous = "v2.8.0"
+
+pre_release = false
+
+preface = """\
+The 2.8.1 registry release fixes the Go module issues that have popped up in the v2.8.0
+
+There have been no chages made in the released binaries.
+
+See changelog below for full list of changes.
+
+### CI
+* ci: use proper git ref for versioning [#3595](https://github.com/distribution/distribution/pull/3595)
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v2.8.0](https://github.com/distribution/distribution/releases/tag/v2.8.0)
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.8.0-beta.1+unknown"
+var Version = "v2.8.1+unknown"
 
 // Revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.


### PR DESCRIPTION
The previous release caused a bit of a [Go modules kerfuffle](https://github.com/distribution/distribution/issues/3590). Let's get this sorted in the patch release.