### PR TITLE
reference: use consts for defaults

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-var (
+const (
 	legacyDefaultDomain = "index.docker.io"
 	defaultDomain       = "docker.io"
 	officialRepoName    = "library"


### PR DESCRIPTION
These should never be modified, so better to use consts for them to indicate they're fixed values.
