### PR TITLE
Set Content-Type header in registry client ReadFrom

### DIFF
--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -43,6 +43,8 @@ func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
 	}
 	defer req.Body.Close()
 
+	req.Header.Set("Content-Type", "application/octet-stream")
+
 	resp, err := hbu.client.Do(req)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Client ReadFrom doesn't set Content-Type header leading to server side implementor to assume it's application/octet-stream. This commit makes this explicit on the client side.

Closes #3965