### PR TITLE
Change GET in example request to POST

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -158,7 +158,7 @@ request coming to an endpoint.
 An example of a full event may look as follows:
 
 ```http request
-GET /callback HTTP/1.1
+POST /callback HTTP/1.1
 Host: application/vnd.docker.distribution.events.v1+json
 Authorization: Bearer <your token, if needed>
 Content-Type: application/vnd.docker.distribution.events.v1+json


### PR DESCRIPTION
The example shows a `GET` request to `/callback`, but it looks like it's
intending to show the `POST` request made by the registry to a
notificaitons endpoint. Unless I'm missing something, no `GET` request
should be involved.