### PR TITLE
Remove uses of deprecated go-digest.NewDigestFromHex, go-digest.Digest.Hex

### DIFF
--- a/manifest/schema1/config_builder.go
+++ b/manifest/schema1/config_builder.go
@@ -132,7 +132,7 @@ func (mb *configManifestBuilder) Build(ctx context.Context) (m distribution.Mani
 			layerCounter++
 		}
 
-		v1ID := digest.FromBytes([]byte(blobsum.Hex() + " " + parent)).Hex()
+		v1ID := digest.FromBytes([]byte(blobsum.Encoded() + " " + parent)).Encoded()
 
 		if i == 0 && img.RootFS.BaseLayer != "" {
 			// windows-only baselayer setup
@@ -140,18 +140,18 @@ func (mb *configManifestBuilder) Build(ctx context.Context) (m distribution.Mani
 			parent = fmt.Sprintf("%x", baseID[:32])
 		}
 
-		v1Compatibility := v1Compatibility{
+		v1Compat := v1Compatibility{
 			ID:      v1ID,
 			Parent:  parent,
 			Comment: h.Comment,
 			Created: h.Created,
 			Author:  h.Author,
 		}
-		v1Compatibility.ContainerConfig.Cmd = []string{img.History[i].CreatedBy}
+		v1Compat.ContainerConfig.Cmd = []string{img.History[i].CreatedBy}
 		if h.EmptyLayer {
-			v1Compatibility.ThrowAway = true
+			v1Compat.ThrowAway = true
 		}
-		jsonBytes, err := json.Marshal(&v1Compatibility)
+		jsonBytes, err := json.Marshal(&v1Compat)
 		if err != nil {
 			return nil, err
 		}
@@ -178,11 +178,11 @@ func (mb *configManifestBuilder) Build(ctx context.Context) (m distribution.Mani
 	}
 
 	fsLayerList[0] = FSLayer{BlobSum: blobsum}
-	dgst := digest.FromBytes([]byte(blobsum.Hex() + " " + parent + " " + string(mb.configJSON)))
+	dgst := digest.FromBytes([]byte(blobsum.Encoded() + " " + parent + " " + string(mb.configJSON)))
 
 	// Top-level v1compatibility string should be a modified version of the
 	// image config.
-	transformedConfig, err := MakeV1ConfigFromConfig(mb.configJSON, dgst.Hex(), parent, latestHistory.EmptyLayer)
+	transformedConfig, err := MakeV1ConfigFromConfig(mb.configJSON, dgst.Encoded(), parent, latestHistory.EmptyLayer)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/storage/linkedblobstore_test.go
+++ b/registry/storage/linkedblobstore_test.go
@@ -150,7 +150,7 @@ func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
 	// cross-repo mount them into a nm/baz and provide a prepopulated blob descriptor
 	for dgst := range testLayers {
 		fooCanonical, _ := reference.WithDigest(fooRepoName, dgst)
-		size, err := strconv.ParseInt("0x"+dgst.Hex()[:8], 0, 64)
+		size, err := strconv.ParseInt("0x"+dgst.Encoded()[:8], 0, 64)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -451,7 +451,7 @@ func digestPathComponents(dgst digest.Digest, multilevel bool) ([]string, error)
 	}
 
 	algorithm := blobAlgorithmReplacer.Replace(string(dgst.Algorithm()))
-	hex := dgst.Hex()
+	hex := dgst.Encoded()
 	prefix := []string{algorithm}
 
 	var suffix []string
@@ -480,6 +480,6 @@ func digestFromPath(digestPath string) (digest.Digest, error) {
 		algo = next
 	}
 
-	dgst := digest.NewDigestFromHex(algo, hex)
+	dgst := digest.NewDigestFromEncoded(digest.Algorithm(algo), hex)
 	return dgst, dgst.Validate()
 }


### PR DESCRIPTION
- relates to https://github.com/opencontainers/go-digest/pull/83

Both of these were deprecated in https://github.com/opencontainers/go-digest/commit/55f675811a1b915549933c64571fd86b2676ba76 (https://github.com/opencontainers/go-digest/pull/33), but the format of the GoDoc comments didn't follow the correct format, which caused them not being picked up by tools as "deprecated".

This patch updates uses in the codebase to use the alternatives.
