### PR TITLE
Work with the storage driver to minimise work when paging

### DIFF
--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -151,7 +151,11 @@ func TestCatalogInParts(t *testing.T) {
 	lastRepo = p[len(p)-1]
 	numFilled, err = env.registry.Repositories(env.ctx, p, lastRepo)
 
-	if err != io.EOF || numFilled != len(p) {
+	if numFilled != len(p) {
+		t.Errorf("Expected more values in catalog")
+	}
+
+	if err != io.EOF {
 		t.Errorf("Expected end of catalog")
 	}
 

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -385,8 +385,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
 // directDescendants will find direct descendants (blobs or virtual containers)

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -226,7 +226,7 @@ func (base *Base) URLFor(ctx context.Context, path string, options map[string]in
 }
 
 // Walk wraps Walk of underlying storage driver.
-func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
+func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
 	ctx, done := dcontext.WithTrace(ctx)
 	defer done("%s.Walk(%q)", base.Name(), path)
 
@@ -234,5 +234,5 @@ func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn)
 		return storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
 	}
 
-	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f))
+	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f, options...))
 }

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -290,8 +290,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
 // fullPath returns the absolute path of a key within the Driver's storage.

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -849,8 +849,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
 func startSession(client *http.Client, bucket string, name string) (uri string, err error) {

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -244,8 +244,8 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file and directory
-func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
-	return storagedriver.WalkFallback(ctx, d, path, f)
+func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
+	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
 type writer struct {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -32,6 +32,19 @@ func (version Version) Minor() uint {
 // CurrentVersion is the current storage driver Version.
 const CurrentVersion Version = "0.1"
 
+// WalkOptions provides options to the walk function that may adjust its behaviour
+type WalkOptions struct {
+	// If StartAfterHint is set, the walk may start with the first item lexographically
+	// after the hint, but it is not guaranteed and drivers may start the walk from the path.
+	StartAfterHint string
+}
+
+func WithStartAfterHint(startAfterHint string) func(*WalkOptions) {
+	return func(s *WalkOptions) {
+		s.StartAfterHint = startAfterHint
+	}
+}
+
 // StorageDriver defines methods that a Storage Driver must implement for a
 // filesystem-like key/value object storage. Storage Drivers are automatically
 // registered via an internal registration mechanism, and generally created
@@ -88,8 +101,9 @@ type StorageDriver interface {
 	// from the given path, calling f on each file.
 	// If the returned error from the WalkFn is ErrSkipDir and fileInfo refers
 	// to a directory, the directory will not be entered and Walk
-	// will continue the traversal.  If fileInfo refers to a normal file, processing stops
-	Walk(ctx context.Context, path string, f WalkFn) error
+	// will continue the traversal.
+	// If the returned error from the WalkFn is ErrFilledBuffer, processing stops.
+	Walk(ctx context.Context, path string, f WalkFn, options ...func(*WalkOptions)) error
 }
 
 // FileWriter provides an abstraction for an opened writable file-like object in

--- a/registry/storage/driver/walk.go
+++ b/registry/storage/driver/walk.go
@@ -3,7 +3,9 @@ package driver
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -13,30 +15,88 @@ import (
 // as an error by any function.
 var ErrSkipDir = errors.New("skip this directory")
 
+// ErrFilledBuffer is used as a return value from onFileFunc to indicate
+// that the requested number of entries has been reached and the walk can
+// stop.
+var ErrFilledBuffer = errors.New("we have enough entries")
+
 // WalkFn is called once per file by Walk
 type WalkFn func(fileInfo FileInfo) error
 
 // WalkFallback traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file. It uses the List method and Stat to drive itself.
-// If the returned error from the WalkFn is ErrSkipDir and fileInfo refers
-// to a directory, the directory will not be entered and Walk
-// will continue the traversal.  If fileInfo refers to a normal file, processing stops
-func WalkFallback(ctx context.Context, driver StorageDriver, from string, f WalkFn) error {
-	_, err := doWalkFallback(ctx, driver, from, f)
-	return err
+// If the returned error from the WalkFn is ErrSkipDir the directory will not be entered and Walk
+// will continue the traversal. If the returned error from the WalkFn is ErrFilledBuffer, the walk
+// stops.
+func WalkFallback(ctx context.Context, driver StorageDriver, from string, f WalkFn, options ...func(*WalkOptions)) error {
+	walkOptions := &WalkOptions{}
+	for _, o := range options {
+		o(walkOptions)
+	}
+
+	startAfterHint := walkOptions.StartAfterHint
+	// Ensure that we are checking the hint is contained within from by adding a "/".
+	// Add to both in case the hint and form are the same, which would still count.
+	rel, err := filepath.Rel(from, startAfterHint)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// The startAfterHint is outside from, so check if we even need to walk anything
+		// Replace any path separators with \x00 so that the sort works in a depth-first way
+		if strings.ReplaceAll(startAfterHint, "/", "\x00") < strings.ReplaceAll(from, "/", "\x00") {
+			_, err := doWalkFallback(ctx, driver, from, "", f)
+			return err
+		}
+	} else {
+		// The startAfterHint is within from.
+		// Walk up the tree until we hit from - we know it is contained.
+		// Ensure startAfterHint is never deeper than a child of the base
+		// directory so that doWalkFallback doesn't have to worry about
+		// depth-first comparisons
+		base := startAfterHint
+		for strings.HasPrefix(base, from) {
+			_, err = doWalkFallback(ctx, driver, base, startAfterHint, f)
+			switch err.(type) {
+			case nil:
+				// No error
+			case PathNotFoundError:
+				// dir doesn't exist, so nothing to walk
+			default:
+				return err
+			}
+			if base == from {
+				break
+			}
+			startAfterHint = base
+			base, _ = filepath.Split(startAfterHint)
+			if len(base) > 1 {
+				base = strings.TrimSuffix(base, "/")
+			}
+		}
+	}
+
+	return nil
 }
 
-func doWalkFallback(ctx context.Context, driver StorageDriver, from string, f WalkFn) (bool, error) {
+// doWalkFallback performs a depth first walk using recursion.
+// from is the directory that this iteration of the function should walk.
+// startAfterHint is the child within from to start the walk after. It should only ever be a child of from, or the empty string.
+func doWalkFallback(ctx context.Context, driver StorageDriver, from string, startAfterHint string, f WalkFn) (bool, error) {
 	children, err := driver.List(ctx, from)
 	if err != nil {
 		return false, err
 	}
-	sort.Stable(sort.StringSlice(children))
+	sort.Strings(children)
 	for _, child := range children {
+		// The startAfterHint has been sanitised in WalkFallback and will either be
+		// empty, or be suitable for an <= check for this _from_.
+		if child <= startAfterHint {
+			continue
+		}
+
 		// TODO(stevvooe): Calling driver.Stat for every entry is quite
 		// expensive when running against backends with a slow Stat
-		// implementation, such as s3. This is very likely a serious
+		// implementation, such as GCS. This is very likely a serious
 		// performance bottleneck.
+		// Those backends should have custom walk functions. See S3.
 		fileInfo, err := driver.Stat(ctx, child)
 		if err != nil {
 			switch err.(type) {
@@ -50,14 +110,13 @@ func doWalkFallback(ctx context.Context, driver StorageDriver, from string, f Wa
 		}
 		err = f(fileInfo)
 		if err == nil && fileInfo.IsDir() {
-			if ok, err := doWalkFallback(ctx, driver, child, f); err != nil || !ok {
+			if ok, err := doWalkFallback(ctx, driver, child, startAfterHint, f); err != nil || !ok {
 				return ok, err
 			}
 		} else if err == ErrSkipDir {
-			// noop for folders, will just skip
-			if !fileInfo.IsDir() {
-				return false, nil // no error but stop iteration
-			}
+			// don't traverse into this directory
+		} else if err == ErrFilledBuffer {
+			return false, nil // no error but stop iteration
 		} else if err != nil {
 			return false, err
 		}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -79,7 +79,8 @@ const (
 //
 //	Manifests:
 //
-//	manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
+//	manifestsPathSpec:             <root>/v2/repositories/<name>/_manifests
+//	manifestRevisionsPathSpec:     <root>/v2/repositories/<name>/_manifests/revisions/
 //	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
 //	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
 //
@@ -129,6 +130,9 @@ func pathFor(spec pathSpec) (string, error) {
 	repoPrefix := append(rootPrefix, "repositories")
 
 	switch v := spec.(type) {
+
+	case manifestsPathSpec:
+		return path.Join(append(repoPrefix, v.name, "_manifests")...), nil
 
 	case manifestRevisionsPathSpec:
 		return path.Join(append(repoPrefix, v.name, "_manifests", "revisions")...), nil
@@ -255,6 +259,13 @@ func pathFor(spec pathSpec) (string, error) {
 type pathSpec interface {
 	pathSpec()
 }
+
+// manifestPathSpec describes the directory path for a manifest.
+type manifestsPathSpec struct {
+	name string
+}
+
+func (manifestsPathSpec) pathSpec() {}
 
 // manifestRevisionsPathSpec describes the directory path for
 // a manifest revision.


### PR DESCRIPTION
    Pass the last paging flag to storage drivers
    
    Storage drivers may be able to take advantage of the hint to start
    their walk more efficiently.
    
    For S3: The API takes a start-after parameter. Registries with many
    repositories can drastically reduce calls to s3 by telling s3 to only
    list results lexographically after the last parameter.
    
    For the fallback: We can start deeper in the tree and avoid statting
    the files and directories before the hint in a walk. For a filesystem
    this improves performance a little, but many of the API based drivers
    are currently treated like a filesystem, so this drastically improves
    the performance of GCP and Azure blob.

Fixes #3678 

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>