### PR TITLE
Concurrent tag lookup

### DIFF
--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -184,10 +184,7 @@ func (repo *repository) Named() reference.Named {
 }
 
 func (repo *repository) Tags(ctx context.Context) distribution.TagService {
-	tags := &tagStore{
-		repository: repo,
-		blobStore:  repo.registry.blobStore,
-	}
+	tags := NewStore(ctx, repo, repo.registry.blobStore)
 
 	return tags
 }

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -2,29 +2,45 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/schema2"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
 )
 
 type tagsTestEnv struct {
-	ts  distribution.TagService
-	bs  distribution.BlobStore
-	ms  distribution.ManifestService
-	gbs distribution.BlobStatter
-	ctx context.Context
+	ts         distribution.TagService
+	bs         distribution.BlobStore
+	ms         distribution.ManifestService
+	gbs        distribution.BlobStatter
+	ctx        context.Context
+	mockDriver *mockInMemory
+}
+
+type mockInMemory struct {
+	*inmemory.Driver
+	GetContentError error
+}
+
+func (m *mockInMemory) GetContent(ctx context.Context, path string) ([]byte, error) {
+	if m.GetContentError != nil {
+		return nil, m.GetContentError
+	}
+	return m.Driver.GetContent(ctx, path)
 }
 
 func testTagStore(t *testing.T) *tagsTestEnv {
 	ctx := context.Background()
-	d := inmemory.New()
-	reg, err := NewRegistry(ctx, d)
+	mockDriver := mockInMemory{inmemory.New(), nil}
+	reg, err := NewRegistry(ctx, &mockDriver)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,11 +56,12 @@ func testTagStore(t *testing.T) *tagsTestEnv {
 	}
 
 	return &tagsTestEnv{
-		ctx: ctx,
-		ts:  repo.Tags(ctx),
-		bs:  repo.Blobs(ctx),
-		gbs: reg.BlobStatter(),
-		ms:  ms,
+		ctx:        ctx,
+		ts:         repo.Tags(ctx),
+		bs:         repo.Blobs(ctx),
+		gbs:        reg.BlobStatter(),
+		ms:         ms,
+		mockDriver: &mockDriver,
 	}
 }
 
@@ -167,13 +184,13 @@ func TestTagStoreAll(t *testing.T) {
 
 func TestTagLookup(t *testing.T) {
 	env := testTagStore(t)
-	tagStore := env.ts
+	TagStore := env.ts
 	ctx := env.ctx
 
 	descA := distribution.Descriptor{Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 	desc0 := distribution.Descriptor{Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
 
-	tags, err := tagStore.Lookup(ctx, descA)
+	tags, err := TagStore.Lookup(ctx, descA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,27 +198,27 @@ func TestTagLookup(t *testing.T) {
 		t.Fatalf("Lookup returned > 0 tags from empty store")
 	}
 
-	err = tagStore.Tag(ctx, "a", descA)
+	err = TagStore.Tag(ctx, "a", descA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "b", descA)
+	err = TagStore.Tag(ctx, "b", descA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "0", desc0)
+	err = TagStore.Tag(ctx, "0", desc0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "1", desc0)
+	err = TagStore.Tag(ctx, "1", desc0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tags, err = tagStore.Lookup(ctx, descA)
+	tags, err = TagStore.Lookup(ctx, descA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +227,7 @@ func TestTagLookup(t *testing.T) {
 		t.Errorf("Lookup of descA returned %d tags, expected 2", len(tags))
 	}
 
-	tags, err = tagStore.Lookup(ctx, desc0)
+	tags, err = TagStore.Lookup(ctx, desc0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,16 +235,44 @@ func TestTagLookup(t *testing.T) {
 	if len(tags) != 2 {
 		t.Errorf("Lookup of descB returned %d tags, expected 2", len(tags))
 	}
+	/// Should handle error looking up tag
+	env.mockDriver.GetContentError = errors.New("Lookup failure")
+
+	for i := 2; i < 15; i++ {
+		err = TagStore.Tag(ctx, strconv.Itoa(i), desc0)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tags, err = TagStore.Lookup(ctx, desc0)
+	if err == nil {
+		t.Fatal("Expected error but none retrieved")
+	}
+	if len(tags) > 0 {
+		t.Errorf("Expected 0 tags on an error but got %d tags", len(tags))
+	}
+
+	// Should not error for a path not found
+	env.mockDriver.GetContentError = storagedriver.PathNotFoundError{}
+
+	tags, err = TagStore.Lookup(ctx, desc0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) > 0 {
+		t.Errorf("Expected 0 tags on path not found but got %d tags", len(tags))
+	}
 }
 
 func TestTagIndexes(t *testing.T) {
 	env := testTagStore(t)
-	tagStore := env.ts
+	TagStore := env.ts
 	ctx := env.ctx
 
-	md, ok := tagStore.(distribution.TagManifestsProvider)
+	md, ok := TagStore.(distribution.TagManifestsProvider)
 	if !ok {
-		t.Fatal("tagStore does not implement TagManifestDigests interface")
+		t.Fatal("TagStore does not implement TagManifestDigests interface")
 	}
 
 	conf, err := env.bs.Put(ctx, "application/octet-stream", []byte{0})
@@ -274,14 +319,14 @@ func TestTagIndexes(t *testing.T) {
 		}
 		if i < 3 {
 			// tag first 3 manifests as "t1"
-			err = tagStore.Tag(ctx, "t1", desc)
+			err = TagStore.Tag(ctx, "t1", desc)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t1Dgsts[dgst] = struct{}{}
 		} else {
 			// the last two under "t2"
-			err = tagStore.Tag(ctx, "t2", desc)
+			err = TagStore.Tag(ctx, "t2", desc)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}


### PR DESCRIPTION
I have no access to [Enapter/distribution](https://github.com/Enapter/distribution) repo anymore so I've opened a new request.
@corhere Please check if I used errgroup correctly in the last commit. I cannot wrap allTags iteration into routine because it seems like `errgroup.Wait()` ends prematurely in this case resulting send to closed channel panic.

P.S. Seems I need help to move concurrency factor setup into common configuration module but it seems too complicated for me to understand how it works and what should I do.