### PR TITLE
port numbers can't have more than 5 digits

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -22,6 +22,8 @@ func TestValidateReferenceName(t *testing.T) {
 		"127.0.0.1:5000/docker/docker",
 		"127.0.0.1:5000/library/debian",
 		"127.0.0.1:5000/debian",
+		"192.168.0.1:8/debian",
+		"192.168.0.2:25000/debian",
 		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
 
 		// This test case was moved from invalid to valid since it is valid input
@@ -40,6 +42,7 @@ func TestValidateReferenceName(t *testing.T) {
 		"docker///docker",
 		"docker.io/docker/Docker",
 		"docker.io/docker///docker",
+		"192.168.0.2:123456/debian",
 		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
 	}
 

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -7,7 +7,7 @@
 //	name                            := [domain '/'] path-component ['/' path-component]*
 //	domain                          := domain-component ['.' domain-component]* [':' port-number]
 //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
-//	port-number                     := /[0-9]+/
+//	port-number                     := /[0-9]{1,5}/
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -31,7 +31,7 @@ var (
 	domain = expression(
 		domainComponent,
 		optional(repeated(literal(`.`), domainComponent)),
-		optional(literal(`:`), `[0-9]+`))
+		optional(literal(`:`), `[0-9]{1,5}`))
 	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image

--- a/reference/regexp_test.go
+++ b/reference/regexp_test.go
@@ -115,6 +115,14 @@ func TestDomainRegexp(t *testing.T) {
 			input: "Asdf.com", // uppercase character
 			match: true,
 		},
+		{
+			input: "192.168.1.1:75050", // ipv4
+			match: true,
+		},
+		{
+			input: "192.168.1.1:750050", // port with more than 5 digits
+			match: false,
+		},
 	}
 	r := regexp.MustCompile(`^` + DomainRegexp.String() + `$`)
 	for i := range hostcases {


### PR DESCRIPTION
be more restrictive on the port regex, since ports
are limited to 0-65535 range, they can't never have
more than 5 digits.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Spin off https://github.com/distribution/distribution/pull/3489#discussion_r904429460