### PR TITLE
add double newlines in ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,11 @@
 Docker Hub https://hub.docker.com/
+
 GitLab Container Registry https://docs.gitlab.com/ee/user/packages/container_registry/
+
 GitHub Container Registry https://docs.github.com/en/free-pro-team@latest/packages/guides/about-github-container-registry
+
 Harbor, CNCF Graduated project https://goharbor.io/
+
 VMware Harbor Registry https://docs.pivotal.io/partners/vmware-harbor/index.html
+
 DigitalOcean Container Registry https://www.digitalocean.com/products/container-registry/


### PR DESCRIPTION
Using double newlines in markdown makes it easier to read in markdown readers, e.g github