### PR TITLE
Introduce a new `purge-uploads` sub command

### DIFF
--- a/registry/purge/purgeuploads.go
+++ b/registry/purge/purgeuploads.go
@@ -1,0 +1,93 @@
+package purge
+
+import (
+	"fmt"
+	"time"
+)
+
+// PurgeOption contains options for purging uploads
+type PurgeOption struct {
+	Enabled  bool
+	Age      time.Duration
+	Interval time.Duration
+	DryRun   bool
+}
+
+func (po *PurgeOption) String() string {
+	return fmt.Sprintf(`
+Purge Option:
+  Enabled:  %t
+  DryRun:   %t
+  Age:      %s
+  Interval: %s
+`, po.Enabled, po.DryRun, po.Age, po.Interval)
+}
+
+// UploadPurgeDefaultConfig provides a default configuration for upload
+// purging to be used in the absence of configuration in the
+// configuration file
+func UploadPurgeDefaultConfig() map[interface{}]interface{} {
+	config := map[interface{}]interface{}{}
+	config["enabled"] = true
+	config["age"] = "168h"
+	config["interval"] = "24h"
+	config["dryrun"] = false
+	return config
+}
+
+func badPurgeUploadConfig(reason string) (*PurgeOption, error) {
+	return nil, fmt.Errorf("Unable to parse upload purge configuration: %s", reason)
+}
+
+// ParseConfig will parse purge uploads configs and set default values if not set
+func ParseConfig(config map[interface{}]interface{}) (*PurgeOption, error) {
+	po := &PurgeOption{}
+
+	if config["enabled"] == true {
+		po.Enabled = true
+	}
+
+	var err error
+	purgeAgeDuration := 168 * time.Hour
+	purgeAge, ok := config["age"]
+	if ok {
+		ageStr, ok := purgeAge.(string)
+		if !ok {
+			return badPurgeUploadConfig("age is not a string")
+		}
+		purgeAgeDuration, err = time.ParseDuration(ageStr)
+		if err != nil {
+			return badPurgeUploadConfig(fmt.Sprintf("cannot parse age: %s", err.Error()))
+		}
+	}
+	po.Age = purgeAgeDuration
+
+	intervalDuration := 24 * time.Hour
+	interval, ok := config["interval"]
+	if ok {
+		intervalStr, ok := interval.(string)
+		if !ok {
+			return badPurgeUploadConfig("interval is not a string")
+		}
+
+		intervalDuration, err = time.ParseDuration(intervalStr)
+		if err != nil {
+			return badPurgeUploadConfig(fmt.Sprintf("cannot parse interval: %s", err.Error()))
+		}
+	}
+	po.Interval = intervalDuration
+
+	var dryRunBool bool
+	dryRun, ok := config["dryrun"]
+	if ok {
+		dryRunBool, ok = dryRun.(bool)
+		if !ok {
+			return badPurgeUploadConfig("cannot parse dryrun")
+		}
+		po.DryRun = dryRunBool
+	} else {
+		po.DryRun = false
+	}
+
+	return po, nil
+}

--- a/registry/purge/purgeuploads_test.go
+++ b/registry/purge/purgeuploads_test.go
@@ -1,0 +1,102 @@
+package purge
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/distribution/distribution/v3/configuration"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		config string
+		want   *PurgeOption
+		err    string
+	}{
+		{
+			config: `
+version: 0.1
+storage:
+  s3:
+  maintenance:
+    uploadpurging:
+      enabled: true
+      age: 120h
+      interval: 48h
+      dryrun: false`,
+			want: &PurgeOption{
+				Enabled:  true,
+				DryRun:   false,
+				Age:      120 * time.Hour,
+				Interval: 48 * time.Hour,
+			},
+			err: "",
+		},
+		{
+			config: `
+version: 0.1
+storage:
+  s3:
+  maintenance:
+    uploadpurging:
+      dryrun: false`,
+			want: &PurgeOption{
+				Enabled:  false,
+				DryRun:   false,
+				Age:      168 * time.Hour,
+				Interval: 24 * time.Hour,
+			},
+			err: "",
+		},
+		{
+			config: `
+version: 0.1
+storage:
+  s3:
+  maintenance:
+    uploadpurging:
+      enabled: true
+      age: aaaa`,
+			want: &PurgeOption{},
+			err:  "age",
+		},
+		{
+			config: `
+version: 0.1
+storage:
+  s3:
+  maintenance:
+    uploadpurging:
+      enabled: true
+      interval: aaaa`,
+			want: &PurgeOption{},
+			err:  "interval",
+		},
+	}
+
+	for _, tc := range tests {
+		fp := strings.NewReader(tc.config)
+		config, err := configuration.Parse(fp)
+		if err != nil {
+			t.Fatalf("failed to parse config file: %s: %s is not a valid config file", err, tc.config)
+		}
+
+		// here we are sure that the config data is valid and we can get the storage.maintenance.uploadpurging value and call type assertion.
+		purgeConfig := config.Storage["maintenance"]["uploadpurging"].(map[interface{}]interface{})
+		got, err := ParseConfig(purgeConfig)
+		if err != nil && tc.err == "" {
+			// got en unexception error
+			t.Fatalf("failed to parse %+v: %+v", purgeConfig, err)
+		} else if tc.err != "" && err == nil {
+			t.Fatalf("should get a parse error for %+v", purgeConfig)
+		} else if err != nil && tc.err != "" && strings.Index(err.Error(), tc.err) < 0 {
+			t.Fatalf("error should contain string %s, but can't fint the string for error %s", tc.err, err.Error())
+		}
+
+		if tc.err == "" && !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}

--- a/registry/root.go
+++ b/registry/root.go
@@ -3,8 +3,10 @@ package registry
 import (
 	"fmt"
 	"os"
+	"time"
 
 	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/purge"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 	"github.com/distribution/distribution/v3/version"
@@ -15,9 +17,15 @@ var showVersion bool
 
 func init() {
 	RootCmd.AddCommand(ServeCmd)
+
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
+
+	RootCmd.AddCommand(PurgeUploadsCmd)
+	PurgeUploadsCmd.Flags().BoolVarP(&purgeDryRun, "dry-run", "d", false, "do everything except remove the upload files")
+	PurgeUploadsCmd.Flags().DurationVarP(&purgeAgeDuration, "age", "a", 0, "the age of temporary files created during upload")
+
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 
@@ -78,6 +86,73 @@ var GCCmd = &cobra.Command{
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to garbage collect: %v", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var (
+	purgeAgeDuration time.Duration
+	purgeDryRun      bool
+)
+
+// PurgeUploadsCmd is the cobra command that corresponds to the purge-uploads subcommand
+var PurgeUploadsCmd = &cobra.Command{
+	Use:   "purge-uploads <config>",
+	Short: "`purge-uploads` deletes outdated upload files",
+	Long:  "`purge-uploads` deletes outdated upload files",
+	Run: func(cmd *cobra.Command, args []string) {
+		config, err := resolveConfiguration(args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		driver, err := factory.Create(config.Storage.Type(), config.Storage.Parameters())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to construct %s driver: %v", config.Storage.Type(), err)
+			os.Exit(1)
+		}
+
+		ctx := dcontext.Background()
+		ctx, err = configureLogging(ctx, config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to configure logging with config: %s", err)
+			os.Exit(1)
+		}
+
+		// default configs
+		purgeConfig := purge.UploadPurgeDefaultConfig()
+		if mc, ok := config.Storage["maintenance"]; ok {
+			if v, ok := mc["uploadpurging"]; ok {
+				purgeConfig, ok = v.(map[interface{}]interface{})
+				if !ok {
+					panic("uploadpurging config key must contain additional keys")
+				}
+			}
+		}
+
+		// parse configs from config file
+		purgeOption, err := purge.ParseConfig(purgeConfig)
+		if err != nil {
+			panic(fmt.Sprintf("Unable to parse upload purge configuration: %s", err.Error()))
+		}
+
+		// overwrite confis by command line options
+		if cmd.Flags().Changed("age") {
+			purgeOption.Age = purgeAgeDuration
+		}
+
+		if cmd.Flags().Changed("dry-run") {
+			purgeOption.DryRun = purgeDryRun
+		}
+
+		fmt.Println(purgeOption.String())
+
+		_, errs := storage.PurgeUploads(ctx, driver, time.Now().Add(-purgeOption.Age), !purgeOption.DryRun)
+		if len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "failed to purge uploads: %v", err)
 			os.Exit(1)
 		}
 	},


### PR DESCRIPTION
Like `garbage-collect`, this sub command supports to run purge uploads in command line mode.

This PR is not perfect yet, and it also lacks some testing and documentation. I just want to hear your opinions first, and then make it better.

Some background can found at #4074