### PR TITLE
Enable Go build tags

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -97,7 +97,7 @@ Run `make validate` to run the validators, including the linter and vendor valid
 ### Optional build tags
 
 Optional [build tags](http://golang.org/pkg/go/build/) can be provided using
-the environment variable `DOCKER_BUILDTAGS`.
+the environment variable `BUILDTAGS`.
 
 <dl>
 <dt>noresumabledigest</dt>

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN --mount=target=. \
 FROM base AS build
 ARG TARGETPLATFORM
 ARG LDFLAGS="-s -w"
-ARG BUILDTAGS="include_oss include_gcs"
+ARG BUILDTAGS="include_oss,include_gcs"
 RUN --mount=type=bind,target=/src,rw \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=type=bind,source=/tmp/.ldflags,target=/tmp/.ldflags,from=version \
-      set -x ; xx-go build -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -o /usr/bin/registry ./cmd/registry \
+      set -x ; xx-go build -tags "${BUILDTAGS}" -trimpath -ldflags "$(cat /tmp/.ldflags) ${LDFLAGS}" -o /usr/bin/registry ./cmd/registry \
       && xx-verify --static /usr/bin/registry
 
 FROM scratch AS binary

--- a/dockerfiles/lint.Dockerfile
+++ b/dockerfiles/lint.Dockerfile
@@ -3,6 +3,7 @@
 ARG GO_VERSION=1.19.9
 ARG ALPINE_VERSION=3.16
 ARG GOLANGCI_LINT_VERSION=v1.52
+ARG BUILDTAGS="include_oss,include_gcs"
 
 FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 
@@ -15,4 +16,4 @@ ENV GOFLAGS="-buildvcs=false"
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
-      golangci-lint run
+      golangci-lint --build-tags "${BUILDTAGS}" run

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -66,7 +66,7 @@ func init() {
 			panic(fmt.Sprintf("Error reading JWT config : %s", err))
 		}
 		email = jwtConfig.Email
-		privateKey = []byte(jwtConfig.PrivateKey)
+		privateKey = jwtConfig.PrivateKey
 		if len(privateKey) == 0 {
 			panic("Error reading JWT config : missing private_key property")
 		}
@@ -262,6 +262,9 @@ func TestEmptyRootList(t *testing.T) {
 		}
 	}()
 	keys, err := emptyRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing empty root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
@@ -269,6 +272,9 @@ func TestEmptyRootList(t *testing.T) {
 	}
 
 	keys, err = slashRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing slash root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -1,3 +1,6 @@
+//go:build include_oss
+// +build include_oss
+
 // Package oss provides a storagedriver.StorageDriver implementation to
 // store blobs in Aliyun OSS cloud storage.
 //
@@ -6,10 +9,6 @@
 //
 // Because OSS is a key, value store the Stat call does not support last modification
 // time for directories (directories are an abstraction for key, value stores)
-//
-//go:build include_oss
-// +build include_oss
-
 package oss
 
 import (
@@ -69,6 +68,8 @@ type ossDriverFactory struct{}
 func (factory *ossDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	return FromParameters(parameters)
 }
+
+var _ storagedriver.StorageDriver = &driver{}
 
 type driver struct {
 	Client          *oss.Client
@@ -505,11 +506,6 @@ func parseError(path string, err error) error {
 	}
 
 	return err
-}
-
-func hasCode(err error, code string) bool {
-	ossErr, ok := err.(*oss.Error)
-	return ok && ossErr.Code == code
 }
 
 func (d *driver) getOptions() oss.Options {

--- a/registry/storage/driver/oss/oss_test.go
+++ b/registry/storage/driver/oss/oss_test.go
@@ -128,6 +128,9 @@ func TestEmptyRootList(t *testing.T) {
 	defer rootedDriver.Delete(ctx, filename)
 
 	keys, err := emptyRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing empty root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
@@ -135,6 +138,9 @@ func TestEmptyRootList(t *testing.T) {
 	}
 
 	keys, err = slashRootDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("unexpected error listing slash root content: %v", err)
+	}
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)


### PR DESCRIPTION
It would appear we are missing the Go build tags so the binary packaged in the image built from the source in this repo  would miss support for some storage drivers causing breakages to end users trying to use them.

This PR enables Go build tags so the GCS and OSS driver support is available in the binary distributed via the image build by Dockerfile.

This led to quite a few fixes in the GCS and OSS packages raised as warnings by `golang-ci` linter.