### PR TITLE
fix for issue #3820 failed to make validate-git in local env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bin/*
 
 # Cover profiles
 *.out
+coverage.txt
 
 # Editor/IDE specific files.
 *.sublime-project

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Used to populate version variable in main package.
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
 REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
-
+COMMIT_RANGE ?= $(shell git reflog show --no-abbrev --format='%h..HEAD')
 
 PKG=github.com/distribution/distribution/v3
 
@@ -104,7 +104,7 @@ lint: ## run all linters
 	docker buildx bake $@
 
 validate-git: ## validate git
-	docker buildx bake $@
+	COMMIT_RANGE=$(COMMIT_RANGE) docker buildx bake $@
 
 validate-vendor: ## validate vendor
 	docker buildx bake $@

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,7 +12,7 @@ target "lint" {
 }
 
 variable "COMMIT_RANGE" {
-  default = ""
+  default = "HEAD..HEAD"
 }
 target "validate-git" {
   dockerfile = "./dockerfiles/git.Dockerfile"


### PR DESCRIPTION
On running make validate-git
On my local mac cloned from the main brunch
Seems the default for the variable at "docker-bake.hcl" COMMIT_RANGE = ""
Is causing the make command to exit with error:
COMMIT_RANGE required
This is set with correct values in the git actions process, and pass. But should also be executed and pass in local env.

Solution:
updating the default in the docker-"bake.hcl" file as naive value of `HEAD..HEAD` and overriding it with local env values from the "Makefile".

in addition adding the "coverage.txt" file to the git ignore so it will not get checked in.

Signed-off-by: alik42 <alik.rogotner@gmail.com>