### PR TITLE
reference: clean up regular expressions

### DIFF
--- a/reference/helpers.go
+++ b/reference/helpers.go
@@ -32,7 +32,7 @@ func FamiliarString(ref Reference) string {
 }
 
 // FamiliarMatch reports whether ref matches the specified pattern.
-// See https://godoc.org/path#Match for supported patterns.
+// See [path.Match] for supported patterns.
 func FamiliarMatch(pattern string, ref Reference) (bool, error) {
 	matched, err := path.Match(pattern, FamiliarString(ref))
 	if namedRef, isNamed := ref.(Named); isNamed && !matched {

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -125,7 +125,7 @@ func ParseDockerRef(ref string) (Named, error) {
 // needs to be already validated before.
 func splitDockerDomain(name string) (domain, remainder string) {
 	i := strings.IndexRune(name, '/')
-	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost" && strings.ToLower(name[:i]) == name[:i]) {
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != localhost && strings.ToLower(name[:i]) == name[:i]) {
 		domain, remainder = defaultDomain, name
 	} else {
 		domain, remainder = name[:i], name[i+1:]

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -58,14 +58,14 @@ func ParseNormalizedNamed(s string) (Named, error) {
 		return nil, fmt.Errorf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings", s)
 	}
 	domain, remainder := splitDockerDomain(s)
-	var remoteName string
+	var remote string
 	if tagSep := strings.IndexRune(remainder, ':'); tagSep > -1 {
-		remoteName = remainder[:tagSep]
+		remote = remainder[:tagSep]
 	} else {
-		remoteName = remainder
+		remote = remainder
 	}
-	if strings.ToLower(remoteName) != remoteName {
-		return nil, fmt.Errorf("invalid reference format: repository name (%s) must be lowercase", remoteName)
+	if strings.ToLower(remote) != remote {
+		return nil, fmt.Errorf("invalid reference format: repository name (%s) must be lowercase", remote)
 	}
 
 	ref, err := Parse(domain + "/" + remainder)
@@ -120,7 +120,7 @@ func ParseDockerRef(ref string) (Named, error) {
 	return TagNameOnly(named), nil
 }
 
-// splitDockerDomain splits a repository name to domain and remotename string.
+// splitDockerDomain splits a repository name to domain and remote-name.
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.
 func splitDockerDomain(name string) (domain, remainder string) {

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -8,10 +8,35 @@ import (
 )
 
 const (
+	// legacyDefaultDomain is the legacy domain for Docker Hub (which was
+	// originally named "the Docker Index"). This domain is still used for
+	// authentication and image search, which were part of the "v1" Docker
+	// registry specification.
+	//
+	// This domain will continue to be supported, but there are plans to consolidate
+	// legacy domains to new "canonical" domains. Once those domains are decided
+	// on, we must update the normalization functions, but preserve compatibility
+	// with existing installs, clients, and user configuration.
 	legacyDefaultDomain = "index.docker.io"
-	defaultDomain       = "docker.io"
-	officialRepoPrefix  = "library/"
-	defaultTag          = "latest"
+
+	// defaultDomain is the default domain used for images on Docker Hub.
+	// It is used to normalize "familiar" names to canonical names, for example,
+	// to convert "ubuntu" to "docker.io/library/ubuntu:latest".
+	//
+	// Note that actual domain of Docker Hub's registry is registry-1.docker.io.
+	// This domain will continue to be supported, but there are plans to consolidate
+	// legacy domains to new "canonical" domains. Once those domains are decided
+	// on, we must update the normalization functions, but preserve compatibility
+	// with existing installs, clients, and user configuration.
+	defaultDomain = "docker.io"
+
+	// officialRepoPrefix is the namespace used for official images on Docker Hub.
+	// It is used to normalize "familiar" names to canonical names, for example,
+	// to convert "ubuntu" to "docker.io/library/ubuntu:latest".
+	officialRepoPrefix = "library/"
+
+	// defaultTag is the default tag if no tag is provided.
+	defaultTag = "latest"
 )
 
 // normalizedNamed represents a name which has been

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -96,11 +96,6 @@ func splitDockerDomain(name string) (domain, remainder string) {
 	if domain == legacyDefaultDomain {
 		domain = defaultDomain
 	}
-	// TODO(thaJeztah): this check may be too strict, as it assumes the
-	//  "library/" namespace does not have nested namespaces. While this
-	//  is true (currently), technically it would be possible for Docker
-	//  Hub to use those (e.g. "library/distros/ubuntu:latest").
-	//  See https://github.com/distribution/distribution/pull/3769#issuecomment-1302031785.
 	if domain == defaultDomain && !strings.ContainsRune(remainder, '/') {
 		remainder = officialRepoPrefix + remainder
 	}

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -23,7 +23,6 @@
 //	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
 //
 //	identifier                      := /[a-f0-9]{64}/
-//	short-identifier                := /[a-f0-9]{6,64}/
 package reference
 
 import (
@@ -188,7 +187,6 @@ func SplitHostname(named Named) (string, string) {
 
 // Parse parses s and returns a syntactically valid Reference.
 // If an error was encountered it is returned, along with a nil Reference.
-// NOTE: Parse will not handle short digests.
 func Parse(s string) (Reference, error) {
 	matches := ReferenceRegexp.FindStringSubmatch(s)
 	if matches == nil {
@@ -240,7 +238,6 @@ func Parse(s string) (Reference, error) {
 // the Named interface. The reference must have a name and be in the canonical
 // form, otherwise an error is returned.
 // If an error was encountered it is returned, along with a nil Reference.
-// NOTE: ParseNamed will not handle short digests.
 func ParseNamed(s string) (Named, error) {
 	named, err := ParseNormalizedNamed(s)
 	if err != nil {

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -146,7 +146,7 @@ type namedRepository interface {
 	Path() string
 }
 
-// Domain returns the domain part of the Named reference
+// Domain returns the domain part of the [Named] reference.
 func Domain(named Named) string {
 	if r, ok := named.(namedRepository); ok {
 		return r.Domain()
@@ -155,7 +155,7 @@ func Domain(named Named) string {
 	return domain
 }
 
-// Path returns the name without the domain part of the Named reference
+// Path returns the name without the domain part of the [Named] reference.
 func Path(named Named) (name string) {
 	if r, ok := named.(namedRepository); ok {
 		return r.Path()

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -4,13 +4,14 @@
 // Grammar
 //
 //	reference                       := name [ ":" tag ] [ "@" digest ]
-//	name                            := [domain '/'] path-component ['/' path-component]*
+//	name                            := [domain '/'] remote-name
 //	domain                          := host [':' port-number]
 //	host                            := domain-name | IPv4address | \[ IPv6address \]	; rfc3986 appendix-A
 //	domain-name                     := domain-component ['.' domain-component]*
 //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
+//	path (or "remote-name")         := path-component ['/' path-component]*
 //	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
 //

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -19,6 +19,10 @@ const (
 	// supported names.
 	separator = `(?:[._]|__|[-]*)`
 
+	// localhost is treated as a special value for domain-name. Any other
+	// domain-name without a "." or a ":port" are considered a path component.
+	localhost = `localhost`
+
 	// domainNameComponent restricts the registry domain component of a
 	// repository name to start with a component as defined by DomainRegexp.
 	domainNameComponent = `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -23,6 +23,10 @@ const (
 	// repository name to start with a component as defined by DomainRegexp.
 	domainNameComponent = `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`
 
+	// optionalPort matches an optional port-number including the port separator
+	// (e.g. ":80").
+	optionalPort = `(?::[0-9]+)?`
+
 	// tag matches valid tag names. From docker/docker:graph/tags.go.
 	tag = `[\w][\w.-]{0,127}`
 
@@ -66,7 +70,7 @@ var (
 
 	// allowed by the URI Host subcomponent on rfc3986 to ensure backwards
 	// compatibility with Docker image names.
-	domain = host + optional(`:[0-9]+`)
+	domainAndPort = host + optionalPort
 
 	// DomainRegexp matches hostname or IP-addresses, optionally including a port
 	// number. It defines the structure of potential domain components that may be
@@ -77,7 +81,7 @@ var (
 	// addresses such as IPv4-Mapped).
 	//
 	// [rfc6874]: https://www.rfc-editor.org/rfc/rfc6874.
-	DomainRegexp = regexp.MustCompile(domain)
+	DomainRegexp = regexp.MustCompile(domainAndPort)
 
 	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
 	TagRegexp = regexp.MustCompile(tag)
@@ -97,7 +101,7 @@ var (
 	// character, with following parts able to be separated by a separator
 	// (one period, one or two underscore and multiple dashes).
 	pathComponent = alphanumeric + optional(repeated(separator, alphanumeric))
-	namePat       = optional(domain+`/`) + pathComponent + optional(repeated(`/`+pathComponent))
+	namePat       = optional(domainAndPort+`/`) + pathComponent + optional(repeated(`/`+pathComponent))
 
 	// NameRegexp is the format for the name component of references, including
 	// an optional domain and port, but without tag or digest suffix.
@@ -105,7 +109,7 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domain), `/`), capture(pathComponent, optional(repeated(`/`+pathComponent)))))
+	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(pathComponent, optional(repeated(`/`+pathComponent)))))
 
 	referencePat = anchored(capture(namePat), optional(`:`, capture(tag)), optional(`@`, capture(digestPat)))
 

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -1,6 +1,9 @@
 package reference
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 const (
 	// alphanumeric defines the alphanumeric atom, typically a
@@ -136,37 +139,32 @@ func literal(s string) string {
 // expression defines a full expression, where each regular expression must
 // follow the previous.
 func expression(res ...string) string {
-	var s string
-	for _, re := range res {
-		s += re
-	}
-
-	return s
+	return strings.Join(res, "")
 }
 
 // optional wraps the expression in a non-capturing group and makes the
 // production optional.
 func optional(res ...string) string {
-	return group(expression(res...)) + `?`
+	return group(strings.Join(res, "")) + `?`
 }
 
 // repeated wraps the regexp in a non-capturing group to get one or more
 // matches.
 func repeated(res ...string) string {
-	return group(expression(res...)) + `+`
+	return group(strings.Join(res, "")) + `+`
 }
 
 // group wraps the regexp in a non-capturing group.
 func group(res ...string) string {
-	return `(?:` + expression(res...) + `)`
+	return `(?:` + strings.Join(res, "") + `)`
 }
 
 // capture wraps the expression in a capturing group.
 func capture(res ...string) string {
-	return `(` + expression(res...) + `)`
+	return `(` + strings.Join(res, "") + `)`
 }
 
 // anchored anchors the regular expression by adding start and end delimiters.
 func anchored(res ...string) string {
-	return `^` + expression(res...) + `$`
+	return `^` + strings.Join(res, "") + `$`
 }

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -96,9 +96,8 @@ var (
 	nameComponent = expression(alphanumeric, optional(repeated(separator, alphanumeric)))
 	namePat       = expression(optional(domain, literal(`/`)), nameComponent, optional(repeated(literal(`/`), nameComponent)))
 
-	// NameRegexp is the format for the name component of references. The
-	// regexp has capturing groups for the domain and name part omitting
-	// the separating forward slash from either.
+	// NameRegexp is the format for the name component of references, including
+	// an optional domain and port, but without tag or digest suffix.
 	NameRegexp = regexp.MustCompile(namePat)
 
 	// anchoredNameRegexp is used to parse a name value, capturing the

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -90,11 +90,11 @@ var (
 	// end of the matched string.
 	anchoredDigestRegexp = regexp.MustCompile(anchored(digestPat))
 
-	// nameComponent restricts registry path component names to start
-	// with at least one letter or number, with following parts able to be
-	// separated by one period, one or two underscore and multiple dashes.
-	nameComponent = expression(alphanumeric, optional(repeated(separator, alphanumeric)))
-	namePat       = expression(optional(domain, literal(`/`)), nameComponent, optional(repeated(literal(`/`), nameComponent)))
+	// pathComponent restricts registry path-components to start with at least
+	// one letter or number, with following parts able to be separated by one
+	// period, one or two underscore and multiple dashes.
+	pathComponent = expression(alphanumeric, optional(repeated(separator, alphanumeric)))
+	namePat       = expression(optional(domain, literal(`/`)), pathComponent, optional(repeated(literal(`/`), pathComponent)))
 
 	// NameRegexp is the format for the name component of references, including
 	// an optional domain and port, but without tag or digest suffix.
@@ -102,7 +102,7 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domain), literal(`/`)), capture(nameComponent, optional(repeated(literal(`/`), nameComponent)))))
+	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domain), literal(`/`)), capture(pathComponent, optional(repeated(literal(`/`), pathComponent)))))
 
 	referencePat = anchored(capture(namePat), optional(literal(":"), capture(tag)), optional(literal("@"), capture(digestPat)))
 

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -2,13 +2,13 @@ package reference
 
 import "regexp"
 
-var (
-	// alphaNumeric defines the alpha numeric atom, typically a
+const (
+	// alphanumeric defines the alphanumeric atom, typically a
 	// component of names. This only allows lower case characters and digits.
-	alphaNumeric = `[a-z0-9]+`
+	alphanumeric = `[a-z0-9]+`
 
 	// separator defines the separators allowed to be embedded in name
-	// components. This allow one period, one or two underscore and multiple
+	// components. This allows one period, one or two underscore and multiple
 	// dashes. Repeated dashes and underscores are intentionally treated
 	// differently. In order to support valid hostnames as name components,
 	// supporting repeated dash was added. Additionally double underscore is
@@ -16,33 +16,43 @@ var (
 	// supported names.
 	separator = `(?:[._]|__|[-]*)`
 
-	// nameComponent restricts registry path component names to start
-	// with at least one letter or number, with following parts able to be
-	// separated by one period, one or two underscore and multiple dashes.
-	nameComponent = expression(
-		alphaNumeric,
-		optional(repeated(separator, alphaNumeric)))
-
 	// domainNameComponent restricts the registry domain component of a
 	// repository name to start with a component as defined by DomainRegexp.
 	domainNameComponent = `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`
+
+	// tag matches valid tag names. From docker/docker:graph/tags.go.
+	tag = `[\w][\w.-]{0,127}`
+
+	// digestPat matches well-formed digests, including algorithm (e.g. "sha256:<encoded>").
+	//
+	// TODO(thaJeztah): this should follow the same rules as https://pkg.go.dev/github.com/opencontainers/go-digest@v1.0.0#DigestRegexp
+	// so that go-digest defines the canonical format. Note that the go-digest is
+	// more relaxed:
+	//   - it allows multiple algorithms (e.g. "sha256+b64:<encoded>") to allow
+	//     future expansion of supported algorithms.
+	//   - it allows the "<encoded>" value to use urlsafe base64 encoding as defined
+	//     in [rfc4648, section 5].
+	//
+	// [rfc4648, section 5]: https://www.rfc-editor.org/rfc/rfc4648#section-5.
+	digestPat = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`
+
+	// identifier is the format for a content addressable identifier using sha256.
+	// These identifiers are like digests without the algorithm, since sha256 is used.
+	identifier = `([a-f0-9]{64})`
 
 	// ipv6address are enclosed between square brackets and may be represented
 	// in many ways, see rfc5952. Only IPv6 in compressed or uncompressed format
 	// are allowed, IPv6 zone identifiers (rfc6874) or Special addresses such as
 	// IPv4-Mapped are deliberately excluded.
-	ipv6address = expression(
-		literal(`[`), `(?:[a-fA-F0-9:]+)`, literal(`]`),
-	)
+	ipv6address = `\[(?:[a-fA-F0-9:]+)\]`
+)
 
+var (
 	// domainName defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names. This includes IPv4 addresses on decimal format.
-	domainName = expression(
-		domainNameComponent,
-		optional(repeated(literal(`.`), domainNameComponent)),
-	)
+	domainName = expression(domainNameComponent, optional(repeated(literal(`.`), domainNameComponent)))
 
 	// host defines the structure of potential domains based on the URI
 	// Host subcomponent on rfc3986. It may be a subset of DNS domain name,
@@ -53,69 +63,63 @@ var (
 
 	// allowed by the URI Host subcomponent on rfc3986 to ensure backwards
 	// compatibility with Docker image names.
-	domain = expression(
-		host,
-		optional(literal(`:`), `[0-9]+`))
+	domain = expression(host, optional(literal(`:`), `[0-9]+`))
 
-	// DomainRegexp defines the structure of potential domain components
-	// that may be part of image names. This is purposely a subset of what is
-	// allowed by DNS to ensure backwards compatibility with Docker image
-	// names.
+	// DomainRegexp matches hostname or IP-addresses, optionally including a port
+	// number. It defines the structure of potential domain components that may be
+	// part of image names. This is purposely a subset of what is allowed by DNS to
+	// ensure backwards compatibility with Docker image names. It may be a subset of
+	// DNS domain name, an IPv4 address in decimal format, or an IPv6 address between
+	// square brackets (excluding zone identifiers as defined by [rfc6874] or special
+	// addresses such as IPv4-Mapped).
+	//
+	// [rfc6874]: https://www.rfc-editor.org/rfc/rfc6874.
 	DomainRegexp = regexp.MustCompile(domain)
 
-	tag = `[\w][\w.-]{0,127}`
 	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
 	TagRegexp = regexp.MustCompile(tag)
 
-	anchoredTag = anchored(tag)
 	// anchoredTagRegexp matches valid tag names, anchored at the start and
 	// end of the matched string.
-	anchoredTagRegexp = regexp.MustCompile(anchoredTag)
+	anchoredTagRegexp = regexp.MustCompile(anchored(tag))
 
-	digestPat = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`
-	// DigestRegexp matches valid digests.
+	// DigestRegexp matches well-formed digests, including algorithm (e.g. "sha256:<encoded>").
 	DigestRegexp = regexp.MustCompile(digestPat)
 
-	anchoredDigest = anchored(digestPat)
 	// anchoredDigestRegexp matches valid digests, anchored at the start and
 	// end of the matched string.
-	anchoredDigestRegexp = regexp.MustCompile(anchoredDigest)
+	anchoredDigestRegexp = regexp.MustCompile(anchored(digestPat))
 
-	namePat = expression(
-		optional(domain, literal(`/`)),
-		nameComponent,
-		optional(repeated(literal(`/`), nameComponent)))
+	// nameComponent restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponent = expression(alphanumeric, optional(repeated(separator, alphanumeric)))
+	namePat       = expression(optional(domain, literal(`/`)), nameComponent, optional(repeated(literal(`/`), nameComponent)))
+
 	// NameRegexp is the format for the name component of references. The
 	// regexp has capturing groups for the domain and name part omitting
 	// the separating forward slash from either.
 	NameRegexp = regexp.MustCompile(namePat)
 
-	anchoredName = anchored(
-		optional(capture(domain), literal(`/`)),
-		capture(nameComponent,
-			optional(repeated(literal(`/`), nameComponent))))
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchoredName)
+	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domain), literal(`/`)), capture(nameComponent, optional(repeated(literal(`/`), nameComponent)))))
 
-	referencePat = anchored(capture(namePat),
-		optional(literal(":"), capture(tag)),
-		optional(literal("@"), capture(digestPat)))
+	referencePat = anchored(capture(namePat), optional(literal(":"), capture(tag)), optional(literal("@"), capture(digestPat)))
+
 	// ReferenceRegexp is the full supported format of a reference. The regexp
 	// is anchored and has capturing groups for name, tag, and digest
 	// components.
 	ReferenceRegexp = regexp.MustCompile(referencePat)
 
-	identifier = `([a-f0-9]{64})`
 	// IdentifierRegexp is the format for string identifier used as a
 	// content addressable identifier using sha256. These identifiers
 	// are like digests without the algorithm, since sha256 is used.
 	IdentifierRegexp = regexp.MustCompile(identifier)
 
-	anchoredIdentifier = anchored(identifier)
 	// anchoredIdentifierRegexp is used to check or match an
 	// identifier value, anchored at start and end of string.
-	anchoredIdentifierRegexp = regexp.MustCompile(anchoredIdentifier)
+	anchoredIdentifierRegexp = regexp.MustCompile(anchored(identifier))
 )
 
 // literal compiles s into a literal regular expression, escaping any regexp

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -55,7 +55,7 @@ var (
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names. This includes IPv4 addresses on decimal format.
-	domainName = expression(domainNameComponent, optional(repeated(`\.`+domainNameComponent)))
+	domainName = domainNameComponent + optional(repeated(`\.`+domainNameComponent))
 
 	// host defines the structure of potential domains based on the URI
 	// Host subcomponent on rfc3986. It may be a subset of DNS domain name,
@@ -66,7 +66,7 @@ var (
 
 	// allowed by the URI Host subcomponent on rfc3986 to ensure backwards
 	// compatibility with Docker image names.
-	domain = expression(host, optional(`:[0-9]+`))
+	domain = host + optional(`:[0-9]+`)
 
 	// DomainRegexp matches hostname or IP-addresses, optionally including a port
 	// number. It defines the structure of potential domain components that may be
@@ -96,8 +96,8 @@ var (
 	// pathComponent restricts path-components to start with an alphanumeric
 	// character, with following parts able to be separated by a separator
 	// (one period, one or two underscore and multiple dashes).
-	pathComponent = expression(alphanumeric, optional(repeated(separator, alphanumeric)))
-	namePat       = expression(optional(domain+`/`), pathComponent, optional(repeated(`/`+pathComponent)))
+	pathComponent = alphanumeric + optional(repeated(separator, alphanumeric))
+	namePat       = optional(domain+`/`) + pathComponent + optional(repeated(`/`+pathComponent))
 
 	// NameRegexp is the format for the name component of references, including
 	// an optional domain and port, but without tag or digest suffix.
@@ -123,12 +123,6 @@ var (
 	// identifier value, anchored at start and end of string.
 	anchoredIdentifierRegexp = regexp.MustCompile(anchored(identifier))
 )
-
-// expression defines a full expression, where each regular expression must
-// follow the previous.
-func expression(res ...string) string {
-	return strings.Join(res, "")
-}
 
 // optional wraps the expression in a non-capturing group and makes the
 // production optional.

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -59,7 +59,7 @@ var (
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names. This includes IPv4 addresses on decimal format.
-	domainName = domainNameComponent + optional(repeated(`\.`+domainNameComponent))
+	domainName = domainNameComponent + anyTimes(`\.`+domainNameComponent)
 
 	// host defines the structure of potential domains based on the URI
 	// Host subcomponent on rfc3986. It may be a subset of DNS domain name,
@@ -100,8 +100,8 @@ var (
 	// pathComponent restricts path-components to start with an alphanumeric
 	// character, with following parts able to be separated by a separator
 	// (one period, one or two underscore and multiple dashes).
-	pathComponent = alphanumeric + optional(repeated(separator, alphanumeric))
-	namePat       = optional(domainAndPort+`/`) + pathComponent + optional(repeated(`/`+pathComponent))
+	pathComponent = alphanumeric + anyTimes(separator+alphanumeric)
+	namePat       = optional(domainAndPort+`/`) + pathComponent + anyTimes(`/`+pathComponent)
 
 	// NameRegexp is the format for the name component of references, including
 	// an optional domain and port, but without tag or digest suffix.
@@ -109,7 +109,7 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(pathComponent, optional(repeated(`/`+pathComponent)))))
+	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(pathComponent, anyTimes(`/`+pathComponent))))
 
 	referencePat = anchored(capture(namePat), optional(`:`, capture(tag)), optional(`@`, capture(digestPat)))
 
@@ -134,10 +134,10 @@ func optional(res ...string) string {
 	return `(?:` + strings.Join(res, "") + `)?`
 }
 
-// repeated wraps the regexp in a non-capturing group to get one or more
-// matches.
-func repeated(res ...string) string {
-	return `(?:` + strings.Join(res, "") + `)+`
+// anyTimes wraps the expression in a non-capturing group that can occur
+// any number of times.
+func anyTimes(res ...string) string {
+	return `(?:` + strings.Join(res, "") + `)*`
 }
 
 // capture wraps the expression in a capturing group.

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -101,7 +101,13 @@ var (
 	// character, with following parts able to be separated by a separator
 	// (one period, one or two underscore and multiple dashes).
 	pathComponent = alphanumeric + anyTimes(separator+alphanumeric)
-	namePat       = optional(domainAndPort+`/`) + pathComponent + anyTimes(`/`+pathComponent)
+
+	// remoteName matches the remote-name of a repository. It consists of one
+	// or more forward slash (/) delimited path-components:
+	//
+	//	pathComponent[[/pathComponent] ...] // e.g., "library/ubuntu"
+	remoteName = pathComponent + anyTimes(`/`+pathComponent)
+	namePat    = optional(domainAndPort+`/`) + remoteName
 
 	// NameRegexp is the format for the name component of references, including
 	// an optional domain and port, but without tag or digest suffix.
@@ -109,7 +115,7 @@ var (
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
-	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(pathComponent, anyTimes(`/`+pathComponent))))
+	anchoredNameRegexp = regexp.MustCompile(anchored(optional(capture(domainAndPort), `/`), capture(remoteName)))
 
 	referencePat = anchored(capture(namePat), optional(`:`, capture(tag)), optional(`@`, capture(digestPat)))
 

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -145,18 +145,13 @@ func expression(res ...string) string {
 // optional wraps the expression in a non-capturing group and makes the
 // production optional.
 func optional(res ...string) string {
-	return group(strings.Join(res, "")) + `?`
+	return `(?:` + strings.Join(res, "") + `)?`
 }
 
 // repeated wraps the regexp in a non-capturing group to get one or more
 // matches.
 func repeated(res ...string) string {
-	return group(strings.Join(res, "")) + `+`
-}
-
-// group wraps the regexp in a non-capturing group.
-func group(res ...string) string {
-	return `(?:` + strings.Join(res, "") + `)`
+	return `(?:` + strings.Join(res, "") + `)+`
 }
 
 // capture wraps the expression in a capturing group.

--- a/reference/sort.go
+++ b/reference/sort.go
@@ -20,14 +20,16 @@ import (
 	"sort"
 )
 
-// Sort sorts string references preferring higher information references
+// Sort sorts string references preferring higher information references.
+//
 // The precedence is as follows:
-// 1. Name + Tag + Digest
-// 2. Name + Tag
-// 3. Name + Digest
-// 4. Name
-// 5. Digest
-// 6. Parse error
+//
+//  1. [Named] + [Tagged] + [Digested] (e.g., "docker.io/library/busybox:latest@sha256:<digest>")
+//  2. [Named] + [Tagged]              (e.g., "docker.io/library/busybox:latest")
+//  3. [Named] + [Digested]            (e.g., "docker.io/library/busybo@sha256:<digest>")
+//  4. [Named]                         (e.g., "docker.io/library/busybox")
+//  5. [Digested]                      (e.g., "docker.io@sha256:<digest>")
+//  6. Parse error
 func Sort(references []string) []string {
 	var prefs []Reference
 	var bad []string


### PR DESCRIPTION
⚠️ for reviewers: best to review this commit-by-commit


This PR:

- moves more regular expressions to be a const
- renames / introduces some variables to better match the grammar or to be more descriptive
- updates some documentation comments to describe regular expressions
- removes some abstraction; the package tried to abstract away regular expression patterns with utilities, but in doing so became a bit of a "regular expression generating machine". The verbosity of these utilities sometimes drowned the actual intent. I tried to reduce verbosity, but maintain readability by using descriptive variable and const-names.
- Moves exported regexes separate from the non-exported ones, and moves them to their own "var" declarations, which allows them to be documented separately (including the use of links) to improve the presentation on pkg.go.dev.

Before:

<img width="1252" alt="Screenshot 2022-11-09 at 15 28 58" src="https://user-images.githubusercontent.com/1804568/201231664-b8dd36f2-c7d3-4cf7-95e8-da548714195f.png">


After: 


<img width="1004" alt="Screenshot 2022-11-11 at 01 07 38" src="https://user-images.githubusercontent.com/1804568/201231911-ed334222-4c74-4d28-99f2-00202fac66ca.png">
