### PR TITLE
Fix separator regex to disallow empty strings

### DIFF
--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -50,7 +50,7 @@ const (
 	// supporting repeated dash was added. Additionally double underscore is
 	// now allowed as a separator to loosen the restriction for previously
 	// supported names.
-	separator = `(?:[._]|__|[-]*)`
+	separator = `(?:[._]|__|[-]+)`
 
 	// localhost is treated as a special value for domain-name. Any other
 	// domain-name without a "." or a ":port" are considered a path component.


### PR DESCRIPTION
It looks like the current expression accepts an empty string as a valid separator.

Context: I was attempting to use this regex in a different language and it was hanging on certain inputs. I'm guessing that allowing empty string as a separator here causes pathological behaviors in some regex implementations. Digging around related context, it looks like the intention here was to allow for one or more dashes, and not to accept empty strings.

At the moment, separator is only used here:

```
pathComponent = alphanumeric + anyTimes(separator+alphanumeric)
```

But since alphanumeric is defined as `[a-z0-9]+`, anything that matched with the empty string behavior should still match.

Signed-off-by: Chris K. Wong <chriskw.xyz@gmail.com>