### PR TITLE
Fix API doc parameter placeholder: last

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1495,7 +1495,7 @@ The error codes that may be included in the response body are enumerated below:
 ##### Tags Paginated
 
 ```
-GET /v2/<name>/tags/list?n=<integer>&last=<integer>
+GET /v2/<name>/tags/list?n=<integer>&last=<last tag value from previous response>
 ```
 
 Return a portion of the tags for the specified repository.
@@ -5471,7 +5471,7 @@ The following headers will be returned with the response:
 ##### Catalog Fetch Paginated
 
 ```
-GET /v2/_catalog?n=<integer>&last=<integer>
+GET /v2/_catalog?n=<integer>&last=<last repository value from previous response>
 ```
 
 Return the specified portion of repositories.


### PR DESCRIPTION
Last is not an integer, but is the last returned value to start the
pagination from.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>

Recreate of #3672 and #3673 with a signed DCO.