### PR TITLE
runtime error: slice bounds out of range [33:7]

### DIFF
--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -138,7 +138,11 @@ func compareReplaceInline(s1, s2 string, old, new byte) int {
 // with Walk to do handling with repositories in a storage.
 func handleRepository(fileInfo driver.FileInfo, root, last string, fn func(repoPath string) error) error {
 	filePath := fileInfo.Path()
-
+	
+	if len(filePath) <= len(root) {
+		return nil
+	}
+	
 	// lop the base path off
 	repo := filePath[len(root)+1:]
 


### PR DESCRIPTION
when data is huge and driver response with a limit frequency, the 'runtime error: slice bounds out of range [33:7]' error may occur.