### PR TITLE
reference: use named capturing groups

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -35,8 +35,6 @@ func TestValidateReferenceName(t *testing.T) {
 		// when specified with a hostname, it removes the ambiguity from about
 		// whether the value is an identifier or repository name
 		"docker.io/1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
-		"Docker/docker",
-		"DOCKER/docker",
 	}
 	invalidRepoNames := []string{
 		"https://github.com/docker/docker",
@@ -53,6 +51,8 @@ func TestValidateReferenceName(t *testing.T) {
 		"[fe80::1%eth0]:5000/debian",
 		"[2001:db8:3:4::192.0.2.33]:5000/debian",
 		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+		"Docker/docker",
+		"DOCKER/docker",
 	}
 
 	for _, name := range invalidRepoNames {
@@ -247,17 +247,17 @@ func TestParseRepositoryInfo(t *testing.T) {
 		},
 		{
 			RemoteName:    "bar",
-			FamiliarName:  "Foo/bar",
-			FullName:      "Foo/bar",
+			FamiliarName:  "Foo.com/bar",
+			FullName:      "Foo.com/bar",
 			AmbiguousName: "",
-			Domain:        "Foo",
+			Domain:        "Foo.com",
 		},
 		{
 			RemoteName:    "bar",
-			FamiliarName:  "FOO/bar",
-			FullName:      "FOO/bar",
+			FamiliarName:  "FOO.COM/bar",
+			FullName:      "FOO.COM/bar",
 			AmbiguousName: "",
-			Domain:        "FOO",
+			Domain:        "FOO.COM",
 		},
 	}
 

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -101,12 +101,10 @@ func TestReferenceParse(t *testing.T) {
 			input: "Uppercase:tag",
 			err:   ErrNameContainsUppercase,
 		},
-		// FIXME "Uppercase" is incorrectly handled as a domain-name here, therefore passes.
-		// See https://github.com/distribution/distribution/pull/1778, and https://github.com/docker/docker/pull/20175
-		// {
-		//	input: "Uppercase/lowercase:tag",
-		//	err:   ErrNameContainsUppercase,
-		// },
+		{
+			input: "Uppercase/lowercase:tag",
+			err:   ErrNameContainsUppercase,
+		},
 		{
 			input: "test:5000/Uppercase/lowercase:tag",
 			err:   ErrNameContainsUppercase,
@@ -122,7 +120,6 @@ func TestReferenceParse(t *testing.T) {
 		},
 		{
 			input:      strings.Repeat("a/", 127) + "a:tag-puts-this-over-max",
-			domain:     "a",
 			repository: strings.Repeat("a/", 127) + "a",
 			tag:        "tag-puts-this-over-max",
 		},
@@ -167,7 +164,6 @@ func TestReferenceParse(t *testing.T) {
 		},
 		{
 			input:      "foo/foo_bar.com:8080",
-			domain:     "foo",
 			repository: "foo/foo_bar.com",
 			tag:        "8080",
 		},
@@ -541,7 +537,7 @@ func TestSerialization(t *testing.T) {
 
 			b2, err := json.Marshal(st)
 			if err != nil {
-				t.Errorf("error marshing serialization type: %v", err)
+				t.Errorf("error marshaling serialization type: %v", err)
 			}
 
 			if string(b) != string(b2) {


### PR DESCRIPTION
- [x] depends on https://github.com/distribution/distribution/pull/3883

Rewrite the regular expressions to use named capturing groups.
This simplifies handling the resulting matches, but does require
some additional handling to associate matches with their names.

Also making some changes to the matching to match how domains
are _actually_ matched; some of that was already handled in
code parsing the results of the regex, but now this is handled
by the regex itself.

Before:

    BenchmarkParse
    BenchmarkParse-10              12696             93805 ns/op            9311 B/op        185 allocs/op
    PASS


After:

    BenchmarkParse
    BenchmarkParse-10              12486             94774 ns/op           18617 B/op        178 allocs/op
    PASS

Benchstat:

    go test -run='^$' -bench=. -count=10 ./reference/ > old.txt
    go test -run='^$' -bench=. -count=10 ./reference/ > new.txt

    benchstat old.txt new.txt
    name       old time/op    new time/op    delta
    Parse-10   91.7µs ± 0%    97.0µs ±11%   +5.82%  (p=0.000 n=9+10)

    name       old alloc/op   new alloc/op   delta
    Parse-10    9.32kB ± 0%   18.63kB ± 0%  +99.93%  (p=0.000 n=10+10)

    name       old allocs/op  new allocs/op  delta
    Parse-10        185 ± 0%       178 ± 0%   -3.78%  (p=0.000 n=10+10)
