### PR TITLE
Upgrade base Alpine packages during release image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ FROM scratch AS binary
 COPY --from=build /usr/local/bin/registry* /
 
 FROM alpine:3.15
-RUN apk add --no-cache ca-certificates
+RUN apk -U --no-cache upgrade \
+    && apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=build /usr/local/bin/registry /bin/registry
 VOLUME ["/var/lib/registry"]


### PR DESCRIPTION
Since Registry is based on `alpine:3.15`, it doesn't get any base package upgrades released since the base image was created

Looking at Docker Hub the base image was updated 3 months ago: https://hub.docker.com/layers/alpine/library/alpine/3.15.0/images/sha256-c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060?context=explore

Running `apk -U --no-cache upgrade` during image build will upgrade the following packages: 

```
root@ubuntu:/home/ubuntu# docker run -it --rm --entrypoint=/bin/sh registry:2
/ # apk -U --no-cache upgrade
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/6) Upgrading busybox (1.34.1-r3 -> 1.34.1-r4)
Executing busybox-1.34.1-r4.post-upgrade
(2/6) Upgrading ca-certificates-bundle (20191127-r7 -> 20211220-r0)
(3/6) Upgrading libcrypto1.1 (1.1.1l-r7 -> 1.1.1l-r8)
(4/6) Upgrading libssl1.1 (1.1.1l-r7 -> 1.1.1l-r8)
(5/6) Upgrading ssl_client (1.34.1-r3 -> 1.34.1-r4)
(6/6) Upgrading ca-certificates (20191127-r7 -> 20211220-r0)
Executing busybox-1.34.1-r4.trigger
Executing ca-certificates-20211220-r0.trigger
OK: 6 MiB in 15 packages
```