### PR TITLE
Revert "registry/client: set Accept: identity header when getting layers

### DIFF
--- a/registry/client/transport/http_reader.go
+++ b/registry/client/transport/http_reader.go
@@ -183,7 +183,6 @@ func (hrs *httpReadSeeker) reader() (io.Reader, error) {
 		// context.GetLogger(hrs.context).Infof("Range: %s", req.Header.Get("Range"))
 	}
 
-	req.Header.Add("Accept-Encoding", "identity")
 	resp, err := hrs.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- reverts https://github.com/distribution/distribution/pull/2015

This revisits fix provided regarding https://github.com/moby/moby/pull/25122

According to https://www.rfc-editor.org/rfc/rfc9110.html#name-content-encoding
> If the media type includes an inherent encoding, such as a data format that is always compressed, then that encoding would not be restated in Content-Encoding even if it happens to be the same algorithm as one of the content codings.

So, an image layer, served with media type `application/vnd.oci.image.layer.v1.tar+gzip` should not get any additional `Content-Encoding` header set until http server is misconfigured.

Using a preventive `Accept-Encoding: identity` allows to avoid such a misconfiguration to have consequences on image transfert, but on the other hand prevents adoption of any other transport optimization, while the default `net/http` golang transport transparently manages `gzip` and can at least compress json manifests.

This would also make it possible to publish images with uncompressed layers referenced in manifests, and get those served with gzip or a more efficient compression (zstd, or any future algorithm) using encoding negotiation between client and registry.
