### PR TITLE
Pass `BUILDTAGS` argument to `go build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=bind,target=/go/src/github.com/docker/distribution,rw \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=type=bind,source=/tmp/.ldflags,target=/tmp/.ldflags,from=version \
-      set -x ; xx-go build -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -o /usr/bin/registry ./cmd/registry \
+      set -x ; xx-go build -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -tags="${BUILDTAGS}" -o /usr/bin/registry ./cmd/registry \
       && xx-verify --static /usr/bin/registry
 
 FROM scratch AS binary


### PR DESCRIPTION
See discussion in https://github.com/distribution/distribution/issues/3919.

> It looks like this might have happened by mistake in https://github.com/distribution/distribution/pull/3903. [The Dockerfile used to build the v2.8.1 tag](https://github.com/distribution/distribution/blob/v2.8.1/Dockerfile#L31) clearly passes the BUILDTAGS argument to Go's build command, which no longer is the case for [the Dockerfile used to build the v2.8.2 tag](https://github.com/distribution/distribution/blob/v2.8.2/Dockerfile#LL30C1-L30C1).

Maintainers, please let me know if basing on `release/2.8` is not the right way to do this, and I'll update my PR accordingly.

Fixes #3919