### PR TITLE
Concurrent Lookup in TagStore

### DIFF
--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -203,10 +203,7 @@ func (repo *repository) Named() reference.Named {
 }
 
 func (repo *repository) Tags(ctx context.Context) distribution.TagService {
-	tags := &tagStore{
-		repository: repo,
-		blobStore:  repo.registry.blobStore,
-	}
+	tags := NewStore(repo, repo.registry.blobStore)
 
 	return tags
 }

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -203,7 +203,7 @@ func (repo *repository) Named() reference.Named {
 }
 
 func (repo *repository) Tags(ctx context.Context) distribution.TagService {
-	tags := NewStore(repo, repo.registry.blobStore)
+	tags := NewStore(ctx, repo, repo.registry.blobStore)
 
 	return tags
 }


### PR DESCRIPTION
Based on https://github.com/distribution/distribution/pull/3589 (boldly stealed the tests)
Channel aware limiter approach
Fixes https://github.com/distribution/distribution/issues/3525 
Tested on 2.6 TiB (~160k blobs and manifests eligible for deletion) repo cleaned down to 500GiB less than 24h (Harbor project)