### PR TITLE
docs: Clarifying rules around `ignore` property for configuring a Registry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1000,14 +1000,14 @@ accept event notifications.
 | `timeout` | yes      | A value for the HTTP timeout. A positive integer and an optional suffix indicating the unit of time, which may be `ns`, `us`, `ms`, `s`, `m`, or `h`. If you omit the unit of time, `ns` is used. |
 | `threshold` | yes    | An integer specifying how long to wait before backing off a failure. |
 | `backoff` | yes      | How long the system backs off before retrying after a failure. A positive integer and an optional suffix indicating the unit of time, which may be `ns`, `us`, `ms`, `s`, `m`, or `h`. If you omit the unit of time, `ns` is used. |
-| `ignoredmediatypes`|no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
+| `ignoredmediatypes` |no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
 | `ignore`  |no| Events with these mediatypes or actions are not published to the endpoint. |
 
 #### `ignore`
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
-| `mediatypes`|no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
-| `actions`   |no| A list of actions to ignore. Events with these actions are not published to the endpoint. |
+| `mediatypes` |no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
+| `actions`    |no| A list of actions to ignore. Events with these actions are not published to the endpoint. |
 
 ### `events`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1004,6 +1004,9 @@ accept event notifications.
 | `ignore`  |no| Events with these mediatypes or actions are not published to the endpoint. |
 
 #### `ignore`
+
+The `ignore` contains the media types or actions to ignore. Either `ignoredmediatypes` or `mediatypes` must be given.
+
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
 | `mediatypes` |no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |


### PR DESCRIPTION
I ran into the following on the [Configure a Registry page](https://docs.docker.com/registry/configuration/).

![Incorrectly rendered](https://user-images.githubusercontent.com/9382530/176183180-53386c07-6eca-4707-b295-16007b1a73de.png)

The table was not being rendered correctly and I saw that a caveat about `mediatypes` was missing in order to make it work based on the logic in the code. 