### PR TITLE
registry/errors: Parse http forbidden as denied

### DIFF
--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -54,6 +54,8 @@ func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 		switch statusCode {
 		case http.StatusUnauthorized:
 			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
+		case http.StatusForbidden:
+			return errcode.ErrorCodeDenied.WithMessage(detailsErr.Details)
 		case http.StatusTooManyRequests:
 			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
 		default:

--- a/registry/client/errors_test.go
+++ b/registry/client/errors_test.go
@@ -102,3 +102,18 @@ func TestHandleErrorResponseUnexpectedStatusCode501(t *testing.T) {
 		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
 	}
 }
+
+func TestHandleErrorResponseInsufficientPrivileges403(t *testing.T) {
+	json := `{"details":"requesting higher privileges than access token allows"}`
+	response := &http.Response{
+		Status:     "403 Forbidden",
+		StatusCode: 403,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+	}
+	err := HandleErrorResponse(response)
+
+	expectedMsg := "denied: requesting higher privileges than access token allows"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected \"%s\", got: \"%s\"", expectedMsg, err.Error())
+	}
+}


### PR DESCRIPTION
This fixes error caused by requesting a push token with the "Public repo read-only" permission not being correctly parsed into a typed error.