### PR TITLE
Skip S3 test if there are no S3 credentials

### DIFF
--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -767,6 +767,10 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 }
 
 func TestListObjectsV2(t *testing.T) {
+	if skipS3() != "" {
+		t.Skip(skipS3())
+	}
+
 	rootDir, err := ioutil.TempDir("", "driver-")
 	if err != nil {
 		t.Fatalf("unexpected error creating temporary directory: %v", err)


### PR DESCRIPTION
The other S3 tests already had it, this one is just missing.

Fixed #3652 

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>