### PR TITLE
Update fossa-contrib/fossa-action action to v2

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run FOSSA scan and upload build data
-        uses: fossa-contrib/fossa-action@v1
+        uses: fossa-contrib/fossa-action@v2
         with:
           fossa-api-key: cac3dc8d4f2ba86142f6c0f2199a160f


### PR DESCRIPTION
This release contains only a change that updates the runtime that will be deprecated, so it's safe to update.
https://github.com/fossa-contrib/fossa-action/releases/tag/v2.0.0