### PR TITLE
docs: note restriction on URL format of mirrors

### DIFF
--- a/docs/recipes/mirror.md
+++ b/docs/recipes/mirror.md
@@ -31,6 +31,18 @@ relying entirely on your local registry is the simplest scenario.
 It's currently not possible to mirror another private registry. Only the central
 Hub can be mirrored.
 
+The URL of a pull-through registry mirror must be the root of a domain.
+No path components other than an optional trailing slash (`/`) are allowed.
+The following table shows examples of allowed and disallowed mirror URLs.
+
+| URL                                    | Allowed |
+| -------------------------------------- | ------- |
+| `https://mirror.company.example`       | Yes     |
+| `https://mirror.company.example/`      | Yes     |
+| `https://mirror.company.example/foo`   | No      |
+| `https://mirror.company.example#bar`   | No      |
+| `https://mirror.company.example?baz=1` | No      |
+
 > **Note**
 >
 > Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates){: target="blank" rel="noopener" class=“”}.
@@ -110,9 +122,13 @@ and add the `registry-mirrors` key and value, to make the change persistent.
 
 ```json
 {
-  "registry-mirrors": ["https://<my-docker-mirror-host>"]
+  "registry-mirrors": ["https://mirror.company.example"]
 }
 ```
+
+> **Note**
+>
+> The mirror URL must be the root of the domain.
 
 Save the file and reload Docker for the change to take effect.
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

Clarify the restriction that pull-through mirrors must use the root of a domain with no path components.

See: https://github.com/docker/docs/issues/17414
