### PR TITLE
Fix Content type octet stream typos

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -3393,7 +3393,7 @@ POST /v2/<name>/blobs/uploads/?digest=<digest>
 Host: <registry host>
 Authorization: <scheme> <token>
 Content-Length: <length of blob>
-Content-Type: application/octect-stream
+Content-Type: application/octet-stream
 
 <binary data>
 ```

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -987,7 +987,7 @@ var routeDescriptors = []RouteDescriptor{
 							},
 						},
 						Body: BodyDescriptor{
-							ContentType: "application/octect-stream",
+							ContentType: "application/octet-stream",
 							Format:      "<binary data>",
 						},
 						Successes: []ResponseDescriptor{


### PR DESCRIPTION
This simply fixes a typo in `registry/api/v2/descriptors.go` which sets the wrong content type at the body of `RouteNameBlobUpload`.

Also fixes a similar typo in the docs.