### PR TITLE
Fix CVE-2022-28391 by bumping alpine from 3.15 to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=from=binary,target=/build \
 FROM scratch AS artifact
 COPY --from=releaser /out /
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=binary /registry /bin/registry


### PR DESCRIPTION
- addresses https://github.com/distribution/distribution/issues/3648