### PR TITLE
reference: replace deprecated function SplitHostname

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -177,7 +177,8 @@ func splitDomain(name string) (string, string) {
 // hostname and name string. If no valid hostname is
 // found, the hostname is empty and the full value
 // is returned as name
-// DEPRECATED: Use Domain or Path
+//
+// Deprecated: Use [Domain] or [Path].
 func SplitHostname(named Named) (string, string) {
 	if r, ok := named.(namedRepository); ok {
 		return r.Domain(), r.Path()

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -322,11 +322,13 @@ func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
 
 // TrimNamed removes any tag or digest from the named reference.
 func TrimNamed(ref Named) Named {
-	domain, path := SplitHostname(ref)
-	return repository{
-		domain: domain,
-		path:   path,
+	repo := repository{}
+	if r, ok := ref.(namedRepository); ok {
+		repo.domain, repo.path = r.Domain(), r.Path()
+	} else {
+		repo.domain, repo.path = splitDomain(ref.Name())
 	}
+	return repo
 }
 
 func getBestReferenceType(ref reference) Reference {


### PR DESCRIPTION
Forward-porting the patch from https://github.com/containerd/containerd/commit/694a007543fafe751cbfab07093ba1b3ae58f1b6 (https://github.com/containerd/containerd/pull/5922)
