### PR TITLE
reference: fix loop-closure bug in test

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -677,6 +677,7 @@ func TestParseDockerRef(t *testing.T) {
 		},
 	}
 	for _, test := range testcases {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			normalized, err := ParseDockerRef(test.input)


### PR DESCRIPTION
```console
$ go vet ./...
# github.com/distribution/distribution/v3/reference
reference/normalize_test.go:682:38: loop variable test captured by func literal
reference/normalize_test.go:687:17: loop variable test captured by func literal
reference/normalize_test.go:688:56: loop variable test captured by func literal
reference/normalize_test.go:688:68: loop variable test captured by func literal
```