### PR TITLE
.github/workflows: use go install instead of go get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
           sudo apt-get -q update
           sudo -E apt-get -yq --no-install-suggests --no-install-recommends install python2-minimal
-          cd /tmp && go get -u github.com/vbatts/git-validation
+          cd /tmp && go install github.com/vbatts/git-validation@latest
 
     - name: Build
       working-directory: ./src/github.com/docker/distribution


### PR DESCRIPTION
for details, see:
 * https://github.com/vbatts/git-validation/commit/1e62ff3cc8bfa8a928fe18e5bece0ce11aa9248b
 * https://github.com/vbatts/git-validation/issues/56