### PR TITLE
s3: add interface assertion

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -151,6 +151,8 @@ func (factory *s3DriverFactory) Create(parameters map[string]interface{}) (stora
 	return FromParameters(parameters)
 }
 
+var _ storagedriver.StorageDriver = &driver{}
+
 type driver struct {
 	S3                          *s3.S3
 	Bucket                      string


### PR DESCRIPTION
- relates to https://github.com/distribution/distribution/pull/3927

This was added for the other drivers in 6b388b1ba604bf5b970bbb41878f97cc3fc93376 (https://github.com/distribution/distribution/pull/3950), but it missed the s3 storage driver.