### PR TITLE
Fix S3 storage driver to support R2 Multipart upload

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1539,5 +1539,5 @@ func (w *writer) flushPart() error {
 	})
 	w.readyPart = w.pendingPart
 	w.pendingPart = nil
-	return nil
+	return w.flushPart()
 }


### PR DESCRIPTION
Add extra call of flushPart to avoid losing pendingBytes when `multipartcombinesmallpart` is `false`

Fixes: https://github.com/distribution/distribution/issues/3873 