### PR TITLE
use manifestTagsPathSpec for listing all tags

### DIFF
--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -24,7 +24,7 @@ type tagStore struct {
 
 // All returns all tags
 func (ts *tagStore) All(ctx context.Context) ([]string, error) {
-	pathSpec, err := pathFor(manifestTagPathSpec{
+	pathSpec, err := pathFor(manifestTagsPathSpec{
 		name: ts.repository.Named().Name(),
 	})
 	if err != nil {


### PR DESCRIPTION
In terms of results, a`manifestTagsPathSpec{ name: "repo" }` equals `manifestTagPathSpec{ name: "repo", tag: "" }`, but from the intention, the `manifestTagsPathSpec` should be used.