### PR TITLE
Add github-release-commenter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,3 +95,11 @@ jobs:
             bin/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: GitHub Release Commenter
+        uses: apexskier/github-release-commenter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            Released {release_link}


### PR DESCRIPTION
This step will notify contributors when their PR (or the issue that PR auto-resolved) was included in a release.

Example: https://github.com/ddelange/pipgrip/pull/90#issuecomment-1180599997