### PR TITLE
remove dot-imports for gopkg.in/check.v1

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 )
 
 // Hook up gocheck into the "go test" runner
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 // configStruct is a canonical example configuration, which should map to configYamlV0_1
 var configStruct = Configuration{
@@ -204,51 +204,51 @@ type ConfigSuite struct {
 	expectedConfig *Configuration
 }
 
-var _ = Suite(new(ConfigSuite))
+var _ = check.Suite(new(ConfigSuite))
 
-func (suite *ConfigSuite) SetUpTest(c *C) {
+func (suite *ConfigSuite) SetUpTest(c *check.C) {
 	os.Clearenv()
 	suite.expectedConfig = copyConfig(configStruct)
 }
 
 // TestMarshalRoundtrip validates that configStruct can be marshaled and
 // unmarshaled without changing any parameters
-func (suite *ConfigSuite) TestMarshalRoundtrip(c *C) {
+func (suite *ConfigSuite) TestMarshalRoundtrip(c *check.C) {
 	configBytes, err := yaml.Marshal(suite.expectedConfig)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	config, err := Parse(bytes.NewReader(configBytes))
 	c.Log(string(configBytes))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseSimple validates that configYamlV0_1 can be parsed into a struct
 // matching configStruct
-func (suite *ConfigSuite) TestParseSimple(c *C) {
+func (suite *ConfigSuite) TestParseSimple(c *check.C) {
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseInmemory validates that configuration yaml with storage provided as
 // a string can be parsed into a Configuration struct with no storage parameters
-func (suite *ConfigSuite) TestParseInmemory(c *C) {
+func (suite *ConfigSuite) TestParseInmemory(c *check.C) {
 	suite.expectedConfig.Storage = Storage{"inmemory": Parameters{}}
 	suite.expectedConfig.Reporting = Reporting{}
 	suite.expectedConfig.Log.Fields = nil
 
 	config, err := Parse(bytes.NewReader([]byte(inmemoryConfigYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseIncomplete validates that an incomplete yaml configuration cannot
 // be parsed without providing environment variables to fill in the missing
 // components.
-func (suite *ConfigSuite) TestParseIncomplete(c *C) {
+func (suite *ConfigSuite) TestParseIncomplete(c *check.C) {
 	incompleteConfigYaml := "version: 0.1"
 	_, err := Parse(bytes.NewReader([]byte(incompleteConfigYaml)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 
 	suite.expectedConfig.Log.Fields = nil
 	suite.expectedConfig.Storage = Storage{"filesystem": Parameters{"rootdirectory": "/tmp/testroot"}}
@@ -265,28 +265,28 @@ func (suite *ConfigSuite) TestParseIncomplete(c *C) {
 	os.Setenv("REGISTRY_AUTH_SILLY_REALM", "silly")
 
 	config, err := Parse(bytes.NewReader([]byte(incompleteConfigYaml)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithSameEnvStorage validates that providing environment variables
 // that match the given storage type will only include environment-defined
 // parameters and remove yaml-defined parameters
-func (suite *ConfigSuite) TestParseWithSameEnvStorage(c *C) {
+func (suite *ConfigSuite) TestParseWithSameEnvStorage(c *check.C) {
 	suite.expectedConfig.Storage = Storage{"somedriver": Parameters{"region": "us-east-1"}}
 
 	os.Setenv("REGISTRY_STORAGE", "somedriver")
 	os.Setenv("REGISTRY_STORAGE_SOMEDRIVER_REGION", "us-east-1")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithDifferentEnvStorageParams validates that providing environment variables that change
 // and add to the given storage parameters will change and add parameters to the parsed
 // Configuration struct
-func (suite *ConfigSuite) TestParseWithDifferentEnvStorageParams(c *C) {
+func (suite *ConfigSuite) TestParseWithDifferentEnvStorageParams(c *check.C) {
 	suite.expectedConfig.Storage.setParameter("string1", "us-west-1")
 	suite.expectedConfig.Storage.setParameter("bool1", true)
 	suite.expectedConfig.Storage.setParameter("newparam", "some Value")
@@ -296,26 +296,26 @@ func (suite *ConfigSuite) TestParseWithDifferentEnvStorageParams(c *C) {
 	os.Setenv("REGISTRY_STORAGE_SOMEDRIVER_NEWPARAM", "some Value")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithDifferentEnvStorageType validates that providing an environment variable that
 // changes the storage type will be reflected in the parsed Configuration struct
-func (suite *ConfigSuite) TestParseWithDifferentEnvStorageType(c *C) {
+func (suite *ConfigSuite) TestParseWithDifferentEnvStorageType(c *check.C) {
 	suite.expectedConfig.Storage = Storage{"inmemory": Parameters{}}
 
 	os.Setenv("REGISTRY_STORAGE", "inmemory")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithDifferentEnvStorageTypeAndParams validates that providing an environment variable
 // that changes the storage type will be reflected in the parsed Configuration struct and that
 // environment storage parameters will also be included
-func (suite *ConfigSuite) TestParseWithDifferentEnvStorageTypeAndParams(c *C) {
+func (suite *ConfigSuite) TestParseWithDifferentEnvStorageTypeAndParams(c *check.C) {
 	suite.expectedConfig.Storage = Storage{"filesystem": Parameters{}}
 	suite.expectedConfig.Storage.setParameter("rootdirectory", "/tmp/testroot")
 
@@ -323,48 +323,48 @@ func (suite *ConfigSuite) TestParseWithDifferentEnvStorageTypeAndParams(c *C) {
 	os.Setenv("REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY", "/tmp/testroot")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithSameEnvLoglevel validates that providing an environment variable defining the log
 // level to the same as the one provided in the yaml will not change the parsed Configuration struct
-func (suite *ConfigSuite) TestParseWithSameEnvLoglevel(c *C) {
+func (suite *ConfigSuite) TestParseWithSameEnvLoglevel(c *check.C) {
 	os.Setenv("REGISTRY_LOGLEVEL", "info")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseWithDifferentEnvLoglevel validates that providing an environment variable defining the
 // log level will override the value provided in the yaml document
-func (suite *ConfigSuite) TestParseWithDifferentEnvLoglevel(c *C) {
+func (suite *ConfigSuite) TestParseWithDifferentEnvLoglevel(c *check.C) {
 	suite.expectedConfig.Log.Level = "error"
 
 	os.Setenv("REGISTRY_LOG_LEVEL", "error")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseInvalidLoglevel validates that the parser will fail to parse a
 // configuration if the loglevel is malformed
-func (suite *ConfigSuite) TestParseInvalidLoglevel(c *C) {
+func (suite *ConfigSuite) TestParseInvalidLoglevel(c *check.C) {
 	invalidConfigYaml := "version: 0.1\nloglevel: derp\nstorage: inmemory"
 	_, err := Parse(bytes.NewReader([]byte(invalidConfigYaml)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 
 	os.Setenv("REGISTRY_LOGLEVEL", "derp")
 
 	_, err = Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 }
 
 // TestParseWithDifferentEnvReporting validates that environment variables
 // properly override reporting parameters
-func (suite *ConfigSuite) TestParseWithDifferentEnvReporting(c *C) {
+func (suite *ConfigSuite) TestParseWithDifferentEnvReporting(c *check.C) {
 	suite.expectedConfig.Reporting.Bugsnag.APIKey = "anotherBugsnagApiKey"
 	suite.expectedConfig.Reporting.Bugsnag.Endpoint = "localhost:8080"
 	suite.expectedConfig.Reporting.NewRelic.LicenseKey = "NewRelicLicenseKey"
@@ -376,23 +376,23 @@ func (suite *ConfigSuite) TestParseWithDifferentEnvReporting(c *C) {
 	os.Setenv("REGISTRY_REPORTING_NEWRELIC_NAME", "some NewRelic NAME")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseInvalidVersion validates that the parser will fail to parse a newer configuration
 // version than the CurrentVersion
-func (suite *ConfigSuite) TestParseInvalidVersion(c *C) {
+func (suite *ConfigSuite) TestParseInvalidVersion(c *check.C) {
 	suite.expectedConfig.Version = MajorMinorVersion(CurrentVersion.Major(), CurrentVersion.Minor()+1)
 	configBytes, err := yaml.Marshal(suite.expectedConfig)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	_, err = Parse(bytes.NewReader(configBytes))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 }
 
 // TestParseExtraneousVars validates that environment variables referring to
 // nonexistent variables don't cause side effects.
-func (suite *ConfigSuite) TestParseExtraneousVars(c *C) {
+func (suite *ConfigSuite) TestParseExtraneousVars(c *check.C) {
 	suite.expectedConfig.Reporting.Bugsnag.Endpoint = "localhost:8080"
 
 	// A valid environment variable
@@ -405,13 +405,13 @@ func (suite *ConfigSuite) TestParseExtraneousVars(c *C) {
 	os.Setenv("REGISTRY_REPORTING_ASDF", "ghjk")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseEnvVarImplicitMaps validates that environment variables can set
 // values in maps that don't already exist.
-func (suite *ConfigSuite) TestParseEnvVarImplicitMaps(c *C) {
+func (suite *ConfigSuite) TestParseEnvVarImplicitMaps(c *check.C) {
 	readonly := make(map[string]interface{})
 	readonly["enabled"] = true
 
@@ -423,41 +423,41 @@ func (suite *ConfigSuite) TestParseEnvVarImplicitMaps(c *C) {
 	os.Setenv("REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED", "true")
 
 	config, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, suite.expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, suite.expectedConfig)
 }
 
 // TestParseEnvWrongTypeMap validates that incorrectly attempting to unmarshal a
 // string over existing map fails.
-func (suite *ConfigSuite) TestParseEnvWrongTypeMap(c *C) {
+func (suite *ConfigSuite) TestParseEnvWrongTypeMap(c *check.C) {
 	os.Setenv("REGISTRY_STORAGE_SOMEDRIVER", "somestring")
 
 	_, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 }
 
 // TestParseEnvWrongTypeStruct validates that incorrectly attempting to
 // unmarshal a string into a struct fails.
-func (suite *ConfigSuite) TestParseEnvWrongTypeStruct(c *C) {
+func (suite *ConfigSuite) TestParseEnvWrongTypeStruct(c *check.C) {
 	os.Setenv("REGISTRY_STORAGE_LOG", "somestring")
 
 	_, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 }
 
 // TestParseEnvWrongTypeSlice validates that incorrectly attempting to
 // unmarshal a string into a slice fails.
-func (suite *ConfigSuite) TestParseEnvWrongTypeSlice(c *C) {
+func (suite *ConfigSuite) TestParseEnvWrongTypeSlice(c *check.C) {
 	os.Setenv("REGISTRY_LOG_HOOKS", "somestring")
 
 	_, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, NotNil)
+	c.Assert(err, check.NotNil)
 }
 
 // TestParseEnvMany tests several environment variable overrides.
 // The result is not checked - the goal of this test is to detect panics
 // from misuse of reflection.
-func (suite *ConfigSuite) TestParseEnvMany(c *C) {
+func (suite *ConfigSuite) TestParseEnvMany(c *check.C) {
 	os.Setenv("REGISTRY_VERSION", "0.1")
 	os.Setenv("REGISTRY_LOG_LEVEL", "debug")
 	os.Setenv("REGISTRY_LOG_FORMATTER", "json")
@@ -471,10 +471,10 @@ func (suite *ConfigSuite) TestParseEnvMany(c *C) {
 	os.Setenv("REGISTRY_AUTH_PARAMS_VALUE2", "value2")
 
 	_, err := Parse(bytes.NewReader([]byte(configYamlV0_1)))
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 }
 
-func checkStructs(c *C, t reflect.Type, structsChecked map[string]struct{}) {
+func checkStructs(c *check.C, t reflect.Type, structsChecked map[string]struct{}) {
 	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Map || t.Kind() == reflect.Slice {
 		t = t.Elem()
 	}
@@ -510,7 +510,7 @@ func checkStructs(c *C, t reflect.Type, structsChecked map[string]struct{}) {
 
 // TestValidateConfigStruct makes sure that the config struct has no members
 // with yaml tags that would be ambiguous to the environment variable parser.
-func (suite *ConfigSuite) TestValidateConfigStruct(c *C) {
+func (suite *ConfigSuite) TestValidateConfigStruct(c *check.C) {
 	structsChecked := make(map[string]struct{})
 	checkStructs(c, reflect.TypeOf(Configuration{}), structsChecked)
 }

--- a/configuration/parser_test.go
+++ b/configuration/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"reflect"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 type localConfiguration struct {
@@ -25,9 +25,9 @@ var expectedConfig = localConfiguration{
 
 type ParserSuite struct{}
 
-var _ = Suite(new(ParserSuite))
+var _ = check.Suite(new(ParserSuite))
 
-func (suite *ParserSuite) TestParserOverwriteIninitializedPoiner(c *C) {
+func (suite *ParserSuite) TestParserOverwriteIninitializedPoiner(c *check.C) {
 	config := localConfiguration{}
 
 	os.Setenv("REGISTRY_LOG_FORMATTER", "json")
@@ -44,11 +44,11 @@ func (suite *ParserSuite) TestParserOverwriteIninitializedPoiner(c *C) {
 	})
 
 	err := p.Parse([]byte(`{version: "0.1", log: {formatter: "text"}}`), &config)
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, expectedConfig)
 }
 
-func (suite *ParserSuite) TestParseOverwriteUnininitializedPoiner(c *C) {
+func (suite *ParserSuite) TestParseOverwriteUnininitializedPoiner(c *check.C) {
 	config := localConfiguration{}
 
 	os.Setenv("REGISTRY_LOG_FORMATTER", "json")
@@ -65,6 +65,6 @@ func (suite *ParserSuite) TestParseOverwriteUnininitializedPoiner(c *C) {
 	})
 
 	err := p.Parse([]byte(`{version: "0.1"}`), &config)
-	c.Assert(err, IsNil)
-	c.Assert(config, DeepEquals, expectedConfig)
+	c.Assert(err, check.IsNil)
+	c.Assert(config, check.DeepEquals, expectedConfig)
 }

--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -8,7 +8,7 @@ import (
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/testsuites"
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 )
 
 // Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 func init() {
 	var (

--- a/registry/storage/driver/filesystem/driver_test.go
+++ b/registry/storage/driver/filesystem/driver_test.go
@@ -7,11 +7,11 @@ import (
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/testsuites"
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 func init() {
 	root, err := os.MkdirTemp("", "driver-")

--- a/registry/storage/driver/middleware/redirect/middleware_test.go
+++ b/registry/storage/driver/middleware/redirect/middleware_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	check "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }


### PR DESCRIPTION
Dot-imports were only used in a couple of places, and replacing them makes it more explicit what's imported.