### PR TITLE
Explain important caveat in htpasswd tutorial

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -400,6 +400,12 @@ secrets.
 > authentication to work.
 {:.warning}
 
+> **Warning**
+> The official registry image **only** supports htpasswd credentials in
+> bcrypt format, so if you omit the `-B` option when generating the credential
+> using htpasswd, all authentication attempts will fail.
+{:.warning}
+
 1.  Create a password file with one entry for the user `testuser`, with password
     `testpassword`:
 


### PR DESCRIPTION
### Proposed changes

Documentation improvement. It took me almost an hour to track down https://github.com/distribution/distribution/issues/2817#issuecomment-762736783 as the reason my private Docker registry was not working, because of the lack of any error message pointing to the cause.

### Related issues (optional)

Relates to https://github.com/distribution/distribution/issues/2817, but does not really solve it. In my opinion, a full solution to that issue would involve Docker Registry outputting a relevant error message when the incorrect credential type is used, rather than silently accepting it and then failing all login attempts.

This is a copy of https://github.com/docker/docker.github.io/pull/14544 since per https://github.com/docker/docker.github.io/pull/14544#issuecomment-1097692369 this repository has the official reference docs, and the others are deprecated / will be removed.
