### PR TITLE
Review contributing for Docker references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@
  - can't figure out something
  - are not sure what's going on or what your problem is
 
-Please ask first in the #distribution channel on Docker community slack.
-[Click here for an invite to Docker community slack](https://dockr.ly/slack)
+Please ask first in the [#distribution](https://cloud-native.slack.com/archives/C01GVR8SY4R) channel on CNCF community slack.
+[Click here for an invite to the CNCF community slack](https://slack.cncf.io/)
 
 ### Reporting security issues
 
-The Docker maintainers take security seriously. If you discover a security
+The maintainers take security seriously. If you discover a security
 issue, please bring it to their attention right away!
 
 Please **DO NOT** file a public issue, instead send your report privately to
@@ -47,7 +47,7 @@ By following these simple rules you will get better and faster feedback on your 
  1. create a new issue, with a succinct title that describes your issue:
    - bad title: "It doesn't work with my docker"
    - good title: "Private registry push fail: 400 error with E_INVALID_DIGEST"
- 2. copy the output of:
+ 2. copy the output of (or similar for other container tools):
    - `docker version`
    - `docker info`
    - `docker exec <registry-container> registry --version`


### PR DESCRIPTION
As the project has transitioned from Docker to CNCF, clean up the
contributing.md to reflect that:
- CNCF slack
- CNCF maintainers
- Use with other container tools

Fixes #3550