### PR TITLE
registry/handlers/app: log healthcheck error before return

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -377,6 +377,9 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 			if _, ok := err.(storagedriver.PathNotFoundError); ok {
 				err = nil // pass this through, backend is responding, but this path doesn't exist.
 			}
+			if err != nil {
+				dcontext.GetLogger(app).Errorf("storage driver health check: %v", err)
+			}
 			return err
 		}
 
@@ -745,7 +748,6 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		}
 
 		dispatch(context, r).ServeHTTP(w, r)
-
 	})
 }
 


### PR DESCRIPTION
this error doesn't show up anywhere, so when the healthcheck does error the cause is often very mysterious.