### PR TITLE
Add username to create redis client

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -525,6 +525,7 @@ func (app *App) createPool(cfg configuration.Redis) *redis.Client {
 			res := cn.Ping(ctx)
 			return res.Err()
 		},
+		Username:        cfg.Username,
 		Password:        cfg.Password,
 		DB:              cfg.DB,
 		MaxRetries:      3,


### PR DESCRIPTION
It seems the `username` is lost in https://github.com/distribution/distribution/pull/4019