### PR TITLE
[release/2.8 backport] revert "registry/client: set Accept: identity header when getting layers

### DIFF
--- a/registry/client/transport/http_reader.go
+++ b/registry/client/transport/http_reader.go
@@ -180,7 +180,6 @@ func (hrs *httpReadSeeker) reader() (io.Reader, error) {
 		// context.GetLogger(hrs.context).Infof("Range: %s", req.Header.Get("Range"))
 	}
 
-	req.Header.Add("Accept-Encoding", "identity")
 	resp, err := hrs.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit 16f086a0ec1e6158375ab34eb9c716a3f99b26f5.
see https://github.com/distribution/distribution/pull/3754