### PR TITLE
Fix json formatting in registry api docs

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -266,7 +266,8 @@ are reported as part of 4xx responses, in a json response body. One or more
 errors will be returned in the following format:
 
     {
-        "errors": [{
+        "errors": [
+            {
                 "code": <error identifier>,
                 "message": <message describing condition>,
                 "detail": <unstructured>
@@ -434,17 +435,16 @@ manifest will be returned, with the following format (see
 [docker/docker#8093](https://github.com/docker/docker/issues/8093) for details):
 
     {
-       "name": <name>,
-       "tag": <tag>,
-       "fsLayers": [
-          {
-             "blobSum": <digest>
-          },
-          ...
-        ]
-       ],
-       "history": <v1 images>,
-       "signature": <JWS>
+        "name": <name>,
+        "tag": <tag>,
+        "fsLayers": [
+            {
+                "blobSum": <digest>
+            },
+            ...
+        ],
+        "history": <v1 images>,
+        "signature": <JWS>
     }
 
 The client should verify the returned manifest signature for authenticity
@@ -825,18 +825,17 @@ image manifest. An image can be pushed using the following request format:
     Content-Type: <manifest media type>
 
     {
-       "name": <name>,
-       "tag": <tag>,
-       "fsLayers": [
-          {
-             "blobSum": <digest>
-          },
-          ...
-        ]
-       ],
-       "history": <v1 images>,
-       "signature": <JWS>,
-       ...
+        "name": <name>,
+        "tag": <tag>,
+        "fsLayers": [
+            {
+                "blobSum": <digest>
+            },
+            ...
+        ],
+        "history": <v1 images>,
+        "signature": <JWS>,
+        ...
     }
 
 The `name` and `reference` fields of the response body must match those
@@ -855,7 +854,8 @@ identifying the missing blob. An error is returned for each unknown blob. The
 response format is as follows:
 
     {
-        "errors": [{
+        "errors": [
+            {
                 "code": "BLOB_UNKNOWN",
                 "message": "blob unknown to registry",
                 "detail": {
@@ -886,10 +886,10 @@ The response will be in the following format:
 Content-Type: application/json
 
 {
-  "repositories": [
-    <name>,
-    ...
-  ]
+    "repositories": [
+        <name>,
+        ...
+    ]
 }
 ```
 
@@ -933,10 +933,10 @@ Content-Type: application/json
 Link: <<url>?n=<n from the request>&last=<last repository in response>>; rel="next"
 
 {
-  "repositories": [
-    <name>,
-    ...
-  ]
+    "repositories": [
+        <name>,
+        ...
+    ]
 }
 ```
 
@@ -1043,11 +1043,11 @@ Content-Type: application/json
 Link: <<url>?n=<n from the request>&last=<last tag value from previous response>>; rel="next"
 
 {
-  "name": <name>,
-  "tags": [
-    <tag>,
-    ...
-  ]
+    "name": <name>,
+    "tags": [
+        <tag>,
+        ...
+    ]
 }
 ```
 
@@ -1764,17 +1764,16 @@ Docker-Content-Digest: <digest>
 Content-Type: <media type of manifest>
 
 {
-   "name": <name>,
-   "tag": <tag>,
-   "fsLayers": [
-      {
-         "blobSum": "<digest>"
-      },
-      ...
-    ]
-   ],
-   "history": <v1 images>,
-   "signature": <JWS>
+    "name": <name>,
+    "tag": <tag>,
+    "fsLayers": [
+        {
+            "blobSum": "<digest>"
+        },
+        ...
+    ],
+    "history": <v1 images>,
+    "signature": <JWS>
 }
 ```
 
@@ -1984,17 +1983,16 @@ Authorization: <scheme> <token>
 Content-Type: <media type of manifest>
 
 {
-   "name": <name>,
-   "tag": <tag>,
-   "fsLayers": [
-      {
-         "blobSum": "<digest>"
-      },
-      ...
-    ]
-   ],
-   "history": <v1 images>,
-   "signature": <JWS>
+    "name": <name>,
+    "tag": <tag>,
+    "fsLayers": [
+        {
+            "blobSum": "<digest>"
+        },
+        ...
+    ],
+    "history": <v1 images>,
+    "signature": <JWS>
 }
 ```
 
@@ -2226,7 +2224,8 @@ The error codes that may be included in the response body are enumerated below:
 Content-Type: application/json
 
 {
-    "errors": [{
+    "errors": [
+        {
             "code": "BLOB_UNKNOWN",
             "message": "blob unknown to registry",
             "detail": {
@@ -5499,7 +5498,7 @@ Content-Type: application/json
 	"repositories": [
 		<name>,
 		...
-	]
+	],
 	"next": "<url>?last=<name>&n=<last value of n>"
 }
 ```


### PR DESCRIPTION
Currently the formatting of example JSON is a bit inconsistent. This PR makes sure they are all formatted using a 4 space indent, and resolves some minor syntax errors.