### PR TITLE
Add option to enable caller information in logger

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -42,6 +42,9 @@ type Configuration struct {
 		// Hooks allows users to configure the log hooks, to enabling the
 		// sequent handling behavior, when defined levels of log message emit.
 		Hooks []LogHook `yaml:"hooks,omitempty"`
+
+		// ReportCaller allows user to configure the log to report the caller
+		ReportCaller bool `yaml:"reportcaller,omitempty"`
 	}
 
 	// Loglevel is the level at which registry operations are logged.

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -23,10 +23,11 @@ var configStruct = Configuration{
 		AccessLog struct {
 			Disabled bool `yaml:"disabled,omitempty"`
 		} `yaml:"accesslog,omitempty"`
-		Level     Loglevel               `yaml:"level,omitempty"`
-		Formatter string                 `yaml:"formatter,omitempty"`
-		Fields    map[string]interface{} `yaml:"fields,omitempty"`
-		Hooks     []LogHook              `yaml:"hooks,omitempty"`
+		Level        Loglevel               `yaml:"level,omitempty"`
+		Formatter    string                 `yaml:"formatter,omitempty"`
+		Fields       map[string]interface{} `yaml:"fields,omitempty"`
+		Hooks        []LogHook              `yaml:"hooks,omitempty"`
+		ReportCaller bool                   `yaml:"reportcaller,omitempty"`
 	}{
 		Level:  "info",
 		Fields: map[string]interface{}{"environment": "test"},

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -345,6 +345,7 @@ func configureReporting(app *handlers.App) http.Handler {
 // configuration.
 func configureLogging(ctx context.Context, config *configuration.Configuration) (context.Context, error) {
 	logrus.SetLevel(logLevel(config.Log.Level))
+	logrus.SetReportCaller(config.Log.ReportCaller)
 
 	formatter := config.Log.Formatter
 	if formatter == "" {


### PR DESCRIPTION
Add options in config.yaml to enable caller log

After enabling this option in config.yaml, the caller information can be displayed in each log item like that

```
INFO[0000]/home/user/goworkdir/src/github.com/distribution/distribution/registry/handlers/app.go:1085 github.com/distribution/distribution/v3/registry/handlers.startUploadPurger.func1() Starting upload purge in 0s                   go.version=go1.18 instance.id=d2d965f5-2277-4128-80b4-201b7cf5c47f service=registry version=v3.0.0+unknown

``` 
It is helpful to diagnostic.