### PR TITLE
registry/client: split errors into new package

### DIFF
--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -1,139 +1,27 @@
 package client
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-
-	"github.com/distribution/distribution/v3/registry/api/errcode"
-	"github.com/distribution/distribution/v3/registry/client/auth/challenge"
+	"github.com/distribution/distribution/v3/registry/client/errors"
 )
 
 // ErrNoErrorsInBody is returned when an HTTP response body parses to an empty
 // errcode.Errors slice.
-var ErrNoErrorsInBody = errors.New("no error details found in HTTP response body")
+var ErrNoErrorsInBody = errors.ErrNoErrorsInBody
 
 // UnexpectedHTTPStatusError is returned when an unexpected HTTP status is
 // returned when making a registry api call.
-type UnexpectedHTTPStatusError struct {
-	Status string
-}
-
-func (e *UnexpectedHTTPStatusError) Error() string {
-	return fmt.Sprintf("received unexpected HTTP status: %s", e.Status)
-}
+type UnexpectedHTTPStatusError = errors.UnexpectedHTTPStatusError
 
 // UnexpectedHTTPResponseError is returned when an expected HTTP status code
 // is returned, but the content was unexpected and failed to be parsed.
-type UnexpectedHTTPResponseError struct {
-	ParseErr   error
-	StatusCode int
-	Response   []byte
-}
-
-func (e *UnexpectedHTTPResponseError) Error() string {
-	return fmt.Sprintf("error parsing HTTP %d response body: %s: %q", e.StatusCode, e.ParseErr.Error(), string(e.Response))
-}
-
-func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
-	var errors errcode.Errors
-	body, err := ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	// For backward compatibility, handle irregularly formatted
-	// messages that contain a "details" field.
-	var detailsErr struct {
-		Details string `json:"details"`
-	}
-	err = json.Unmarshal(body, &detailsErr)
-	if err == nil && detailsErr.Details != "" {
-		switch statusCode {
-		case http.StatusUnauthorized:
-			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
-		case http.StatusTooManyRequests:
-			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
-		default:
-			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)
-		}
-	}
-
-	if err := json.Unmarshal(body, &errors); err != nil {
-		return &UnexpectedHTTPResponseError{
-			ParseErr:   err,
-			StatusCode: statusCode,
-			Response:   body,
-		}
-	}
-
-	if len(errors) == 0 {
-		// If there was no error specified in the body, return
-		// UnexpectedHTTPResponseError.
-		return &UnexpectedHTTPResponseError{
-			ParseErr:   ErrNoErrorsInBody,
-			StatusCode: statusCode,
-			Response:   body,
-		}
-	}
-
-	return errors
-}
-
-func makeErrorList(err error) []error {
-	if errL, ok := err.(errcode.Errors); ok {
-		return []error(errL)
-	}
-	return []error{err}
-}
-
-func mergeErrors(err1, err2 error) error {
-	return errcode.Errors(append(makeErrorList(err1), makeErrorList(err2)...))
-}
+type UnexpectedHTTPResponseError = errors.UnexpectedHTTPResponseError
 
 // HandleErrorResponse returns error parsed from HTTP response for an
 // unsuccessful HTTP response code (in the range 400 - 499 inclusive). An
 // UnexpectedHTTPStatusError returned for response code outside of expected
 // range.
-func HandleErrorResponse(resp *http.Response) error {
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-		// Check for OAuth errors within the `WWW-Authenticate` header first
-		// See https://tools.ietf.org/html/rfc6750#section-3
-		for _, c := range challenge.ResponseChallenges(resp) {
-			if c.Scheme == "bearer" {
-				var err errcode.Error
-				// codes defined at https://tools.ietf.org/html/rfc6750#section-3.1
-				switch c.Parameters["error"] {
-				case "invalid_token":
-					err.Code = errcode.ErrorCodeUnauthorized
-				case "insufficient_scope":
-					err.Code = errcode.ErrorCodeDenied
-				default:
-					continue
-				}
-				if description := c.Parameters["error_description"]; description != "" {
-					err.Message = description
-				} else {
-					err.Message = err.Code.Message()
-				}
-
-				return mergeErrors(err, parseHTTPErrorResponse(resp.StatusCode, resp.Body))
-			}
-		}
-		err := parseHTTPErrorResponse(resp.StatusCode, resp.Body)
-		if uErr, ok := err.(*UnexpectedHTTPResponseError); ok && resp.StatusCode == 401 {
-			return errcode.ErrorCodeUnauthorized.WithDetail(uErr.Response)
-		}
-		return err
-	}
-	return &UnexpectedHTTPStatusError{Status: resp.Status}
-}
+var HandleErrorResponse = errors.HandleErrorResponse
 
 // SuccessStatus returns true if the argument is a successful HTTP response
 // code (in the range 200 - 399 inclusive).
-func SuccessStatus(status int) bool {
-	return status >= 200 && status <= 399
-}
+var SuccessStatus = errors.SuccessStatus

--- a/registry/client/errors/errors.go
+++ b/registry/client/errors/errors.go
@@ -1,0 +1,139 @@
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/distribution/distribution/v3/registry/client/auth/challenge"
+)
+
+// ErrNoErrorsInBody is returned when an HTTP response body parses to an empty
+// errcode.Errors slice.
+var ErrNoErrorsInBody = errors.New("no error details found in HTTP response body")
+
+// UnexpectedHTTPStatusError is returned when an unexpected HTTP status is
+// returned when making a registry api call.
+type UnexpectedHTTPStatusError struct {
+	Status string
+}
+
+func (e *UnexpectedHTTPStatusError) Error() string {
+	return fmt.Sprintf("received unexpected HTTP status: %s", e.Status)
+}
+
+// UnexpectedHTTPResponseError is returned when an expected HTTP status code
+// is returned, but the content was unexpected and failed to be parsed.
+type UnexpectedHTTPResponseError struct {
+	ParseErr   error
+	StatusCode int
+	Response   []byte
+}
+
+func (e *UnexpectedHTTPResponseError) Error() string {
+	return fmt.Sprintf("error parsing HTTP %d response body: %s: %q", e.StatusCode, e.ParseErr.Error(), string(e.Response))
+}
+
+func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
+	var errors errcode.Errors
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// For backward compatibility, handle irregularly formatted
+	// messages that contain a "details" field.
+	var detailsErr struct {
+		Details string `json:"details"`
+	}
+	err = json.Unmarshal(body, &detailsErr)
+	if err == nil && detailsErr.Details != "" {
+		switch statusCode {
+		case http.StatusUnauthorized:
+			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
+		case http.StatusTooManyRequests:
+			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
+		default:
+			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)
+		}
+	}
+
+	if err := json.Unmarshal(body, &errors); err != nil {
+		return &UnexpectedHTTPResponseError{
+			ParseErr:   err,
+			StatusCode: statusCode,
+			Response:   body,
+		}
+	}
+
+	if len(errors) == 0 {
+		// If there was no error specified in the body, return
+		// UnexpectedHTTPResponseError.
+		return &UnexpectedHTTPResponseError{
+			ParseErr:   ErrNoErrorsInBody,
+			StatusCode: statusCode,
+			Response:   body,
+		}
+	}
+
+	return errors
+}
+
+func makeErrorList(err error) []error {
+	if errL, ok := err.(errcode.Errors); ok {
+		return []error(errL)
+	}
+	return []error{err}
+}
+
+func mergeErrors(err1, err2 error) error {
+	return errcode.Errors(append(makeErrorList(err1), makeErrorList(err2)...))
+}
+
+// HandleErrorResponse returns error parsed from HTTP response for an
+// unsuccessful HTTP response code (in the range 400 - 499 inclusive). An
+// UnexpectedHTTPStatusError returned for response code outside of expected
+// range.
+func HandleErrorResponse(resp *http.Response) error {
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// Check for OAuth errors within the `WWW-Authenticate` header first
+		// See https://tools.ietf.org/html/rfc6750#section-3
+		for _, c := range challenge.ResponseChallenges(resp) {
+			if c.Scheme == "bearer" {
+				var err errcode.Error
+				// codes defined at https://tools.ietf.org/html/rfc6750#section-3.1
+				switch c.Parameters["error"] {
+				case "invalid_token":
+					err.Code = errcode.ErrorCodeUnauthorized
+				case "insufficient_scope":
+					err.Code = errcode.ErrorCodeDenied
+				default:
+					continue
+				}
+				if description := c.Parameters["error_description"]; description != "" {
+					err.Message = description
+				} else {
+					err.Message = err.Code.Message()
+				}
+
+				return mergeErrors(err, parseHTTPErrorResponse(resp.StatusCode, resp.Body))
+			}
+		}
+		err := parseHTTPErrorResponse(resp.StatusCode, resp.Body)
+		if uErr, ok := err.(*UnexpectedHTTPResponseError); ok && resp.StatusCode == 401 {
+			return errcode.ErrorCodeUnauthorized.WithDetail(uErr.Response)
+		}
+		return err
+	}
+	return &UnexpectedHTTPStatusError{Status: resp.Status}
+}
+
+// SuccessStatus returns true if the argument is a successful HTTP response
+// code (in the range 200 - 399 inclusive).
+func SuccessStatus(status int) bool {
+	return status >= 200 && status <= 399
+}

--- a/registry/client/errors/errors_test.go
+++ b/registry/client/errors/errors_test.go
@@ -1,0 +1,104 @@
+package errors
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func TestHandleErrorResponse401ValidBody(t *testing.T) {
+	json := "{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"action requires authentication\"}]}"
+	response := &http.Response{
+		Status:     "401 Unauthorized",
+		StatusCode: 401,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "unauthorized: action requires authentication"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}
+
+func TestHandleErrorResponse401WithInvalidBody(t *testing.T) {
+	json := "{invalid json}"
+	response := &http.Response{
+		Status:     "401 Unauthorized",
+		StatusCode: 401,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "unauthorized: authentication required"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}
+
+func TestHandleErrorResponseExpectedStatusCode400ValidBody(t *testing.T) {
+	json := "{\"errors\":[{\"code\":\"DIGEST_INVALID\",\"message\":\"provided digest does not match\"}]}"
+	response := &http.Response{
+		Status:     "400 Bad Request",
+		StatusCode: 400,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "digest invalid: provided digest does not match"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}
+
+func TestHandleErrorResponseExpectedStatusCode404EmptyErrorSlice(t *testing.T) {
+	json := `{"randomkey": "randomvalue"}`
+	response := &http.Response{
+		Status:     "404 Not Found",
+		StatusCode: 404,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := `error parsing HTTP 404 response body: no error details found in HTTP response body: "{\"randomkey\": \"randomvalue\"}"`
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}
+
+func TestHandleErrorResponseExpectedStatusCode404InvalidBody(t *testing.T) {
+	json := "{invalid json}"
+	response := &http.Response{
+		Status:     "404 Not Found",
+		StatusCode: 404,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "error parsing HTTP 404 response body: invalid character 'i' looking for beginning of object key string: \"{invalid json}\""
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}
+
+func TestHandleErrorResponseUnexpectedStatusCode501(t *testing.T) {
+	response := &http.Response{
+		Status:     "501 Not Implemented",
+		StatusCode: 501,
+		Body:       nopCloser{bytes.NewBufferString("{\"Error Encountered\" : \"Function not implemented.\"}")},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "received unexpected HTTP status: 501 Not Implemented"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}


### PR DESCRIPTION
Split error handling functions from `registry/client` into a new
`registry/client/errors` package.

This allows consumers who are only interested in the error handling code
to import this package without getting big unrelated imports in their
binary. At the moment `/registry/client` will import
`/registry/storage/cache` -> `/metrics` -> `github.com/docker/go-metrics`
-> `github.com/prometheus/client_golang/prometheus` and so on.

The prometheus dependencies are big (about 700k in the binary) so it
would help us if we could remove them from the import chain.

This commit keeps backwards compatibility by type aliasing from the old
locations.
