### PR TITLE
minor fixes and enhancements

### DIFF
--- a/manifest/manifestlist/manifestlist_test.go
+++ b/manifest/manifestlist/manifestlist_test.go
@@ -12,7 +12,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var expectedManifestListSerialization = []byte(`{
+const expectedManifestListSerialization = `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "manifests": [
@@ -38,7 +38,7 @@ var expectedManifestListSerialization = []byte(`{
          }
       }
    ]
-}`)
+}`
 
 func makeTestManifestList(t *testing.T, mediaType string) ([]ManifestDescriptor, *DeserializedManifestList) {
 	manifestDescriptors := []ManifestDescriptor{
@@ -85,17 +85,17 @@ func TestManifestList(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&deserialized.ManifestList, "", "   ")
+	expected, err := json.MarshalIndent(&deserialized.ManifestList, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest list: %v", err)
 	}
-	if !bytes.Equal(p, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(p))
+	if !bytes.Equal(expected, canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", string(expected), string(canonical))
 	}
 
 	// Check that the canonical field has the expected value.
-	if !bytes.Equal(expectedManifestListSerialization, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(expectedManifestListSerialization))
+	if !bytes.Equal([]byte(expectedManifestListSerialization), canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", expectedManifestListSerialization, string(canonical))
 	}
 
 	var unmarshalled DeserializedManifestList
@@ -136,7 +136,7 @@ func TestManifestList(t *testing.T) {
 // Requires changes to distribution/distribution/manifest/manifestlist.ManifestList and .ManifestDescriptor
 // and associated serialization APIs in manifestlist.go. Or split the OCI index and
 // docker manifest list implementations, which would require a lot of refactoring.
-var expectedOCIImageIndexSerialization = []byte(`{
+const expectedOCIImageIndexSerialization = `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [
@@ -177,7 +177,7 @@ var expectedOCIImageIndexSerialization = []byte(`{
          }
       }
    ]
-}`)
+}`
 
 func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]ManifestDescriptor, *DeserializedManifestList) {
 	manifestDescriptors := []ManifestDescriptor{
@@ -234,17 +234,17 @@ func TestOCIImageIndex(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&deserialized.ManifestList, "", "   ")
+	expected, err := json.MarshalIndent(&deserialized.ManifestList, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest list: %v", err)
 	}
-	if !bytes.Equal(p, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(p))
+	if !bytes.Equal(expected, canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", string(expected), string(canonical))
 	}
 
 	// Check that the canonical field has the expected value.
-	if !bytes.Equal(expectedOCIImageIndexSerialization, canonical) {
-		t.Fatalf("manifest bytes not equal to expected: %q != %q", string(canonical), string(expectedOCIImageIndexSerialization))
+	if !bytes.Equal([]byte(expectedOCIImageIndexSerialization), canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", expectedOCIImageIndexSerialization, string(canonical))
 	}
 
 	var unmarshalled DeserializedManifestList

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -93,17 +93,17 @@ func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
 	copy(m.canonical, b)
 
 	// Unmarshal canonical JSON into Manifest object
-	var manifest Manifest
-	if err := json.Unmarshal(m.canonical, &manifest); err != nil {
+	var mfst Manifest
+	if err := json.Unmarshal(m.canonical, &mfst); err != nil {
 		return err
 	}
 
-	if manifest.MediaType != "" && manifest.MediaType != v1.MediaTypeImageManifest {
+	if mfst.MediaType != "" && mfst.MediaType != v1.MediaTypeImageManifest {
 		return fmt.Errorf("if present, mediaType in manifest should be '%s' not '%s'",
-			v1.MediaTypeImageManifest, manifest.MediaType)
+			v1.MediaTypeImageManifest, mfst.MediaType)
 	}
 
-	m.Manifest = manifest
+	m.Manifest = mfst
 
 	return nil
 }

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -13,7 +13,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var expectedManifestSerialization = []byte(`{
+const expectedManifestSerialization = `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "config": {
@@ -37,7 +37,7 @@ var expectedManifestSerialization = []byte(`{
    "annotations": {
       "hot": "potato"
    }
-}`)
+}`
 
 func makeTestManifest(mediaType string) Manifest {
 	return Manifest{
@@ -79,17 +79,17 @@ func TestManifest(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&mfst, "", "   ")
+	expected, err := json.MarshalIndent(&mfst, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest: %v", err)
 	}
-	if !bytes.Equal(p, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(p))
+	if !bytes.Equal(expected, canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", string(expected), string(canonical))
 	}
 
 	// Check that canonical field matches expected value.
-	if !bytes.Equal(expectedManifestSerialization, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(expectedManifestSerialization))
+	if !bytes.Equal([]byte(expectedManifestSerialization), canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", expectedManifestSerialization, string(canonical))
 	}
 
 	var unmarshalled DeserializedManifest

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -64,9 +64,9 @@ func makeTestManifest(mediaType string) Manifest {
 }
 
 func TestManifest(t *testing.T) {
-	manifest := makeTestManifest(v1.MediaTypeImageManifest)
+	mfst := makeTestManifest(v1.MediaTypeImageManifest)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := FromStruct(mfst)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifest: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestManifest(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&manifest, "", "   ")
+	p, err := json.MarshalIndent(&mfst, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest: %v", err)
 	}
@@ -143,9 +143,9 @@ func TestManifest(t *testing.T) {
 }
 
 func mediaTypeTest(t *testing.T, mediaType string, shouldError bool) {
-	manifest := makeTestManifest(mediaType)
+	mfst := makeTestManifest(mediaType)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := FromStruct(mfst)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifest: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestMediaTypes(t *testing.T) {
 }
 
 func TestValidateManifest(t *testing.T) {
-	manifest := Manifest{
+	mfst := Manifest{
 		Config: distribution.Descriptor{Size: 1},
 		Layers: []distribution.Descriptor{{Size: 2}},
 	}
@@ -196,7 +196,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 	}
 	t.Run("valid", func(t *testing.T) {
-		b, err := json.Marshal(manifest)
+		b, err := json.Marshal(mfst)
 		if err != nil {
 			t.Fatal("unexpected error marshaling manifest", err)
 		}

--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -126,12 +126,12 @@ func (sm *SignedManifest) UnmarshalJSON(b []byte) error {
 	copy(sm.Canonical, bytes)
 
 	// Unmarshal canonical JSON into Manifest object
-	var manifest Manifest
-	if err := json.Unmarshal(sm.Canonical, &manifest); err != nil {
+	var mfst Manifest
+	if err := json.Unmarshal(sm.Canonical, &mfst); err != nil {
 		return err
 	}
 
-	sm.Manifest = manifest
+	sm.Manifest = mfst
 
 	return nil
 }

--- a/manifest/schema1/manifest_test.go
+++ b/manifest/schema1/manifest_test.go
@@ -21,13 +21,13 @@ func TestManifestMarshaling(t *testing.T) {
 
 	// Check that the all field is the same as json.MarshalIndent with these
 	// parameters.
-	p, err := json.MarshalIndent(env.signed, "", "   ")
+	expected, err := json.MarshalIndent(env.signed, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest: %v", err)
 	}
 
-	if !bytes.Equal(p, env.signed.all) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(env.signed.all), string(p))
+	if !bytes.Equal(expected, env.signed.all) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", string(expected), string(env.signed.all))
 	}
 }
 

--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -109,17 +109,17 @@ func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
 	copy(m.canonical, b)
 
 	// Unmarshal canonical JSON into Manifest object
-	var manifest Manifest
-	if err := json.Unmarshal(m.canonical, &manifest); err != nil {
+	var mfst Manifest
+	if err := json.Unmarshal(m.canonical, &mfst); err != nil {
 		return err
 	}
 
-	if manifest.MediaType != MediaTypeManifest {
+	if mfst.MediaType != MediaTypeManifest {
 		return fmt.Errorf("mediaType in manifest should be '%s' not '%s'",
-			MediaTypeManifest, manifest.MediaType)
+			MediaTypeManifest, mfst.MediaType)
 	}
 
-	m.Manifest = manifest
+	m.Manifest = mfst
 
 	return nil
 }

--- a/manifest/schema2/manifest_test.go
+++ b/manifest/schema2/manifest_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/distribution/distribution/v3/manifest"
 )
 
-var expectedManifestSerialization = []byte(`{
+const expectedManifestSerialization = `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "config": {
@@ -25,7 +25,7 @@ var expectedManifestSerialization = []byte(`{
          "digest": "sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b"
       }
    ]
-}`)
+}`
 
 func makeTestManifest(mediaType string) Manifest {
 	return Manifest{
@@ -64,17 +64,17 @@ func TestManifest(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&mfst, "", "   ")
+	expected, err := json.MarshalIndent(&mfst, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest: %v", err)
 	}
-	if !bytes.Equal(p, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(p))
+	if !bytes.Equal(expected, canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", string(expected), string(canonical))
 	}
 
 	// Check that canonical field matches expected value.
-	if !bytes.Equal(expectedManifestSerialization, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(expectedManifestSerialization))
+	if !bytes.Equal([]byte(expectedManifestSerialization), canonical) {
+		t.Fatalf("manifest bytes not equal:\nexpected:\n%s\nactual:\n%s\n", expectedManifestSerialization, string(canonical))
 	}
 
 	var unmarshalled DeserializedManifest

--- a/manifest/schema2/manifest_test.go
+++ b/manifest/schema2/manifest_test.go
@@ -49,9 +49,9 @@ func makeTestManifest(mediaType string) Manifest {
 }
 
 func TestManifest(t *testing.T) {
-	manifest := makeTestManifest(MediaTypeManifest)
+	mfst := makeTestManifest(MediaTypeManifest)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := FromStruct(mfst)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifest: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestManifest(t *testing.T) {
 
 	// Check that the canonical field is the same as json.MarshalIndent
 	// with these parameters.
-	p, err := json.MarshalIndent(&manifest, "", "   ")
+	p, err := json.MarshalIndent(&mfst, "", "   ")
 	if err != nil {
 		t.Fatalf("error marshaling manifest: %v", err)
 	}
@@ -119,9 +119,9 @@ func TestManifest(t *testing.T) {
 }
 
 func mediaTypeTest(t *testing.T, mediaType string, shouldError bool) {
-	manifest := makeTestManifest(mediaType)
+	mfst := makeTestManifest(mediaType)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := FromStruct(mfst)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifest: %v", err)
 	}

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -33,8 +33,8 @@ type manifestStoreTestEnv struct {
 
 func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string, options ...RegistryOption) *manifestStoreTestEnv {
 	ctx := context.Background()
-	driver := inmemory.New()
-	registry, err := NewRegistry(ctx, driver, options...)
+	drvr := inmemory.New()
+	registry, err := NewRegistry(ctx, drvr, options...)
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
@@ -46,7 +46,7 @@ func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string, opt
 
 	return &manifestStoreTestEnv{
 		ctx:        ctx,
-		driver:     driver,
+		driver:     drvr,
 		registry:   registry,
 		repository: repo,
 		name:       name,
@@ -434,25 +434,25 @@ func testOCIManifestStorage(t *testing.T, testname string, includeMediaTypes boo
 		builder.AppendReference(distribution.Descriptor{Digest: dgst})
 	}
 
-	manifest, err := builder.Build(ctx)
+	mfst, err := builder.Build(ctx)
 	if err != nil {
 		t.Fatalf("%s: unexpected error generating manifest: %v", testname, err)
 	}
 
 	// before putting the manifest test for proper handling of SchemaVersion
 
-	if manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion != 2 {
+	if mfst.(*ocischema.DeserializedManifest).Manifest.SchemaVersion != 2 {
 		t.Fatalf("%s: unexpected error generating default version for oci manifest", testname)
 	}
-	manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 0
+	mfst.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 0
 
 	var manifestDigest digest.Digest
-	if manifestDigest, err = ms.Put(ctx, manifest); err != nil {
+	if manifestDigest, err = ms.Put(ctx, mfst); err != nil {
 		if err.Error() != "unrecognized manifest schema version 0" {
 			t.Fatalf("%s: unexpected error putting manifest: %v", testname, err)
 		}
-		manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 2
-		if manifestDigest, err = ms.Put(ctx, manifest); err != nil {
+		mfst.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 2
+		if manifestDigest, err = ms.Put(ctx, mfst); err != nil {
 			t.Fatalf("%s: unexpected error putting manifest: %v", testname, err)
 		}
 	}

--- a/testutil/manifests.go
+++ b/testutil/manifests.go
@@ -42,7 +42,7 @@ func MakeManifestList(blobstatter distribution.BlobStatter, manifestDigests []di
 // MakeSchema1Manifest constructs a schema 1 manifest from a given list of digests and returns
 // the digest of the manifest
 func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error) {
-	manifest := schema1.Manifest{
+	mfst := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
@@ -50,9 +50,9 @@ func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error)
 		Tag:  "cares",
 	}
 
-	for _, digest := range digests {
-		manifest.FSLayers = append(manifest.FSLayers, schema1.FSLayer{BlobSum: digest})
-		manifest.History = append(manifest.History, schema1.History{V1Compatibility: ""})
+	for _, d := range digests {
+		mfst.FSLayers = append(mfst.FSLayers, schema1.FSLayer{BlobSum: d})
+		mfst.History = append(mfst.History, schema1.History{V1Compatibility: ""})
 	}
 
 	pk, err := libtrust.GenerateECP256PrivateKey()
@@ -60,7 +60,7 @@ func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error)
 		return nil, fmt.Errorf("unexpected error generating private key: %v", err)
 	}
 
-	signedManifest, err := schema1.Sign(&manifest, pk)
+	signedManifest, err := schema1.Sign(&mfst, pk)
 	if err != nil {
 		return nil, fmt.Errorf("error signing manifest: %v", err)
 	}
@@ -74,14 +74,14 @@ func MakeSchema2Manifest(repository distribution.Repository, digests []digest.Di
 	ctx := context.Background()
 	blobStore := repository.Blobs(ctx)
 	builder := schema2.NewManifestBuilder(blobStore, schema2.MediaTypeImageConfig, []byte{})
-	for _, digest := range digests {
-		builder.AppendReference(distribution.Descriptor{Digest: digest})
+	for _, d := range digests {
+		builder.AppendReference(distribution.Descriptor{Digest: d})
 	}
 
-	manifest, err := builder.Build(ctx)
+	mfst, err := builder.Build(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error generating manifest: %v", err)
 	}
 
-	return manifest, nil
+	return mfst, nil
 }

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -96,7 +96,7 @@ func CreateRandomLayers(n int) (map[digest.Digest]io.ReadSeeker, error) {
 // UploadBlobs lets you upload blobs to a repository
 func UploadBlobs(repository distribution.Repository, layers map[digest.Digest]io.ReadSeeker) error {
 	ctx := context.Background()
-	for digest, rs := range layers {
+	for dgst, rs := range layers {
 		wr, err := repository.Blobs(ctx).Create(ctx)
 		if err != nil {
 			return fmt.Errorf("unexpected error creating upload: %v", err)
@@ -106,7 +106,7 @@ func UploadBlobs(repository distribution.Repository, layers map[digest.Digest]io
 			return fmt.Errorf("unexpected error copying to upload: %v", err)
 		}
 
-		if _, err := wr.Commit(ctx, distribution.Descriptor{Digest: digest}); err != nil {
+		if _, err := wr.Commit(ctx, distribution.Descriptor{Digest: dgst}); err != nil {
 			return fmt.Errorf("unexpected error committinng upload: %v", err)
 		}
 	}


### PR DESCRIPTION
Extracting this from a branch I'm working on;


- Fix some variables that collided with imports
- Use consts for fixed values 
- Improve test-output for some compares to assist in debugging;

manifest: improve test output and use const
Use consts to make clear these values are fixed, and improve the output
to make it clearer which part is the expected output, and which part
the actual.

Before this:

    === RUN   TestManifest
        manifest_test.go:87: manifest bytes not equal: "{\n   \"schemaVersion\": 2,\n   \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\",\n   \"config\": {\n      \"mediaType\": \"application/vnd.oci.image.config.v1+json\",\n      \"size\": 985,\n      \"digest\": \"sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b\",\n      \"annotations\": {\n         \"apple\": \"orange\"\n      }\n   },\n   \"layers\": [\n      {\n         \"mediaType\": \"application/vnd.oci.image.layer.v1.tar+gzip\",\n         \"size\": 153263,\n         \"digest\": \"sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b\",\n         \"annotations\": {\n            \"lettuce\": \"wrap\"\n         }\n      }\n   ],\n   \"annotations\": {\n      \"hot\": \"potato\"\n   }\n}" != "{\n   \"schemaVersion\": 2,\n   \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\",\n   \"config\": {\n      \"mediaType\": \"application/vnd.oci.image.config.v1+json\",\n      \"size\": 985,\n      \"digest\": \"sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b\",\n      \"annotations\": {\n         \"apple\": \"orange\"\n      }\n   },\n   \"layers\": [\n      {\n         \"mediaType\": \"application/vnd.oci.image.layer.v1.tar+gzip\",\n         \"size\": 153263,\n         \"digest\": \"sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b\",\n         \"annotations\": {\n            \"lettuce\": \"wrap\"\n         }\n      }\n   ],\n   \"annotations\": {\n      \"hot\": \"potato\"\n   }\n}"
    --- FAIL: TestManifest (0.00s)

After this:

    === RUN   TestManifest
        manifest_test.go:72: manifest bytes not equal:
            expected:
            {
               "schemaVersion": 2,
               "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
               "config": {
                  "mediaType": "application/vnd.docker.container.image.v1+json",
                  "size": 985,
                  "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
               },
               "layers": [
                  {
                     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                     "size": 153263,
                     "digest": "sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b"
                  }
               ]
            }
            actual:
            {
               "schemaVersion": 2,
               "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
               "config": {
                  "mediaType": "application/vnd.docker.container.image.v1+json",
                  "size": 985,
                  "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
               },
               "layers": [
                  {
                     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                     "size": 153263,
                     "digest": "sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b"
                  }
               ]
            }
    --- FAIL: TestManifest (0.00s)
