### PR TITLE
remove script directory and fuzz left-overs

### DIFF
--- a/script/oss_fuzz_build.sh
+++ b/script/oss_fuzz_build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -eu
-
-sed 's/parserFuzzer/ParserFuzzer/g' -i ./configuration/fuzz.go
-sed 's/fuzzParseNormalizedNamed/FuzzParseNormalizedNamed/g' -i ./reference/fuzz.go
-sed 's/fuzzParseForwardedHeader/FuzzParseForwardedHeader/g' -i ./registry/api/v2/fuzz.go
-
-compile_go_fuzzer github.com/distribution/distribution/v3/configuration ParserFuzzer parser_fuzzer
-compile_go_fuzzer github.com/distribution/distribution/v3/reference FuzzParseNormalizedNamed fuzz_parsed_normalized_named
-compile_go_fuzzer github.com/distribution/distribution/v3/registry/api/v2 FuzzParseForwardedHeader fuzz_parse_forwarded_header


### PR DESCRIPTION
- follow-up to https://github.com/distribution/distribution/pull/3794

commit 9337b8df6644390f427162143ee8c83ad3db7c96 (https://github.com/distribution/distribution/pull/3794) rewrote the fuzzers to native go fuzzers, so the script was no longer needed. With this, the script directory is no longer used, so we can remove it.
