### PR TITLE
Update milosgajdos maintainer email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,7 +12,7 @@
 "joaodrp","João Pereira","jpereira@gitlab.com"
 "justincormack","Justin Cormack","justin.cormack@docker.com"
 "squizzi","Kyle Squizzato","ksquizzato@mirantis.com"
-"milosgajdos","Milos Gajdos","milos.gajdos@docker.com"
+"milosgajdos","Milos Gajdos","milosthegajdos@gmail.com"
 "sargun","Sargun Dhillon","sargun@sargun.me"
 "wy65701436","Wang Yan","wangyan@vmware.com"
 "stevelasker","Steve Lasker","steve.lasker@microsoft.com"


### PR DESCRIPTION
It's been pointed out to me today that my maintainer email is different from the one I use for signing commits. Let's fix that 😅 