### PR TITLE
pass X-Request-ID from upstream

### DIFF
--- a/context/http.go
+++ b/context/http.go
@@ -62,6 +62,16 @@ func RemoteIP(r *http.Request) string {
 	return addr
 }
 
+// getXRequestID get X-Request-ID from HTTP header
+// or generate an UUID if not found in header
+func getXRequestID(r *http.Request) string {
+	rid := r.Header.Get("X-Request-ID")
+	if rid != "" {
+		return rid
+	}
+	return uuid.Generate().String()
+}
+
 // WithRequest places the request on the context. The context of the request
 // is assigned a unique id, available at "http.request.id". The request itself
 // is available at "http.request". Other common attributes are available under
@@ -78,7 +88,7 @@ func WithRequest(ctx context.Context, r *http.Request) context.Context {
 	return &httpRequestContext{
 		Context:   ctx,
 		startedAt: time.Now(),
-		id:        uuid.Generate().String(),
+		id:        getXRequestID(r),
 		r:         r,
 	}
 }


### PR DESCRIPTION
This will get `X-Request-ID` from the caller and write to `http.request.id` filed in the log for distributed debugging purpose.

Related #1607 #1479, these two issues are serval years ago, I'm not sure this PR can fix these or give some hint to them.