### PR TITLE
Fix proxy statistics

### DIFF
--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -62,7 +62,8 @@ func (pbs *proxyBlobStore) copyContent(ctx context.Context, dgst digest.Digest, 
 		return distribution.Descriptor{}, err
 	}
 
-	proxyMetrics.BlobPush(uint64(desc.Size))
+	proxyMetrics.BlobPull(uint64(desc.Size))
+	proxyMetrics.BlobPush(uint64(desc.Size), false)
 
 	return desc, nil
 }
@@ -75,7 +76,7 @@ func (pbs *proxyBlobStore) serveLocal(ctx context.Context, w http.ResponseWriter
 		return false, nil
 	}
 
-	proxyMetrics.BlobPush(uint64(localDesc.Size))
+	proxyMetrics.BlobPush(uint64(localDesc.Size), true)
 	return true, pbs.localStore.ServeBlob(ctx, w, r, dgst)
 }
 

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -60,7 +60,7 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 		return nil, err
 	}
 
-	proxyMetrics.ManifestPush(uint64(len(payload)))
+	proxyMetrics.ManifestPush(uint64(len(payload)), !fromRemote)
 	if fromRemote {
 		proxyMetrics.ManifestPull(uint64(len(payload)))
 

--- a/registry/proxy/proxymetrics.go
+++ b/registry/proxy/proxymetrics.go
@@ -46,14 +46,18 @@ func (pmc *proxyMetricsCollector) BlobPull(bytesPulled uint64) {
 }
 
 // BlobPush tracks metrics about blobs pushed to clients
-func (pmc *proxyMetricsCollector) BlobPush(bytesPushed uint64) {
+func (pmc *proxyMetricsCollector) BlobPush(bytesPushed uint64, isHit bool) {
 	atomic.AddUint64(&pmc.blobMetrics.Requests, 1)
-	atomic.AddUint64(&pmc.blobMetrics.Hits, 1)
 	atomic.AddUint64(&pmc.blobMetrics.BytesPushed, bytesPushed)
 
 	requests.WithValues("blob").Inc(1)
-	hits.WithValues("blob").Inc(1)
 	pushedBytes.WithValues("blob").Inc(float64(bytesPushed))
+
+	if isHit {
+		atomic.AddUint64(&pmc.blobMetrics.Hits, 1)
+
+		hits.WithValues("blob").Inc(1)
+	}
 }
 
 // ManifestPull tracks metrics related to Manifests pulled into the cache
@@ -66,14 +70,18 @@ func (pmc *proxyMetricsCollector) ManifestPull(bytesPulled uint64) {
 }
 
 // ManifestPush tracks metrics about manifests pushed to clients
-func (pmc *proxyMetricsCollector) ManifestPush(bytesPushed uint64) {
+func (pmc *proxyMetricsCollector) ManifestPush(bytesPushed uint64, isHit bool) {
 	atomic.AddUint64(&pmc.manifestMetrics.Requests, 1)
-	atomic.AddUint64(&pmc.manifestMetrics.Hits, 1)
 	atomic.AddUint64(&pmc.manifestMetrics.BytesPushed, bytesPushed)
 
 	requests.WithValues("manifest").Inc(1)
-	hits.WithValues("manifest").Inc(1)
 	pushedBytes.WithValues("manifest").Inc(float64(bytesPushed))
+
+	if isHit {
+		atomic.AddUint64(&pmc.manifestMetrics.Hits, 1)
+
+		hits.WithValues("manifest").Inc(1)
+	}
 }
 
 // proxyMetrics tracks metrics about the proxy cache.  This is


### PR DESCRIPTION
If registry is configured as pull through cache the reported proxy statistics are incorrect.
Fixes #4044.