### PR TITLE
Remove references to schema1 pacakge from proxy package

### DIFF
--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -1,14 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
-	"io"
 	"sync"
 	"testing"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/manifest"
-	"github.com/distribution/distribution/v3/manifest/schema1" //nolint:staticcheck // Ignore SA1019: "github.com/distribution/distribution/v3/manifest/schema1" is deprecated, as it's used for backward compatibility.
+	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/reference"
 	"github.com/distribution/distribution/v3/registry/client/auth"
 	"github.com/distribution/distribution/v3/registry/client/auth/challenge"
@@ -17,7 +16,6 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/cache/memory"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/distribution/distribution/v3/testutil"
-	"github.com/docker/libtrust"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -87,16 +85,10 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 	if err != nil {
 		t.Fatalf("unable to parse reference: %s", err)
 	}
-	k, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	ctx := context.Background()
 	truthRegistry, err := storage.NewRegistry(ctx, inmemory.New(),
-		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)),
-		storage.Schema1SigningKey(k),
-		storage.EnableSchema1)
+		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)))
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
@@ -118,7 +110,8 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 		t.Fatalf(err.Error())
 	}
 
-	localRegistry, err := storage.NewRegistry(ctx, inmemory.New(), storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)), storage.EnableRedirect, storage.DisableDigestResumption, storage.Schema1SigningKey(k), storage.EnableSchema1)
+	localRegistry, err := storage.NewRegistry(ctx, inmemory.New(),
+		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)), storage.EnableRedirect, storage.DisableDigestResumption)
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
@@ -126,7 +119,7 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}
-	lr, err := localRepo.Manifests(ctx)
+	lr, err := localRepo.Manifests(ctx, storage.SkipLayerVerification())
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -151,46 +144,40 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 }
 
 func populateRepo(ctx context.Context, t *testing.T, repository distribution.Repository, name, tag string) (digest.Digest, error) {
-	m := schema1.Manifest{ //nolint:staticcheck // Ignore SA1019: "github.com/distribution/distribution/v3/manifest/schema1" is deprecated, as it's used for backward compatibility.
-		Versioned: manifest.Versioned{
-			SchemaVersion: 1,
+	config := []byte(`{"name": "foo"}`)
+	configDigest := digest.FromBytes(config)
+	configReader := bytes.NewReader(config)
+
+	if err := testutil.PushBlob(ctx, repository, configReader, configDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	m := schema2.Manifest{
+		Versioned: schema2.SchemaVersion,
+		Config: distribution.Descriptor{
+			MediaType: "foo/bar",
+			Digest:    configDigest,
 		},
-		Name: name,
-		Tag:  tag,
 	}
 
 	for i := 0; i < 2; i++ {
-		wr, err := repository.Blobs(ctx).Create(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error creating test upload: %v", err)
-		}
-
 		rs, dgst, err := testutil.CreateRandomTarFile()
 		if err != nil {
 			t.Fatalf("unexpected error generating test layer file")
 		}
-		if _, err := io.Copy(wr, rs); err != nil {
-			t.Fatalf("unexpected error copying to upload: %v", err)
+
+		if err := testutil.PushBlob(ctx, repository, rs, dgst); err != nil {
+			t.Fatal(err)
 		}
-
-		if _, err := wr.Commit(ctx, distribution.Descriptor{Digest: dgst}); err != nil {
-			t.Fatalf("unexpected error finishing upload: %v", err)
-		}
-	}
-
-	pk, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatalf("unexpected error generating private key: %v", err)
-	}
-
-	sm, err := schema1.Sign(&m, pk) //nolint:staticcheck // Ignore SA1019: "github.com/distribution/distribution/v3/manifest/schema1" is deprecated, as it's used for backward compatibility.
-	if err != nil {
-		t.Fatalf("error signing manifest: %v", err)
 	}
 
 	ms, err := repository.Manifests(ctx)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
+	}
+	sm, err := schema2.FromStruct(m)
+	if err != nil {
+		t.Fatal(err.Error())
 	}
 	dgst, err := ms.Put(ctx, sm)
 	if err != nil {

--- a/testutil/push.go
+++ b/testutil/push.go
@@ -1,0 +1,36 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
+)
+
+// PushBlob pushes a blob with the given digest to the given repository.
+func PushBlob(ctx context.Context, repository distribution.Repository, blobReader io.ReadSeeker, dgst digest.Digest) error {
+	blobs := repository.Blobs(ctx)
+
+	wr, err := blobs.Create(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating layer upload: %v", err)
+	}
+
+	// Use the resumes, as well!
+	wr, err = blobs.Resume(ctx, wr.ID())
+	if err != nil {
+		return fmt.Errorf("error resuming layer upload: %v", err)
+	}
+
+	if _, err := io.Copy(wr, blobReader); err != nil {
+		return fmt.Errorf("unexpected error uploading: %v", err)
+	}
+
+	if _, err := wr.Commit(ctx, distribution.Descriptor{Digest: dgst}); err != nil {
+		return fmt.Errorf("unexpected error finishing upload: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is another step towards the elimination of `schema v1` support in `distribution` (see https://github.com/distribution/distribution/issues/3966).

This PR removes `schema1` package references from the `proxy` package.

**NOTE:** it duplicates `testutil/push.go` file that's also introduced in https://github.com/distribution/distribution/pull/3976. Depending on which PR gets merged first we'll update the other one accordingly.