### PR TITLE
registry/storage/driver: test call to Stat(ctx, "/")

### DIFF
--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -432,7 +432,13 @@ func (d *driver) blobName(path string) string {
 }
 
 func is404(err error) bool {
-	return bloberror.HasCode(err, bloberror.BlobNotFound, bloberror.ContainerNotFound, bloberror.ResourceNotFound)
+	return bloberror.HasCode(
+		err,
+		bloberror.BlobNotFound,
+		bloberror.ContainerNotFound,
+		bloberror.ResourceNotFound,
+		bloberror.CannotVerifyCopySource,
+	)
 }
 
 type writer struct {

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -63,7 +63,8 @@ func New(params *Parameters) (*Driver, error) {
 	d := &driver{
 		azClient:      azClient,
 		client:        client,
-		rootDirectory: params.RootDirectory}
+		rootDirectory: params.RootDirectory,
+	}
 	return &Driver{baseEmbed: baseEmbed{Base: base.Base{StorageDriver: d}}}, nil
 }
 
@@ -420,6 +421,13 @@ func (d *driver) listBlobs(ctx context.Context, virtPath string) ([]string, erro
 }
 
 func (d *driver) blobName(path string) string {
+	// avoid returning an empty blob name.
+	// this will happen when rootDirectory is unset, and path == "/",
+	// which is what we get from the storage driver health check Stat call.
+	if d.rootDirectory == "" && path == "/" {
+		return path
+	}
+
 	return strings.TrimLeft(strings.TrimRight(d.rootDirectory, "/")+path, "/")
 }
 

--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -52,14 +52,18 @@ func init() {
 	}
 
 	azureDriverConstructor := func() (storagedriver.StorageDriver, error) {
-		params := Parameters{
-			Container:     container,
-			AccountName:   accountName,
-			AccountKey:    accountKey,
-			Realm:         realm,
-			RootDirectory: rootDirectory,
+		parameters := map[string]interface{}{
+			"container":     container,
+			"accountname":   accountName,
+			"accountkey":    accountKey,
+			"realm":         realm,
+			"rootdirectory": rootDirectory,
 		}
-		return New(&params)
+		params, err := NewParameters(parameters)
+		if err != nil {
+			return nil, err
+		}
+		return New(params)
 	}
 
 	// Skip Azure storage driver tests if environment variable parameters are not provided

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -388,7 +388,11 @@ func (suite *DriverSuite) TestReaderWithOffset(c *check.C) {
 // TestContinueStreamAppendLarge tests that a stream write can be appended to without
 // corrupting the data with a large chunk size.
 func (suite *DriverSuite) TestContinueStreamAppendLarge(c *check.C) {
-	suite.testContinueStreamAppend(c, int64(10*1024*1024))
+	chunkSize := int64(10 * 1024 * 1024)
+	if suite.Name() == "azure" {
+		chunkSize = int64(4 * 1024 * 1024)
+	}
+	suite.testContinueStreamAppend(c, chunkSize)
 }
 
 // TestContinueStreamAppendSmall is the same as TestContinueStreamAppendLarge, but only

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -824,6 +824,15 @@ func (suite *DriverSuite) TestStatCall(c *check.C) {
 	c.Assert(fi.Path(), check.Equals, dirPath)
 	c.Assert(fi.Size(), check.Equals, int64(0))
 	c.Assert(fi.IsDir(), check.Equals, true)
+
+	// The storage healthcheck performs this exact call to Stat.
+	// PathNotFoundErrors are not considered health check failures.
+	_, err = suite.StorageDriver.Stat(suite.ctx, "/")
+	// Some drivers will return a not found here, while others will not
+	// return an error at all. If we get an error, ensure it's a not found.
+	if err != nil {
+		c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
+	}
 }
 
 // TestPutContentMultipleTimes checks that if storage driver can overwrite the content


### PR DESCRIPTION
The registry [storage driver health check calls `Stat(app, "/")`](https://github.com/distribution/distribution/blob/main/registry/handlers/app.go#L376). For Azure, this call is currently broken.

This PR fixes the call and add test coverage for it.

Also fix a couple of unrelated tests which were broken on main (see commits for details).
Fixes #3931.