### PR TITLE
Added support for specifying ACME-server by using REGISTRY_HTTP_TLS_LETSENCRYPT_DIRECTORYURL

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -131,6 +131,10 @@ type Configuration struct {
 				// Hosts specifies the hosts which are allowed to obtain Let's
 				// Encrypt certificates.
 				Hosts []string `yaml:"hosts,omitempty"`
+
+				// DirectoryURL points to the CA directory endpoint.
+				// If empty, LetsEncrypt is used.
+				DirectoryURL string `yaml:"directoryurl,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		} `yaml:"tls,omitempty"`
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -89,9 +89,10 @@ var configStruct = Configuration{
 			MinimumTLS   string   `yaml:"minimumtls,omitempty"`
 			CipherSuites []string `yaml:"ciphersuites,omitempty"`
 			LetsEncrypt  struct {
-				CacheFile string   `yaml:"cachefile,omitempty"`
-				Email     string   `yaml:"email,omitempty"`
-				Hosts     []string `yaml:"hosts,omitempty"`
+				CacheFile    string   `yaml:"cachefile,omitempty"`
+				Email        string   `yaml:"email,omitempty"`
+				Hosts        []string `yaml:"hosts,omitempty"`
+				DirectoryURL string   `yaml:"directoryurl,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		} `yaml:"tls,omitempty"`
 		Headers http.Header `yaml:"headers,omitempty"`
@@ -113,9 +114,10 @@ var configStruct = Configuration{
 			MinimumTLS   string   `yaml:"minimumtls,omitempty"`
 			CipherSuites []string `yaml:"ciphersuites,omitempty"`
 			LetsEncrypt  struct {
-				CacheFile string   `yaml:"cachefile,omitempty"`
-				Email     string   `yaml:"email,omitempty"`
-				Hosts     []string `yaml:"hosts,omitempty"`
+				CacheFile    string   `yaml:"cachefile,omitempty"`
+				Email        string   `yaml:"email,omitempty"`
+				Hosts        []string `yaml:"hosts,omitempty"`
+				DirectoryURL string   `yaml:"directoryurl,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		}{
 			ClientCAs: []string{"/path/to/ca.pem"},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,7 @@ http:
       cachefile: /path/to/cache-file
       email: emailused@letsencrypt.com
       hosts: [myregistryaddress.org]
+      directoryurl: https://acme-v02.api.letsencrypt.org/directory
   debug:
     addr: localhost:5001
     prometheus:
@@ -823,6 +824,7 @@ http:
       cachefile: /path/to/cache-file
       email: emailused@letsencrypt.com
       hosts: [myregistryaddress.org]
+      directoryurl: https://acme-v02.api.letsencrypt.org/directory
   debug:
     addr: localhost:5001
   headers:
@@ -914,11 +916,12 @@ TLS certificates provided by
 > ensure that you have the `ca-certificates` package installed in order to verify
 > letsencrypt certificates.
 
-| Parameter | Required | Description                                           |
-|-----------|----------|-------------------------------------------------------|
-| `cachefile` | yes    | Absolute path to a file where the Let's Encrypt agent can cache data. |
-| `email`   | yes      | The email address used to register with Let's Encrypt. |
-| `hosts`   | no       | The hostnames allowed for Let's Encrypt certificates. |
+| Parameter      | Required | Description                                                           |
+|----------------|----------|-----------------------------------------------------------------------|
+| `cachefile`    | yes      | Absolute path to a file where the Let's Encrypt agent can cache data. |
+| `email`        | yes      | The email address used to register with Let's Encrypt.                |
+| `hosts`        | no       | The hostnames allowed for Let's Encrypt certificates.                 |
+| `directoryurl` | no       | The url to use for the ACME server.                                   |
 
 ### `debug`
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -188,6 +188,14 @@ func getCipherSuiteNames(ids []uint16) []string {
 	return names
 }
 
+// set ACME-server/DirectoryURL, if provided
+func setDirectoryURL(directoryurl string) *acme.Client {
+	if len(directoryurl) > 0 {
+		return &acme.Client{DirectoryURL: directoryurl}
+	}
+	return nil
+}
+
 // ListenAndServe runs the registry's HTTP server.
 func (registry *Registry) ListenAndServe() error {
 	config := registry.config
@@ -236,6 +244,7 @@ func (registry *Registry) ListenAndServe() error {
 				Cache:      autocert.DirCache(config.HTTP.TLS.LetsEncrypt.CacheFile),
 				Email:      config.HTTP.TLS.LetsEncrypt.Email,
 				Prompt:     autocert.AcceptTOS,
+				Client:     setDirectoryURL(config.HTTP.TLS.LetsEncrypt.DirectoryURL),
 			}
 			tlsConf.GetCertificate = m.GetCertificate
 			tlsConf.NextProtos = append(tlsConf.NextProtos, acme.ALPNProto)


### PR DESCRIPTION
Copy of #3464  with updated tests