### PR TITLE
Scorecard Badge Viewer Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![codecov](https://codecov.io/gh/distribution/distribution/branch/main/graph/badge.svg)](https://codecov.io/gh/distribution/distribution)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fdistribution%2Fdistribution.svg?type=shield)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fdistribution%2Fdistribution?ref=badge_shield)
 [![OCI Conformance](https://github.com/distribution/distribution/workflows/conformance/badge.svg)](https://github.com/distribution/distribution/actions?query=workflow%3Aconformance)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/distribution/distribution/badge)](https://api.securityscorecards.dev/projects/github.com/distribution/distribution)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/distribution/distribution/badge)](https://securityscorecards.dev/viewer/?uri=github.com/distribution/distribution)
+
+
 
 The toolset to pack, ship, store, and deliver content.
 


### PR DESCRIPTION
Hi, just a minor fix to the link attached to the badge: now the OpenSSF Scorecard has a much better viewer to understand the results:

https://securityscorecards.dev/viewer/?uri=github.com/distribution/distribution

Thanks!