### PR TITLE
[release/2.8 backport] Fix CVE-2022-28391 by bumping alpine from 3.14 to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=build /out/*.sha256 /
 FROM scratch AS binary
 COPY --from=build /usr/local/bin/registry* /
 
-FROM alpine:3.14
+FROM alpine:3.16
 RUN apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=build /usr/local/bin/registry /bin/registry


### PR DESCRIPTION
- backport of https://github.com/distribution/distribution/pull/3649
- addresses https://github.com/distribution/distribution/issues/3648

(cherry picked from commit 9f2bc25b7accaa578ea5431b750f8c19a42df1b5)
