### PR TITLE
reference: rewrite various tests to use subtests

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestValidateReferenceName(t *testing.T) {
+	t.Parallel()
 	validRepoNames := []string{
 		"docker/docker",
 		"library/debian",
@@ -70,6 +71,7 @@ func TestValidateReferenceName(t *testing.T) {
 }
 
 func TestValidateRemoteName(t *testing.T) {
+	t.Parallel()
 	validRepositoryNames := []string{
 		// Sanity check.
 		"docker/docker",
@@ -139,6 +141,7 @@ func TestValidateRemoteName(t *testing.T) {
 }
 
 func TestParseRepositoryInfo(t *testing.T) {
+	t.Parallel()
 	type tcase struct {
 		RemoteName, FamiliarName, FullName, AmbiguousName, Domain string
 	}
@@ -292,6 +295,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 }
 
 func TestParseReferenceWithTagAndDigest(t *testing.T) {
+	t.Parallel()
 	shortRef := "busybox:latest@sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa"
 	ref, err := ParseNormalizedNamed(shortRef)
 	if err != nil {
@@ -313,6 +317,7 @@ func TestParseReferenceWithTagAndDigest(t *testing.T) {
 }
 
 func TestInvalidReferenceComponents(t *testing.T) {
+	t.Parallel()
 	if _, err := ParseNormalizedNamed("-foo"); err == nil {
 		t.Fatal("Expected WithName to detect invalid name")
 	}
@@ -355,6 +360,7 @@ func equalReference(r1, r2 Reference) bool {
 }
 
 func TestParseAnyReference(t *testing.T) {
+	t.Parallel()
 	tcases := []struct {
 		Reference  string
 		Equivalent string
@@ -445,6 +451,7 @@ func TestParseAnyReference(t *testing.T) {
 }
 
 func TestNormalizedSplitHostname(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		input  string
 		domain string
@@ -527,6 +534,7 @@ func TestNormalizedSplitHostname(t *testing.T) {
 }
 
 func TestMatchError(t *testing.T) {
+	t.Parallel()
 	named, err := ParseAnyReference("foo")
 	if err != nil {
 		t.Fatal(err)
@@ -538,6 +546,7 @@ func TestMatchError(t *testing.T) {
 }
 
 func TestMatch(t *testing.T) {
+	t.Parallel()
 	matchCases := []struct {
 		reference string
 		pattern   string
@@ -605,6 +614,7 @@ func TestMatch(t *testing.T) {
 }
 
 func TestParseDockerRef(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name     string
 		input    string
@@ -668,6 +678,7 @@ func TestParseDockerRef(t *testing.T) {
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			normalized, err := ParseDockerRef(test.input)
 			if err != nil {
 				t.Fatal(err)

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestReferenceParse(t *testing.T) {
+	t.Parallel()
 	// referenceTestcases is a unified set of testcases for
 	// testing the parsing of references
 	referenceTestcases := []struct {
@@ -269,6 +270,7 @@ func TestReferenceParse(t *testing.T) {
 	for _, testcase := range referenceTestcases {
 		testcase := testcase
 		t.Run(testcase.input, func(t *testing.T) {
+			t.Parallel()
 			repo, err := Parse(testcase.input)
 			if testcase.err != nil {
 				if err == nil {
@@ -329,6 +331,7 @@ func TestReferenceParse(t *testing.T) {
 // TestWithNameFailure tests cases where WithName should fail. Cases where it
 // should succeed are covered by TestSplitHostname, below.
 func TestWithNameFailure(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		input string
 		err   error
@@ -361,6 +364,7 @@ func TestWithNameFailure(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.input, func(t *testing.T) {
+			t.Parallel()
 			_, err := WithName(testcase.input)
 			if err == nil {
 				t.Errorf("no error parsing name. expected: %s", testcase.err)
@@ -370,6 +374,7 @@ func TestWithNameFailure(t *testing.T) {
 }
 
 func TestSplitHostname(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		input  string
 		domain string
@@ -409,6 +414,7 @@ func TestSplitHostname(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.input, func(t *testing.T) {
+			t.Parallel()
 			named, err := WithName(testcase.input)
 			if err != nil {
 				t.Errorf("error parsing name: %s", err)
@@ -430,6 +436,7 @@ type serializationType struct {
 }
 
 func TestSerialization(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		description string
 		input       string
@@ -463,6 +470,7 @@ func TestSerialization(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
+			t.Parallel()
 			m := map[string]string{
 				"Description": testcase.description,
 				"Field":       testcase.input,
@@ -551,6 +559,7 @@ func TestSerialization(t *testing.T) {
 }
 
 func TestWithTag(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name     string
 		digest   digest.Digest
@@ -587,6 +596,7 @@ func TestWithTag(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.combined, func(t *testing.T) {
+			t.Parallel()
 			named, err := WithName(testcase.name)
 			if err != nil {
 				t.Errorf("error parsing name: %s", err)
@@ -611,6 +621,7 @@ func TestWithTag(t *testing.T) {
 }
 
 func TestWithDigest(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name     string
 		digest   digest.Digest
@@ -642,6 +653,7 @@ func TestWithDigest(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.combined, func(t *testing.T) {
+			t.Parallel()
 			named, err := WithName(testcase.name)
 			if err != nil {
 				t.Errorf("error parsing name: %s", err)
@@ -665,6 +677,7 @@ func TestWithDigest(t *testing.T) {
 }
 
 func TestParseNamed(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		input  string
 		domain string
@@ -711,6 +724,7 @@ func TestParseNamed(t *testing.T) {
 	for _, testcase := range testcases {
 		testcase := testcase
 		t.Run(testcase.input, func(t *testing.T) {
+			t.Parallel()
 			named, err := ParseNamed(testcase.input)
 			if err != nil && testcase.err == nil {
 				t.Errorf("error parsing name: %s", err)

--- a/reference/regexp_test.go
+++ b/reference/regexp_test.go
@@ -13,6 +13,7 @@ type regexpMatch struct {
 }
 
 func checkRegexp(t *testing.T, r *regexp.Regexp, m regexpMatch) {
+	t.Helper()
 	matches := r.FindStringSubmatch(m.input)
 	if m.match && matches != nil {
 		if len(matches) != (r.NumSubexp()+1) || matches[0] != m.input {
@@ -34,7 +35,10 @@ func checkRegexp(t *testing.T, r *regexp.Regexp, m regexpMatch) {
 }
 
 func TestDomainRegexp(t *testing.T) {
-	hostcases := []regexpMatch{
+	hostcases := []struct {
+		input string
+		match bool
+	}{
 		{
 			input: "test.com",
 			match: true,
@@ -157,8 +161,14 @@ func TestDomainRegexp(t *testing.T) {
 		},
 	}
 	r := regexp.MustCompile(`^` + DomainRegexp.String() + `$`)
-	for i := range hostcases {
-		checkRegexp(t, r, hostcases[i])
+	for _, tc := range hostcases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			match := r.MatchString(tc.input)
+			if match != tc.match {
+				t.Errorf("Expected match=%t, got %t", tc.match, match)
+			}
+		})
 	}
 }
 
@@ -452,8 +462,11 @@ func TestFullNameRegexp(t *testing.T) {
 			match: false,
 		},
 	}
-	for i := range testcases {
-		checkRegexp(t, anchoredNameRegexp, testcases[i])
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			checkRegexp(t, anchoredNameRegexp, tc)
+		})
 	}
 }
 
@@ -522,13 +535,19 @@ func TestReferenceRegexp(t *testing.T) {
 		},
 	}
 
-	for i := range testcases {
-		checkRegexp(t, ReferenceRegexp, testcases[i])
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			checkRegexp(t, ReferenceRegexp, tc)
+		})
 	}
 }
 
 func TestIdentifierRegexp(t *testing.T) {
-	fullCases := []regexpMatch{
+	fullCases := []struct {
+		input string
+		match bool
+	}{
 		{
 			input: "da304e823d8ca2b9d863a3c897baeb852ba21ea9a9f1414736394ae7fcaf9821",
 			match: true,
@@ -550,7 +569,13 @@ func TestIdentifierRegexp(t *testing.T) {
 			match: false,
 		},
 	}
-	for i := range fullCases {
-		checkRegexp(t, anchoredIdentifierRegexp, fullCases[i])
+	for _, tc := range fullCases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			match := anchoredIdentifierRegexp.MatchString(tc.input)
+			if match != tc.match {
+				t.Errorf("Expected match=%t, got %t", tc.match, match)
+			}
+		})
 	}
 }

--- a/reference/regexp_test.go
+++ b/reference/regexp_test.go
@@ -35,6 +35,7 @@ func checkRegexp(t *testing.T, r *regexp.Regexp, m regexpMatch) {
 }
 
 func TestDomainRegexp(t *testing.T) {
+	t.Parallel()
 	hostcases := []struct {
 		input string
 		match bool
@@ -164,6 +165,7 @@ func TestDomainRegexp(t *testing.T) {
 	for _, tc := range hostcases {
 		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			match := r.MatchString(tc.input)
 			if match != tc.match {
 				t.Errorf("Expected match=%t, got %t", tc.match, match)
@@ -173,6 +175,7 @@ func TestDomainRegexp(t *testing.T) {
 }
 
 func TestFullNameRegexp(t *testing.T) {
+	t.Parallel()
 	if anchoredNameRegexp.NumSubexp() != 2 {
 		t.Fatalf("anchored name regexp should have two submatches: %v, %v != 2",
 			anchoredNameRegexp, anchoredNameRegexp.NumSubexp())
@@ -465,12 +468,14 @@ func TestFullNameRegexp(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			checkRegexp(t, anchoredNameRegexp, tc)
 		})
 	}
 }
 
 func TestReferenceRegexp(t *testing.T) {
+	t.Parallel()
 	if ReferenceRegexp.NumSubexp() != 3 {
 		t.Fatalf("anchored name regexp should have three submatches: %v, %v != 3",
 			ReferenceRegexp, ReferenceRegexp.NumSubexp())
@@ -538,12 +543,14 @@ func TestReferenceRegexp(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			checkRegexp(t, ReferenceRegexp, tc)
 		})
 	}
 }
 
 func TestIdentifierRegexp(t *testing.T) {
+	t.Parallel()
 	fullCases := []struct {
 		input string
 		match bool
@@ -572,6 +579,7 @@ func TestIdentifierRegexp(t *testing.T) {
 	for _, tc := range fullCases {
 		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			match := anchoredIdentifierRegexp.MatchString(tc.input)
 			if match != tc.match {
 				t.Errorf("Expected match=%t, got %t", tc.match, match)

--- a/reference/sort_test.go
+++ b/reference/sort_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestReferenceSorting(t *testing.T) {
+	t.Parallel()
 	digested := func(seed int64) string {
 		b, err := io.ReadAll(io.LimitReader(rand.New(rand.NewSource(seed)), 64))
 		if err != nil {


### PR DESCRIPTION
This replaces the "self-made" subtests with native Go subtests, which makes sure that all test-cases are ran (instead of failing early), and helped with debugging (allows for individual tests to be run).
