### PR TITLE
Raise a specific error for env var parsing issues

### DIFF
--- a/configuration/parser.go
+++ b/configuration/parser.go
@@ -138,7 +138,7 @@ func (p *Parser) Parse(in []byte, v interface{}) error {
 
 			err = p.overwriteFields(parseAs, pathStr, path[1:], envVar.value)
 			if err != nil {
-				return err
+				return fmt.Errorf("parsing environment variable %s: %v", pathStr, err)
 			}
 		}
 	}
@@ -206,7 +206,6 @@ func (p *Parser) overwriteStruct(v reflect.Value, fullpath string, path []string
 		fieldVal := reflect.New(sf.Type)
 		err := yaml.Unmarshal([]byte(payload), fieldVal.Interface())
 		if err != nil {
-			logrus.Warnf("Error parsing environment variable %s: %s", fullpath, err)
 			return err
 		}
 		field.Set(reflect.Indirect(fieldVal))


### PR DESCRIPTION
Without this, the log message for the user indicates a problem with the
yaml file, so identifying the actual error is hard. This change fixes
the output so that the incorrect environment variable is easy to spot.

Fixes #3653

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>