### PR TITLE
add HEAD request for ManifestService

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -52,6 +52,9 @@ type ManifestService interface {
 	// Exists returns true if the manifest exists.
 	Exists(ctx context.Context, dgst digest.Digest) (bool, error)
 
+	// Head retrieves the manifest digest by the given tag
+	Head(ctx context.Context, tag string) (digest.Digest, error)
+
 	// Get retrieves the manifest specified by the given digest
 	Get(ctx context.Context, dgst digest.Digest, options ...ManifestServiceOption) (Manifest, error)
 

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -39,6 +39,18 @@ func (pms proxyManifestStore) Exists(ctx context.Context, dgst digest.Digest) (b
 	return pms.remoteManifests.Exists(ctx, dgst)
 }
 
+func (pms proxyManifestStore) Head(ctx context.Context, tag string) (digest.Digest, error) {
+	dgst, err := pms.localManifests.Head(ctx, tag)
+	if err == nil {
+		return dgst, nil
+	}
+	if err := pms.authChallenger.tryEstablishChallenges(ctx); err != nil {
+		return "", err
+	}
+
+	return pms.remoteManifests.Head(ctx, tag)
+}
+
 func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	// At this point `dgst` was either specified explicitly, or returned by the
 	// tagstore with the most recent association.

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -71,6 +71,17 @@ func (ms *manifestStore) Exists(ctx context.Context, dgst digest.Digest) (bool, 
 	return true, nil
 }
 
+func (ms *manifestStore) Head(ctx context.Context, tag string) (digest.Digest, error) {
+	dcontext.GetLogger(ms.ctx).Debug("(*manifestStore).Head")
+
+	desc, err := ms.repository.Tags(ctx).Get(ctx, tag)
+	if err != nil {
+		return "", err
+	}
+
+	return desc.Digest, nil
+}
+
 func (ms *manifestStore) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestStore).Get")
 


### PR DESCRIPTION
Unlike the existing `Exists` function, the `Head` function takes a tag as an argument and returns a digest linked to that tag.

**Motivation**
I wanted to make sure that the local manifest is the latest one linked to given tag.