### PR TITLE
Update OCI conformance workflow check

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,7 +32,7 @@ jobs:
           docker run --rm -p 5000:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true -idt "registry:local"
       -
         name: Run OCI Distribution Spec conformance tests
-        uses: opencontainers/distribution-spec@main
+        uses: opencontainers/distribution-spec@v1.0.1
         env:
           OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_NAMESPACE: oci-conformance/distribution-test


### PR DESCRIPTION
Pin the OCI conformance check workflow GHA to v1.0.1

Closes https://github.com/distribution/distribution/issues/3972