### PR TITLE
[release/2.8 backport] Set Content-Type header in registry client ReadFrom

### DIFF
--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -42,6 +42,8 @@ func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
 	}
 	defer req.Body.Close()
 
+	req.Header.Set("Content-Type", "application/octet-stream")
+
 	resp, err := hbu.client.Do(req)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
- backport of https://github.com/distribution/distribution/pull/3981
- fixes https://github.com/distribution/distribution/issues/3965
- addresses https://github.com/moby/moby/issues/46006#issuecomment-1645389961


Client ReadFrom doesn't set Content-Type header leading to server side implementor to assume it's application/octet-stream. This commit makes this explicit on the client side.


(cherry picked from commit 24de708d229e4b67fb434151895e909f31aa08e6)