### PR TITLE
Use http.NewRequestWithContext for outgoing HTTP requests

### DIFF
--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -13,6 +13,8 @@ import (
 )
 
 type httpBlobUpload struct {
+	ctx context.Context
+
 	statter distribution.BlobStatter
 	client  *http.Client
 
@@ -36,7 +38,7 @@ func (hbu *httpBlobUpload) handleErrorResponse(resp *http.Response) error {
 }
 
 func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
-	req, err := http.NewRequest("PATCH", hbu.location, ioutil.NopCloser(r))
+	req, err := http.NewRequestWithContext(hbu.ctx, "PATCH", hbu.location, ioutil.NopCloser(r))
 	if err != nil {
 		return 0, err
 	}
@@ -69,7 +71,7 @@ func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
 }
 
 func (hbu *httpBlobUpload) Write(p []byte) (n int, err error) {
-	req, err := http.NewRequest("PATCH", hbu.location, bytes.NewReader(p))
+	req, err := http.NewRequestWithContext(hbu.ctx, "PATCH", hbu.location, bytes.NewReader(p))
 	if err != nil {
 		return 0, err
 	}
@@ -117,7 +119,7 @@ func (hbu *httpBlobUpload) StartedAt() time.Time {
 
 func (hbu *httpBlobUpload) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
 	// TODO(dmcgowan): Check if already finished, if so just fetch
-	req, err := http.NewRequest("PUT", hbu.location, nil)
+	req, err := http.NewRequestWithContext(hbu.ctx, "PUT", hbu.location, nil)
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}
@@ -140,7 +142,7 @@ func (hbu *httpBlobUpload) Commit(ctx context.Context, desc distribution.Descrip
 }
 
 func (hbu *httpBlobUpload) Cancel(ctx context.Context) error {
-	req, err := http.NewRequest("DELETE", hbu.location, nil)
+	req, err := http.NewRequestWithContext(hbu.ctx, "DELETE", hbu.location, nil)
 	if err != nil {
 		return err
 	}

--- a/registry/client/blob_writer_test.go
+++ b/registry/client/blob_writer_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -126,6 +127,7 @@ func TestUploadReadFrom(t *testing.T) {
 	defer c()
 
 	blobUpload := &httpBlobUpload{
+		ctx:    context.Background(),
 		client: &http.Client{},
 	}
 
@@ -265,6 +267,7 @@ func TestUploadSize(t *testing.T) {
 
 	// Writing with ReadFrom
 	blobUpload := &httpBlobUpload{
+		ctx:      context.Background(),
 		client:   &http.Client{},
 		location: e + readFromLocationPath,
 	}
@@ -284,6 +287,7 @@ func TestUploadSize(t *testing.T) {
 
 	// Writing with Write
 	blobUpload = &httpBlobUpload{
+		ctx:      context.Background(),
 		client:   &http.Client{},
 		location: e + writeLocationPath,
 	}
@@ -409,6 +413,7 @@ func TestUploadWrite(t *testing.T) {
 	defer c()
 
 	blobUpload := &httpBlobUpload{
+		ctx:    context.Background(),
 		client: &http.Client{},
 	}
 

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -118,9 +118,7 @@ func (r *registry) Repositories(ctx context.Context, entries []string, last stri
 			return 0, err
 		}
 
-		for cnt := range ctlg.Repositories {
-			entries[cnt] = ctlg.Repositories[cnt]
-		}
+		copy(entries, ctlg.Repositories)
 		numFilled = len(ctlg.Repositories)
 
 		link := resp.Header.Get("Link")
@@ -373,7 +371,7 @@ func (t *tags) Untag(ctx context.Context, tag string) error {
 		return err
 	}
 
-	req, err := http.NewRequest("DELETE", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "DELETE", u, nil)
 	if err != nil {
 		return err
 	}
@@ -792,7 +790,7 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -827,6 +825,7 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 		}
 
 		return &httpBlobUpload{
+			ctx:       ctx,
 			statter:   bs.statter,
 			client:    bs.client,
 			uuid:      uuid,
@@ -845,6 +844,7 @@ func (bs *blobs) Resume(ctx context.Context, id string) (distribution.BlobWriter
 	}
 
 	return &httpBlobUpload{
+		ctx:       ctx,
 		statter:   bs.statter,
 		client:    bs.client,
 		uuid:      id,


### PR DESCRIPTION
This simple change mainly affects the distribution client. By respecting
the context the caller passes in, timeouts and cancellations will work
as expected. Also, transports which rely on the context (such as tracing
transports that retrieve a span from the context) will work properly.