### PR TITLE
Incorrect variable in test output

### DIFF
--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -529,7 +529,7 @@ func testOCIManifestStorage(t *testing.T, testname string, includeMediaTypes boo
 	}
 
 	if fetchedIndex.MediaType != indexMediaType {
-		t.Fatalf("%s: unexpected MediaType for result, %s", testname, fetchedManifest.MediaType)
+		t.Fatalf("%s: unexpected MediaType for result, %s", testname, fetchedIndex.MediaType)
 	}
 
 	payloadMediaType, _, err = fromStore.Payload()


### PR DESCRIPTION
Looks like a copy-paste bug from the same test for the image manifest.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>