### PR TITLE
registry: add loglevel support for aws s3 storage driver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,7 @@ storage:
     multipartcopythresholdsize: 33554432
     rootdirectory: /s3/object/name/prefix
     usedualstack: false
+    loglevel: debug
   inmemory:  # This driver takes no parameters
   delete:
     enabled: false
@@ -410,6 +411,7 @@ storage:
     multipartcopymaxconcurrency: 100
     multipartcopythresholdsize: 33554432
     rootdirectory: /s3/object/name/prefix
+    loglevel: debug
   inmemory:
   delete:
     enabled: false

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -26,6 +26,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `rootdirectory`  | no | This is a prefix that is applied to all S3 keys to allow you to segment data in your bucket if necessary. |
 | `storageclass`  | no | The S3 storage class applied to each registry file. The default is `STANDARD`. |
 | `objectacl`  | no | The S3 Canned ACL for objects. The default value is "private". |
+| `loglevel`  | no | The log level for the S3 client. The default value is `off`. |
 
 > **Note** You can provide empty strings for your access and secret keys to run the driver
 > on an ec2 instance and handles authentication with the instance's credentials. If you
@@ -56,6 +57,7 @@ Amazon S3 or S3 compatible services for object storage.
 
 `objectacl`: (optional) The canned object ACL to be applied to each registry object. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your objects. Other valid options are available in the [AWS S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 
+`loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
 
 ## S3 permission scopes
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -117,6 +117,7 @@ type DriverParameters struct {
 	SessionToken                string
 	UseDualStack                bool
 	Accelerate                  bool
+	LogLevel                    aws.LogLevelType
 }
 
 func init() {
@@ -461,9 +462,37 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(sessionToken),
 		useDualStackBool,
 		accelerateBool,
+		getS3LogLevelFromParam(parameters["loglevel"]),
 	}
 
 	return New(params)
+}
+
+func getS3LogLevelFromParam(param interface{}) aws.LogLevelType {
+	if param == nil {
+		return aws.LogOff
+	}
+	logLevelParam := param.(string)
+	var logLevel aws.LogLevelType
+	switch strings.ToLower(logLevelParam) {
+	case "off":
+		logLevel = aws.LogOff
+	case "debug":
+		logLevel = aws.LogDebug
+	case "debugwithsigning":
+		logLevel = aws.LogDebugWithSigning
+	case "debugwithhttpbody":
+		logLevel = aws.LogDebugWithHTTPBody
+	case "debugwithrequestretries":
+		logLevel = aws.LogDebugWithRequestRetries
+	case "debugwithrequesterrors":
+		logLevel = aws.LogDebugWithRequestErrors
+	case "debugwitheventstreambody":
+		logLevel = aws.LogDebugWithEventStreamBody
+	default:
+		logLevel = aws.LogOff
+	}
+	return logLevel
 }
 
 // getParameterAsInt64 converts parameters[name] to an int64 value (using
@@ -504,7 +533,7 @@ func New(params DriverParameters) (*Driver, error) {
 		return nil, fmt.Errorf("on Amazon S3 this storage driver can only be used with v4 authentication")
 	}
 
-	awsConfig := aws.NewConfig()
+	awsConfig := aws.NewConfig().WithLogLevel(params.LogLevel)
 
 	if params.AccessKey != "" && params.SecretKey != "" {
 		creds := credentials.NewStaticCredentials(

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/driver/testsuites"
 )
 
-var s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error)
-var skipS3 func() string
+var (
+	s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error)
+	skipS3              func() string
+)
 
 func init() {
 	var (
@@ -42,6 +44,7 @@ func init() {
 		useDualStack     = os.Getenv("S3_USE_DUALSTACK")
 		combineSmallPart = os.Getenv("MULTIPART_COMBINE_SMALL_PART")
 		accelerate       = os.Getenv("S3_ACCELERATE")
+		logLevel         = os.Getenv("S3_LOGLEVEL")
 	)
 
 	root, err := os.MkdirTemp("", "driver-")
@@ -135,6 +138,7 @@ func init() {
 			sessionToken,
 			useDualStackBool,
 			accelerateBool,
+			getS3LogLevelFromParam(logLevel),
 		}
 
 		return New(parameters)


### PR DESCRIPTION
based on the work from https://github.com/distribution/distribution/pull/3057.

---
I have run the s3 tests locally and here's a sample output with `loglevel: logdebug`
```
-----------------------------------------------------
2023/09/27 16:49:15 DEBUG: Request s3/PutObject Details:
---[ REQUEST POST-SIGN ]-----------------------------
PUT /var/folders/p0/c1z2jht90l99pg75kvywwyfw0000gn/T/TestListObjectsV23912336142/001/test-list-objects-v2/3 HTTP/1.1
Host: redacted.s3.eu-north-1.amazonaws.com
User-Agent: aws-sdk-go/1.44.325 (go1.21.0; darwin; amd64) s3aws-test
Content-Length: 23
Authorization: AWS4-HMAC-SHA256 Credential=redacted/20230927/eu-north-1/s3/aws4_request, SignedHeaders=content-length;content-md5;content-type;host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-storage-class, Signature=redacted
Content-Md5: uyzn4ebeBLo5Pn+lmCe3sw==
Content-Type: application/octet-stream
X-Amz-Acl:
X-Amz-Content-Sha256: 89b3e90a62f6cd4a71a8aa72dcdf84d70dbbba80010546679edc18f8bb5cc177
X-Amz-Date: 20230927T144915Z
X-Amz-Storage-Class: STANDARD
Accept-Encoding: gzip
```