### PR TITLE
Do not recreate mux router for each incoming request

### DIFF
--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -1,6 +1,10 @@
 package v2
 
-import "github.com/gorilla/mux"
+import (
+	"sync"
+
+	"github.com/gorilla/mux"
+)
 
 // The following are definitions of the name under which all V2 routes are
 // registered. These symbols can be used to look up a route based on the name.
@@ -14,11 +18,19 @@ const (
 	RouteNameCatalog         = "catalog"
 )
 
+var (
+	baseRouter           *mux.Router
+	createBaseRouterOnce sync.Once
+)
+
 // Router builds a gorilla router with named routes for the various API
 // methods. This can be used directly by both server implementations and
 // clients.
 func Router() *mux.Router {
-	return RouterWithPrefix("")
+	createBaseRouterOnce.Do(func() {
+		baseRouter = RouterWithPrefix("")
+	})
+	return baseRouter
 }
 
 // RouterWithPrefix builds a gorilla router with a configured prefix


### PR DESCRIPTION
`(*App).context`, called in the HTTP handler on each request, creates a
`URLBuilder`, which involves calling `Router()`. This shows up in profiles a
hot spot because it involves compiling the regexps which define all the
routes. For efficiency, cache the router and return the same object each
time.

It appears to be safe to reuse the router because `GetRoute` is the only
method ever called on the returned router object.