### PR TITLE
Remove blobstore from manifest builder

### DIFF
--- a/manifest/schema2/builder.go
+++ b/manifest/schema2/builder.go
@@ -4,16 +4,12 @@ import (
 	"context"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/opencontainers/go-digest"
 )
 
 // builder is a type for constructing manifests.
 type builder struct {
-	// bs is a BlobService used to publish the configuration blob.
-	bs distribution.BlobService
-
-	// configMediaType is media type used to describe configuration
-	configMediaType string
+	// configDescriptor is used to describe configuration
+	configDescriptor distribution.Descriptor
 
 	// configJSON references
 	configJSON []byte
@@ -26,11 +22,10 @@ type builder struct {
 // NewManifestBuilder is used to build new manifests for the current schema
 // version. It takes a BlobService so it can publish the configuration blob
 // as part of the Build process.
-func NewManifestBuilder(bs distribution.BlobService, configMediaType string, configJSON []byte) distribution.ManifestBuilder {
+func NewManifestBuilder(configDescriptor distribution.Descriptor, configJSON []byte) distribution.ManifestBuilder {
 	mb := &builder{
-		bs:              bs,
-		configMediaType: configMediaType,
-		configJSON:      make([]byte, len(configJSON)),
+		configDescriptor: configDescriptor,
+		configJSON:       make([]byte, len(configJSON)),
 	}
 	copy(mb.configJSON, configJSON)
 
@@ -45,30 +40,7 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 	}
 	copy(m.Layers, mb.dependencies)
 
-	configDigest := digest.FromBytes(mb.configJSON)
-
-	var err error
-	m.Config, err = mb.bs.Stat(ctx, configDigest)
-	switch err {
-	case nil:
-		// Override MediaType, since Put always replaces the specified media
-		// type with application/octet-stream in the descriptor it returns.
-		m.Config.MediaType = mb.configMediaType
-		return FromStruct(m)
-	case distribution.ErrBlobUnknown:
-		// nop
-	default:
-		return nil, err
-	}
-
-	// Add config to the blob store
-	m.Config, err = mb.bs.Put(ctx, mb.configMediaType, mb.configJSON)
-	// Override MediaType, since Put always replaces the specified media
-	// type with application/octet-stream in the descriptor it returns.
-	m.Config.MediaType = mb.configMediaType
-	if err != nil {
-		return nil, err
-	}
+	m.Config = mb.configDescriptor
 
 	return FromStruct(m)
 }

--- a/testutil/manifests.go
+++ b/testutil/manifests.go
@@ -44,7 +44,7 @@ func MakeManifestList(blobstatter distribution.BlobStatter, manifestDigests []di
 //
 // Deprecated: Docker Image Manifest v2, Schema 1 is deprecated since 2015.
 // Use Docker Image Manifest v2, Schema 2, or the OCI Image Specification.
-func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error) {
+func MakeSchema1Manifest(digests []digest.Digest) (*schema1.SignedManifest, error) {
 	mfst := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
@@ -76,9 +76,16 @@ func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error)
 func MakeSchema2Manifest(repository distribution.Repository, digests []digest.Digest) (distribution.Manifest, error) {
 	ctx := context.Background()
 	blobStore := repository.Blobs(ctx)
-	builder := schema2.NewManifestBuilder(blobStore, schema2.MediaTypeImageConfig, []byte{})
-	for _, d := range digests {
-		builder.AppendReference(distribution.Descriptor{Digest: d})
+
+	var configJSON []byte
+
+	d, err := blobStore.Put(ctx, schema2.MediaTypeImageConfig, configJSON)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error storing content in blobstore %v", err)
+	}
+	builder := schema2.NewManifestBuilder(d, configJSON)
+	for _, digest := range digests {
+		builder.AppendReference(distribution.Descriptor{Digest: digest})
 	}
 
 	mfst, err := builder.Build(ctx)

--- a/testutil/manifests.go
+++ b/testutil/manifests.go
@@ -81,7 +81,7 @@ func MakeSchema2Manifest(repository distribution.Repository, digests []digest.Di
 
 	d, err := blobStore.Put(ctx, schema2.MediaTypeImageConfig, configJSON)
 	if err != nil {
-		return nil, fmt.Errorf("unexpected error storing content in blobstore %v", err)
+		return nil, fmt.Errorf("unexpected error storing content in blobstore: %v", err)
 	}
 	builder := schema2.NewManifestBuilder(d, configJSON)
 	for _, digest := range digests {


### PR DESCRIPTION
Rebase from https://github.com/distribution/distribution/pull/2782

> This PR aims to close https://github.com/distribution/distribution/issues/2150 by removing blobstore from schema2 manifest builder.
>
> The builder now take configuration Descriptor as parameter instead of a blobstore and media type.

@milosgajdos friendly ping since you were the one to review the original PR.