### PR TITLE
Implementiing Tag Immutable return

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,16 @@ var ErrManifestNotModified = errors.New("manifest not modified")
 // performed
 var ErrUnsupported = errors.New("operation unsupported")
 
+// ErrTagConflict is returned if a tag cannot be overwritten
+type ErrTagConflict struct {
+	Tag  string
+	Name string
+}
+
+func (err ErrTagConflict) Error() string {
+	return fmt.Sprintf("tag=%s cannot be overwritten because %s is an immutable repository", err.Tag, err.Name)
+}
+
 // ErrSchemaV1Unsupported is returned when a client tries to upload a schema v1
 // manifest but the registry is configured to reject it
 var ErrSchemaV1Unsupported = errors.New("manifest schema v1 unsupported")

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -370,6 +370,9 @@ func (imh *manifestHandler) PutManifest(w http.ResponseWriter, r *http.Request) 
 					}
 				}
 			}
+		case distribution.ErrTagConflict:
+			imh.Errors = append(imh.Errors, v2.ErrorCodeNameInvalid.WithMessage(fmt.Sprintf("%s:%s exists and is immutable",err.Name, err.Tag)))
+			return
 		case errcode.Error:
 			imh.Errors = append(imh.Errors, err)
 		default:


### PR DESCRIPTION
This allows manifests to return a tag immutable error. I used the `ErrorCodeNameInvalid.WithMessage` but I am not sure if there is a better error message in return or if a new error needs to be created.