### PR TITLE
[release/2.8] Enable build tags in 2.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_BUILDTAGS: "include_oss include_gcs"
+      BUILDTAGS: "include_oss,include_gcs"
       CGO_ENABLED: 1
       GO111MODULE: "auto"
       GOPATH: ${{ github.workspace }}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -114,4 +114,4 @@ the registry binary generated in the "./bin" directory:
 ### Optional build tags
 
 Optional [build tags](http://golang.org/pkg/go/build/) can be provided using
-the environment variable `DOCKER_BUILDTAGS`.
+the environment variable `BUILDTAGS`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN --mount=target=. \
 FROM base AS build
 ARG TARGETPLATFORM
 ARG LDFLAGS="-s -w"
-ARG BUILDTAGS="include_oss include_gcs"
+ARG BUILDTAGS="include_oss,include_gcs"
 RUN --mount=type=bind,target=/go/src/github.com/docker/distribution,rw \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=type=bind,source=/tmp/.ldflags,target=/tmp/.ldflags,from=version \
-      set -x ; xx-go build -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -tags="${BUILDTAGS}" -o /usr/bin/registry ./cmd/registry \
+      set -x ; xx-go build -tags "${BUILDTAGS}" -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -o /usr/bin/registry ./cmd/registry \
       && xx-verify --static /usr/bin/registry
 
 FROM scratch AS binary

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
-
 PKG=github.com/docker/distribution
 
 # Project packages.
@@ -50,7 +49,7 @@ version/version.go:
 
 check: ## run all linters (TODO: enable "unused", "varcheck", "ineffassign", "unconvert", "staticheck", "goimports", "structcheck")
 	@echo "$(WHALE) $@"
-	@GO111MODULE=off golangci-lint run
+	@GO111MODULE=off golangci-lint --build-tags "${BUILDTAGS}" run
 
 test: ## run tests, except integration test with test.short
 	@echo "$(WHALE) $@"

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -1,18 +1,17 @@
+//go:build include_gcs
+// +build include_gcs
+
 // Package gcs provides a storagedriver.StorageDriver implementation to
 // store blobs in Google cloud storage.
 //
 // This package leverages the google.golang.org/cloud/storage client library
-//for interfacing with gcs.
+// for interfacing with gcs.
 //
 // Because gcs is a key, value store the Stat call does not support last modification
 // time for directories (directories are an abstraction for key, value stores)
 //
 // Note that the contents of incomplete uploads are not accessible even though
 // Stat returns their length
-//
-//go:build include_gcs
-// +build include_gcs
-
 package gcs
 
 import (
@@ -62,7 +61,6 @@ var rangeHeader = regexp.MustCompile(`^bytes=([0-9])+-([0-9]+)$`)
 // driverParameters is a struct that encapsulates all of the driver parameters after all values have been set
 type driverParameters struct {
 	bucket        string
-	config        *jwt.Config
 	email         string
 	privateKey    []byte
 	client        *http.Client
@@ -87,6 +85,8 @@ type gcsDriverFactory struct{}
 func (factory *gcsDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	return FromParameters(parameters)
 }
+
+var _ storagedriver.StorageDriver = &driver{}
 
 // driver is a storagedriver.StorageDriver implementation backed by GCS
 // Objects are stored at absolute keys in the provided bucket.
@@ -298,7 +298,7 @@ func (d *driver) Reader(context context.Context, path string, offset int64) (io.
 				if err != nil {
 					return nil, err
 				}
-				if offset == int64(obj.Size) {
+				if offset == obj.Size {
 					return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
 				}
 				return nil, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
@@ -614,10 +614,10 @@ func (d *driver) Stat(context context.Context, path string) (storagedriver.FileI
 	//try to get as folder
 	dirpath := d.pathToDirKey(path)
 
-	var query *storage.Query
-	query = &storage.Query{}
-	query.Prefix = dirpath
-	query.MaxResults = 1
+	query := &storage.Query{
+		Prefix:     dirpath,
+		MaxResults: 1,
+	}
 
 	objects, err := storageListObjects(gcsContext, d.bucket, query)
 	if err != nil {
@@ -639,7 +639,7 @@ func (d *driver) Stat(context context.Context, path string) (storagedriver.FileI
 }
 
 // List returns a list of the objects that are direct descendants of the
-//given path.
+// given path.
 func (d *driver) List(context context.Context, path string) ([]string, error) {
 	var query *storage.Query
 	query = &storage.Query{}

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -59,7 +59,7 @@ func init() {
 			panic(fmt.Sprintf("Error reading JWT config : %s", err))
 		}
 		email = jwtConfig.Email
-		privateKey = []byte(jwtConfig.PrivateKey)
+		privateKey = jwtConfig.PrivateKey
 		if len(privateKey) == 0 {
 			panic("Error reading JWT config : missing private_key property")
 		}
@@ -260,6 +260,9 @@ func TestEmptyRootList(t *testing.T) {
 		}
 	}()
 	keys, err := emptyRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing empty root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
@@ -267,6 +270,9 @@ func TestEmptyRootList(t *testing.T) {
 	}
 
 	keys, err = slashRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing slash root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -1,3 +1,6 @@
+//go:build include_oss
+// +build include_oss
+
 // Package oss provides a storagedriver.StorageDriver implementation to
 // store blobs in Aliyun OSS cloud storage.
 //
@@ -6,10 +9,6 @@
 //
 // Because OSS is a key, value store the Stat call does not support last modification
 // time for directories (directories are an abstraction for key, value stores)
-//
-//go:build include_oss
-// +build include_oss
-
 package oss
 
 import (
@@ -38,12 +37,11 @@ const driverName = "oss"
 const minChunkSize = 5 << 20
 
 const defaultChunkSize = 2 * minChunkSize
-const defaultTimeout = 2 * time.Minute // 2 minute timeout per chunk
 
 // listMax is the largest amount of objects you can request from OSS in a list call
 const listMax = 1000
 
-//DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
+// DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
 type DriverParameters struct {
 	AccessKeyID     string
 	AccessKeySecret string
@@ -67,6 +65,8 @@ type ossDriverFactory struct{}
 func (factory *ossDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	return FromParameters(parameters)
 }
+
+var _ storagedriver.StorageDriver = &driver{}
 
 type driver struct {
 	Client        *oss.Client
@@ -496,11 +496,6 @@ func parseError(path string, err error) error {
 	}
 
 	return err
-}
-
-func hasCode(err error, code string) bool {
-	ossErr, ok := err.(*oss.Error)
-	return ok && ossErr.Code == code
 }
 
 func (d *driver) getOptions() oss.Options {

--- a/registry/storage/driver/oss/oss_test.go
+++ b/registry/storage/driver/oss/oss_test.go
@@ -128,6 +128,9 @@ func TestEmptyRootList(t *testing.T) {
 	defer rootedDriver.Delete(ctx, filename)
 
 	keys, err := emptyRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing empty root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
@@ -135,6 +138,9 @@ func TestEmptyRootList(t *testing.T) {
 	}
 
 	keys, err = slashRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing slash root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -137,6 +137,8 @@ func (factory *s3DriverFactory) Create(parameters map[string]interface{}) (stora
 	return FromParameters(parameters)
 }
 
+var _ storagedriver.StorageDriver = &driver{}
+
 type driver struct {
 	S3                          *s3.S3
 	Bucket                      string


### PR DESCRIPTION
It would appear we were missing the Go build tags on 2.8.X branch so the images would not have the necessary support for some storage drivers causing breakages to end users trying to use them.

This commit fixes both the build and linting issues.

Fixes: #3919 