### PR TITLE
Split OCI Image Index from Docker Manifest List

### DIFF
--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -23,13 +23,6 @@ var SchemaVersion = manifest.Versioned{
 	MediaType:     MediaTypeManifestList,
 }
 
-// OCISchemaVersion provides a pre-initialized version structure for this
-// packages OCIschema version of the manifest.
-var OCISchemaVersion = manifest.Versioned{
-	SchemaVersion: 2,
-	MediaType:     v1.MediaTypeImageIndex,
-}
-
 func init() {
 	manifestListFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
 		m := new(DeserializedManifestList)
@@ -51,31 +44,6 @@ func init() {
 	err := distribution.RegisterManifestSchema(MediaTypeManifestList, manifestListFunc)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to register manifest: %s", err))
-	}
-
-	imageIndexFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
-		if err := validateIndex(b); err != nil {
-			return nil, distribution.Descriptor{}, err
-		}
-		m := new(DeserializedManifestList)
-		err := m.UnmarshalJSON(b)
-		if err != nil {
-			return nil, distribution.Descriptor{}, err
-		}
-
-		if m.MediaType != "" && m.MediaType != v1.MediaTypeImageIndex {
-			err = fmt.Errorf("if present, mediaType in image index should be '%s' not '%s'",
-				v1.MediaTypeImageIndex, m.MediaType)
-
-			return nil, distribution.Descriptor{}, err
-		}
-
-		dgst := digest.FromBytes(b)
-		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeImageIndex}, err
-	}
-	err = distribution.RegisterManifestSchema(v1.MediaTypeImageIndex, imageIndexFunc)
-	if err != nil {
-		panic(fmt.Sprintf("Unable to register OCI Image Index: %s", err))
 	}
 }
 
@@ -154,18 +122,11 @@ type DeserializedManifestList struct {
 // DeserializedManifestList which contains the resulting manifest list
 // and its JSON representation.
 func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedManifestList, error) {
-	var mediaType string
-	if len(descriptors) > 0 && descriptors[0].Descriptor.MediaType == v1.MediaTypeImageManifest {
-		mediaType = v1.MediaTypeImageIndex
-	} else {
-		mediaType = MediaTypeManifestList
-	}
-
-	return FromDescriptorsWithMediaType(descriptors, mediaType)
+	return fromDescriptorsWithMediaType(descriptors, MediaTypeManifestList)
 }
 
-// FromDescriptorsWithMediaType is for testing purposes, it's useful to be able to specify the media type explicitly
-func FromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType string) (*DeserializedManifestList, error) {
+// fromDescriptorsWithMediaType is for testing purposes, it's useful to be able to specify the media type explicitly
+func fromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType string) (*DeserializedManifestList, error) {
 	m := ManifestList{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
@@ -215,32 +176,21 @@ func (m *DeserializedManifestList) MarshalJSON() ([]byte, error) {
 // Payload returns the raw content of the manifest list. The contents can be
 // used to calculate the content identifier.
 func (m DeserializedManifestList) Payload() (string, []byte, error) {
-	var mediaType string
-	if m.MediaType == "" {
-		mediaType = v1.MediaTypeImageIndex
-	} else {
-		mediaType = m.MediaType
-	}
-
-	return mediaType, m.canonical, nil
+	return m.MediaType, m.canonical, nil
 }
 
-// unknownDocument represents a manifest, manifest list, or index that has not
-// yet been validated
-type unknownDocument struct {
-	Config interface{} `json:"config,omitempty"`
-	Layers interface{} `json:"layers,omitempty"`
-}
-
-// validateIndex returns an error if the byte slice is invalid JSON or if it
+// validateManifestList returns an error if the byte slice is invalid JSON or if it
 // contains fields that belong to a manifest
-func validateIndex(b []byte) error {
-	var doc unknownDocument
+func validateManifestList(b []byte) error {
+	var doc struct {
+		Config interface{} `json:"config,omitempty"`
+		Layers interface{} `json:"layers,omitempty"`
+	}
 	if err := json.Unmarshal(b, &doc); err != nil {
 		return err
 	}
 	if doc.Config != nil || doc.Layers != nil {
-		return errors.New("index: expected index but found manifest")
+		return errors.New("manifestlist: expected list but found manifest")
 	}
 	return nil
 }

--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -129,7 +129,7 @@ func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedManifestLis
 func fromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType string) (*DeserializedManifestList, error) {
 	m := ManifestList{
 		Versioned: manifest.Versioned{
-			SchemaVersion: 2,
+			SchemaVersion: SchemaVersion.SchemaVersion,
 			MediaType:     mediaType,
 		},
 	}

--- a/manifest/ocischema/index.go
+++ b/manifest/ocischema/index.go
@@ -1,0 +1,168 @@
+package ocischema
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/manifest"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// OCISchemaVersion provides a pre-initialized version structure for this
+// packages OCIschema version of the manifest.
+var OCISchemaVersion = manifest.Versioned{
+	SchemaVersion: 2,
+	MediaType:     v1.MediaTypeImageIndex,
+}
+
+func init() {
+	imageIndexFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		if err := validateIndex(b); err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+		m := new(DeserializedImageIndex)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		if m.MediaType != "" && m.MediaType != v1.MediaTypeImageIndex {
+			err = fmt.Errorf("if present, mediaType in image index should be '%s' not '%s'",
+				v1.MediaTypeImageIndex, m.MediaType)
+
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeImageIndex}, err
+	}
+	err := distribution.RegisterManifestSchema(v1.MediaTypeImageIndex, imageIndexFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register OCI Image Index: %s", err))
+	}
+}
+
+// A ManifestDescriptor references a platform-specific manifest.
+type ManifestDescriptor struct {
+	distribution.Descriptor
+
+	// Platform specifies which platform the manifest pointed to by the
+	// descriptor runs on.
+	Platform *v1.Platform `json:"platform,omitempty"`
+}
+
+// ImageIndex references manifests for various platforms.
+type ImageIndex struct {
+	manifest.Versioned
+
+	// Manifests references a list of manifests
+	Manifests []ManifestDescriptor `json:"manifests"`
+}
+
+// References returns the distribution descriptors for the referenced image
+// manifests.
+func (ii ImageIndex) References() []distribution.Descriptor {
+	dependencies := make([]distribution.Descriptor, len(ii.Manifests))
+	for i := range ii.Manifests {
+		dependencies[i] = ii.Manifests[i].Descriptor
+		dependencies[i].Platform = ii.Manifests[i].Platform
+	}
+
+	return dependencies
+}
+
+// DeserializedImageIndex wraps ManifestList with a copy of the original
+// JSON.
+type DeserializedImageIndex struct {
+	ImageIndex
+
+	// canonical is the canonical byte representation of the Manifest.
+	canonical []byte
+}
+
+// FromDescriptors takes a slice of descriptors, and returns a
+// DeserializedManifestList which contains the resulting manifest list
+// and its JSON representation.
+func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedImageIndex, error) {
+	return fromDescriptorsWithMediaType(descriptors, v1.MediaTypeImageIndex)
+}
+
+// fromDescriptorsWithMediaType is for testing purposes, it's useful to be able to specify the media type explicitly
+func fromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType string) (*DeserializedImageIndex, error) {
+	m := ImageIndex{
+		Versioned: manifest.Versioned{
+			SchemaVersion: 2,
+			MediaType:     mediaType,
+		},
+	}
+
+	m.Manifests = make([]ManifestDescriptor, len(descriptors))
+	copy(m.Manifests, descriptors)
+
+	deserialized := DeserializedImageIndex{
+		ImageIndex: m,
+	}
+
+	var err error
+	deserialized.canonical, err = json.MarshalIndent(&m, "", "   ")
+	return &deserialized, err
+}
+
+// UnmarshalJSON populates a new ManifestList struct from JSON data.
+func (m *DeserializedImageIndex) UnmarshalJSON(b []byte) error {
+	m.canonical = make([]byte, len(b))
+	// store manifest list in canonical
+	copy(m.canonical, b)
+
+	// Unmarshal canonical JSON into ManifestList object
+	var manifestList ImageIndex
+	if err := json.Unmarshal(m.canonical, &manifestList); err != nil {
+		return err
+	}
+
+	m.ImageIndex = manifestList
+
+	return nil
+}
+
+// MarshalJSON returns the contents of canonical. If canonical is empty,
+// marshals the inner contents.
+func (m *DeserializedImageIndex) MarshalJSON() ([]byte, error) {
+	if len(m.canonical) > 0 {
+		return m.canonical, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedImageIndex")
+}
+
+// Payload returns the raw content of the manifest list. The contents can be
+// used to calculate the content identifier.
+func (m DeserializedImageIndex) Payload() (string, []byte, error) {
+	var mediaType string
+	if m.MediaType == "" {
+		mediaType = v1.MediaTypeImageIndex
+	} else {
+		mediaType = m.MediaType
+	}
+
+	return mediaType, m.canonical, nil
+}
+
+// validateIndex returns an error if the byte slice is invalid JSON or if it
+// contains fields that belong to a manifest
+func validateIndex(b []byte) error {
+	var doc struct {
+		Config interface{} `json:"config,omitempty"`
+		Layers interface{} `json:"layers,omitempty"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return err
+	}
+	if doc.Config != nil || doc.Layers != nil {
+		return errors.New("index: expected index but found manifest")
+	}
+	return nil
+}

--- a/manifest/ocischema/index.go
+++ b/manifest/ocischema/index.go
@@ -60,6 +60,10 @@ type ImageIndex struct {
 
 	// Manifests references a list of manifests
 	Manifests []ManifestDescriptor `json:"manifests"`
+
+	// Annotations is an optional field that contains arbitrary metadata for the
+	// image index
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // References returns the distribution descriptors for the referenced image
@@ -83,20 +87,22 @@ type DeserializedImageIndex struct {
 	canonical []byte
 }
 
-// FromDescriptors takes a slice of descriptors, and returns a
-// DeserializedManifestList which contains the resulting manifest list
-// and its JSON representation.
-func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedImageIndex, error) {
-	return fromDescriptorsWithMediaType(descriptors, v1.MediaTypeImageIndex)
+// FromDescriptors takes a slice of descriptors and a map of annotations, and
+// returns a DeserializedManifestList which contains the resulting manifest list
+// and its JSON representation. If annotations is nil or empty then the
+// annotations property will be omitted from the JSON representation.
+func FromDescriptors(descriptors []ManifestDescriptor, annotations map[string]string) (*DeserializedImageIndex, error) {
+	return fromDescriptorsWithMediaType(descriptors, annotations, v1.MediaTypeImageIndex)
 }
 
 // fromDescriptorsWithMediaType is for testing purposes, it's useful to be able to specify the media type explicitly
-func fromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType string) (*DeserializedImageIndex, error) {
+func fromDescriptorsWithMediaType(descriptors []ManifestDescriptor, annotations map[string]string, mediaType string) (*DeserializedImageIndex, error) {
 	m := ImageIndex{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
 			MediaType:     mediaType,
 		},
+		Annotations: annotations,
 	}
 
 	m.Manifests = make([]ManifestDescriptor, len(descriptors))

--- a/manifest/ocischema/index_test.go
+++ b/manifest/ocischema/index_test.go
@@ -51,34 +51,28 @@ const expectedOCIImageIndexSerialization = `{
    }
 }`
 
-func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]ManifestDescriptor, *DeserializedImageIndex) {
-	manifestDescriptors := []ManifestDescriptor{
+func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]distribution.Descriptor, *DeserializedImageIndex) {
+	manifestDescriptors := []distribution.Descriptor{
 		{
-			Descriptor: distribution.Descriptor{
-				MediaType: "application/vnd.oci.image.manifest.v1+json",
-				Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
-				Size:      985,
-			},
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+			Size:      985,
 			Platform: &v1.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			},
 		},
 		{
-			Descriptor: distribution.Descriptor{
-				MediaType:   "application/vnd.oci.image.manifest.v1+json",
-				Digest:      "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
-				Size:        985,
-				Annotations: map[string]string{"platform": "none"},
-			},
+			MediaType:   "application/vnd.oci.image.manifest.v1+json",
+			Digest:      "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+			Size:        985,
+			Annotations: map[string]string{"platform": "none"},
 		},
 		{
-			Descriptor: distribution.Descriptor{
-				MediaType:   "application/vnd.oci.image.manifest.v1+json",
-				Digest:      "sha256:6346340964309634683409684360934680934608934608934608934068934608",
-				Size:        2392,
-				Annotations: map[string]string{"what": "for"},
-			},
+			MediaType:   "application/vnd.oci.image.manifest.v1+json",
+			Digest:      "sha256:6346340964309634683409684360934680934608934608934608934068934608",
+			Size:        2392,
+			Annotations: map[string]string{"what": "for"},
 			Platform: &v1.Platform{
 				Architecture: "sun4m",
 				OS:           "sunos",
@@ -135,15 +129,8 @@ func TestOCIImageIndex(t *testing.T) {
 	if len(references) != 3 {
 		t.Fatalf("unexpected number of references: %d", len(references))
 	}
-	for i := range references {
-		expectedPlatform := manifestDescriptors[i].Platform
-		if !reflect.DeepEqual(references[i].Platform, expectedPlatform) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
-		}
-		references[i].Platform = nil
-		if !reflect.DeepEqual(references[i], manifestDescriptors[i].Descriptor) {
-			t.Fatalf("unexpected value %d returned by References: %v", i, references[i])
-		}
+	if !reflect.DeepEqual(references, manifestDescriptors) {
+		t.Errorf("expected references:\n%v\nbut got:\n%v", references, manifestDescriptors)
 	}
 }
 
@@ -199,9 +186,7 @@ func TestValidateIndex(t *testing.T) {
 		Layers: []distribution.Descriptor{{Size: 2}},
 	}
 	index := ImageIndex{
-		Manifests: []ManifestDescriptor{
-			{Descriptor: distribution.Descriptor{Size: 3}},
-		},
+		Manifests: []distribution.Descriptor{{Size: 3}},
 	}
 	t.Run("valid", func(t *testing.T) {
 		b, err := json.Marshal(index)

--- a/manifest/ocischema/index_test.go
+++ b/manifest/ocischema/index_test.go
@@ -11,12 +11,6 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// TODO (mikebrow): add annotations on the manifest list (index) and support for
-// empty platform structs (move to Platform *Platform `json:"platform,omitempty"`
-// from current Platform PlatformSpec `json:"platform"`) in the manifest descriptor.
-// Requires changes to distribution/distribution/manifest/manifestlist.ManifestList and .ManifestDescriptor
-// and associated serialization APIs in manifestlist.go. Or split the OCI index and
-// docker manifest list implementations, which would require a lot of refactoring.
 const expectedOCIImageIndexSerialization = `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
@@ -50,7 +44,11 @@ const expectedOCIImageIndexSerialization = `{
             "os": "sunos"
          }
       }
-   ]
+   ],
+   "annotations": {
+      "com.example.favourite-colour": "blue",
+      "com.example.locale": "en_GB"
+   }
 }`
 
 func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]ManifestDescriptor, *DeserializedImageIndex) {
@@ -87,8 +85,12 @@ func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]ManifestDescriptor
 			},
 		},
 	}
+	annotations := map[string]string{
+		"com.example.favourite-colour": "blue",
+		"com.example.locale":           "en_GB",
+	}
 
-	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, mediaType)
+	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, annotations, mediaType)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifestList: %v", err)
 	}

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -11,10 +11,10 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// SchemaVersion provides a pre-initialized version structure for this
-// packages version of the manifest.
+// SchemaVersion provides a pre-initialized version structure for OCI Image
+// Manifests
 var SchemaVersion = manifest.Versioned{
-	SchemaVersion: 2, // historical value here.. does not pertain to OCI or docker version
+	SchemaVersion: 2,
 	MediaType:     v1.MediaTypeImageManifest,
 }
 

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -124,16 +124,12 @@ func (m DeserializedManifest) Payload() (string, []byte, error) {
 	return v1.MediaTypeImageManifest, m.canonical, nil
 }
 
-// unknownDocument represents a manifest, manifest list, or index that has not
-// yet been validated
-type unknownDocument struct {
-	Manifests interface{} `json:"manifests,omitempty"`
-}
-
 // validateManifest returns an error if the byte slice is invalid JSON or if it
 // contains fields that belong to a index
 func validateManifest(b []byte) error {
-	var doc unknownDocument
+	var doc struct {
+		Manifests interface{} `json:"manifests,omitempty"`
+	}
 	if err := json.Unmarshal(b, &doc); err != nil {
 		return err
 	}

--- a/registry/storage/manifestlisthandler.go
+++ b/registry/storage/manifestlisthandler.go
@@ -34,17 +34,19 @@ func (ms *manifestListHandler) Unmarshal(ctx context.Context, dgst digest.Digest
 func (ms *manifestListHandler) Put(ctx context.Context, manifestList distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestListHandler).Put")
 
-	var schemaVersion int
+	var schemaVersion, expectedSchemaVersion int
 	switch m := manifestList.(type) {
 	case *manifestlist.DeserializedManifestList:
+		expectedSchemaVersion = manifestlist.SchemaVersion.SchemaVersion
 		schemaVersion = m.SchemaVersion
 	case *ocischema.DeserializedImageIndex:
+		expectedSchemaVersion = ocischema.IndexSchemaVersion.SchemaVersion
 		schemaVersion = m.SchemaVersion
 	default:
 		return "", fmt.Errorf("wrong type put to manifestListHandler: %T", manifestList)
 	}
-	if schemaVersion != 2 {
-		return "", fmt.Errorf("unrecognized manifest list schema version %d", schemaVersion)
+	if schemaVersion != expectedSchemaVersion {
+		return "", fmt.Errorf("unrecognized manifest list schema version %d, expected %d", schemaVersion, expectedSchemaVersion)
 	}
 
 	if err := ms.verifyManifest(ms.ctx, manifestList, skipDependencyVerification); err != nil {

--- a/registry/storage/manifestlisthandler.go
+++ b/registry/storage/manifestlisthandler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/distribution/distribution/v3"
 	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
+	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -33,16 +34,24 @@ func (ms *manifestListHandler) Unmarshal(ctx context.Context, dgst digest.Digest
 func (ms *manifestListHandler) Put(ctx context.Context, manifestList distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestListHandler).Put")
 
-	m, ok := manifestList.(*manifestlist.DeserializedManifestList)
-	if !ok {
+	var schemaVersion int
+	switch m := manifestList.(type) {
+	case *manifestlist.DeserializedManifestList:
+		schemaVersion = m.SchemaVersion
+	case *ocischema.DeserializedImageIndex:
+		schemaVersion = m.SchemaVersion
+	default:
 		return "", fmt.Errorf("wrong type put to manifestListHandler: %T", manifestList)
 	}
+	if schemaVersion != 2 {
+		return "", fmt.Errorf("unrecognized manifest list schema version %d", schemaVersion)
+	}
 
-	if err := ms.verifyManifest(ms.ctx, *m, skipDependencyVerification); err != nil {
+	if err := ms.verifyManifest(ms.ctx, manifestList, skipDependencyVerification); err != nil {
 		return "", err
 	}
 
-	mt, payload, err := m.Payload()
+	mt, payload, err := manifestList.Payload()
 	if err != nil {
 		return "", err
 	}
@@ -60,12 +69,8 @@ func (ms *manifestListHandler) Put(ctx context.Context, manifestList distributio
 // perspective of the registry. As a policy, the registry only tries to
 // store valid content, leaving trust policies of that content up to
 // consumers.
-func (ms *manifestListHandler) verifyManifest(ctx context.Context, mnfst manifestlist.DeserializedManifestList, skipDependencyVerification bool) error {
+func (ms *manifestListHandler) verifyManifest(ctx context.Context, mnfst distribution.Manifest, skipDependencyVerification bool) error {
 	var errs distribution.ErrManifestVerification
-
-	if mnfst.SchemaVersion != 2 {
-		return fmt.Errorf("unrecognized manifest list schema version %d", mnfst.SchemaVersion)
-	}
 
 	if !skipDependencyVerification {
 		// This manifest service is different from the blob service

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -464,20 +464,12 @@ func testOCIManifestStorage(t *testing.T, testname string, includeMediaTypes boo
 		t.Fatalf("%s: unexpected error getting manifest descriptor", testname)
 	}
 	descriptor.MediaType = v1.MediaTypeImageManifest
-
-	platformSpec := v1.Platform{
+	descriptor.Platform = &v1.Platform{
 		Architecture: "atari2600",
 		OS:           "CP/M",
 	}
 
-	manifestDescriptors := []ocischema.ManifestDescriptor{
-		{
-			Descriptor: descriptor,
-			Platform:   &platformSpec,
-		},
-	}
-
-	imageIndex, err := ociIndexFromDesriptorsWithMediaType(manifestDescriptors, indexMediaType)
+	imageIndex, err := ociIndexFromDesriptorsWithMediaType([]distribution.Descriptor{descriptor}, indexMediaType)
 	if err != nil {
 		t.Fatalf("%s: unexpected error creating image index: %v", testname, err)
 	}
@@ -575,7 +567,7 @@ func TestLinkPathFuncs(t *testing.T) {
 	}
 }
 
-func ociIndexFromDesriptorsWithMediaType(descriptors []ocischema.ManifestDescriptor, mediaType string) (*ocischema.DeserializedImageIndex, error) {
+func ociIndexFromDesriptorsWithMediaType(descriptors []distribution.Descriptor, mediaType string) (*ocischema.DeserializedImageIndex, error) {
 	manifest, err := ocischema.FromDescriptors(descriptors, nil)
 	if err != nil {
 		return nil, err

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -576,7 +576,7 @@ func TestLinkPathFuncs(t *testing.T) {
 }
 
 func ociIndexFromDesriptorsWithMediaType(descriptors []ocischema.ManifestDescriptor, mediaType string) (*ocischema.DeserializedImageIndex, error) {
-	manifest, err := ocischema.FromDescriptors(descriptors)
+	manifest, err := ocischema.FromDescriptors(descriptors, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/storage/ociindexhandler.go
+++ b/registry/storage/ociindexhandler.go
@@ -1,0 +1,28 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/manifest/ocischema"
+	"github.com/opencontainers/go-digest"
+)
+
+// ocischemaIndexHandler is a ManifestHandler that covers the OCI Image Index.
+type ocischemaIndexHandler struct {
+	*manifestListHandler
+}
+
+var _ ManifestHandler = &manifestListHandler{}
+
+func (ms *ocischemaIndexHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ms.ctx).Debug("(*ociIndexHandler).Unmarshal")
+
+	m := &ocischema.DeserializedImageIndex{}
+	if err := m.UnmarshalJSON(content); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -259,6 +259,12 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 		}
 	}
 
+	manifestListHandler := &manifestListHandler{
+		ctx:        ctx,
+		repository: repo,
+		blobStore:  blobStore,
+	}
+
 	ms := &manifestStore{
 		ctx:            ctx,
 		repository:     repo,
@@ -270,16 +276,15 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 			blobStore:    blobStore,
 			manifestURLs: repo.registry.manifestURLs,
 		},
-		manifestListHandler: &manifestListHandler{
-			ctx:        ctx,
-			repository: repo,
-			blobStore:  blobStore,
-		},
+		manifestListHandler: manifestListHandler,
 		ocischemaHandler: &ocischemaManifestHandler{
 			ctx:          ctx,
 			repository:   repo,
 			blobStore:    blobStore,
 			manifestURLs: repo.registry.manifestURLs,
+		},
+		ocischemaIndexHandler: &ocischemaIndexHandler{
+			manifestListHandler: manifestListHandler,
 		},
 	}
 


### PR DESCRIPTION
Move implementation of the index from the manifestlist package to the ocischema package so that other modules making empty imports support the manifest types their authors would expect. This is a breaking change to distribution as a library but not the registry.

As OCI 1.0 released the manifest and index together, that is a good package from which to initialise both manifests. The docker manifest and manifest list remain in separate packages because one was released later.

The image index and manifest list still share common code in many functions not intended for import by other modules.

This now supports (omits) empty platform objects in OCI Image Indices.

This adds support for annotations on OCI Image Indices.

fixes #3836 
fixes #2652