### PR TITLE
simplify mocks

### DIFF
--- a/manifest/ocischema/builder_test.go
+++ b/manifest/ocischema/builder_test.go
@@ -12,6 +12,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -19,14 +20,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -37,14 +30,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestBuilder(t *testing.T) {

--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -17,6 +17,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -24,14 +25,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -42,14 +35,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestEmptyTar(t *testing.T) {

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -11,6 +11,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -18,14 +19,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -36,14 +29,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestBuilder(t *testing.T) {

--- a/registry/proxy/proxytagservice_test.go
+++ b/registry/proxy/proxytagservice_test.go
@@ -13,9 +13,8 @@ import (
 type mockTagStore struct {
 	mapping map[string]distribution.Descriptor
 	sync.Mutex
+	distribution.TagService
 }
-
-var _ distribution.TagService = &mockTagStore{}
 
 func (m *mockTagStore) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
 	m.Lock()
@@ -56,10 +55,6 @@ func (m *mockTagStore) All(ctx context.Context) ([]string, error) {
 	}
 
 	return tags, nil
-}
-
-func (m *mockTagStore) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
-	panic("not implemented")
 }
 
 func testProxyTagService(local, remote map[string]distribution.Descriptor) *proxyTagService {


### PR DESCRIPTION
Embed the interface that we're mocking; calling any of it's methods that are not implemented will panic, so should give the same result as before.
