### PR TITLE
Fix last parameter placeholder

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1495,7 +1495,7 @@ The error codes that may be included in the response body are enumerated below:
 ##### Tags Paginated
 
 ```
-GET /v2/<name>/tags/list?n=<integer>&last=<integer>
+GET /v2/<name>/tags/list?n=<integer>&last=<last entry from response>
 ```
 
 Return a portion of the tags for the specified repository.
@@ -5471,7 +5471,7 @@ The following headers will be returned with the response:
 ##### Catalog Fetch Paginated
 
 ```
-GET /v2/_catalog?n=<integer>&last=<integer>
+GET /v2/_catalog?n=<integer>&last=<last entry from response>
 ```
 
 Return the specified portion of repositories.


### PR DESCRIPTION
Fix `last` query incorrectly noted as an integer.

Signed-off-by: Graham Miln <graham.miln@miln.eu>