### PR TITLE
[Test] remove include_gcs buildtag

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -10,8 +10,6 @@
 // Note that the contents of incomplete uploads are not accessible even though
 // Stat returns their length
 //
-//go:build include_gcs
-// +build include_gcs
 
 package gcs
 


### PR DESCRIPTION
Simulating `go build -tags include_gcs ./...` in current `main` branch.

If you run `go build ./...` against this branch you should get the following error.
```
# google.golang.org/cloud/storage
vendor/google.golang.org/cloud/storage/acl.go:65:15: invalid operation: v (variable of type *"google.golang.org/api/storage/v1".ObjectAccessControl) is not an interface
vendor/google.golang.org/cloud/storage/acl.go:144:15: invalid operation: v (variable of type *"google.golang.org/api/storage/v1".ObjectAccessControl) is not an interface
```

Hopefully tests in this PR show the same issue.