### PR TITLE
Remove libtrust from handler tests

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -31,7 +31,6 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/distribution/distribution/v3/testutil"
 	"github.com/distribution/reference"
-	"github.com/docker/libtrust"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
 )
@@ -2128,7 +2127,6 @@ func testManifestDelete(t *testing.T, env *testEnv, args manifestArgs) {
 }
 
 type testEnv struct {
-	pk      libtrust.PrivateKey
 	ctx     context.Context
 	config  configuration.Configuration
 	app     *App
@@ -2186,13 +2184,7 @@ func newTestEnvWithConfig(t *testing.T, config *configuration.Configuration) *te
 		t.Fatalf("error creating url builder: %v", err)
 	}
 
-	pk, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatalf("unexpected error generating private key: %v", err)
-	}
-
 	return &testEnv{
-		pk:      pk,
 		ctx:     ctx,
 		config:  *config,
 		app:     app,


### PR DESCRIPTION
It was used for signing `schema v1` manifests in tests which have now been removed so there is no point in keeping these there anymore.

`libtrust` imports are now limited to `auth` package only replacement of which will be the subject of this issue https://github.com/distribution/distribution/issues/1820