### PR TITLE
Properly indent prometheus docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -828,7 +828,13 @@ the `HOST:PORT` on which the debug server should accept connections.
 If the registry is configured as a pull-through cache, the `debug` server can be used
 to access proxy statistics. These statistics are exposed at `/debug/vars` in JSON format.
 
-## `prometheus`
+#### `prometheus`
+
+```none
+prometheus:
+  enabled: true
+  path: /metrics
+```
 
 The `prometheus` option defines whether the prometheus metrics are enabled, as well
 as the path to access the metrics.


### PR DESCRIPTION
Incorrect section indentation of the `prometheus` section in the docs confuses some folks. This commit fixes that by indenting the `prometheus` section under the `debug` configuration section.

This is more visible in the [docs published by Docker inc](https://docs.docker.com/registry/configuration/#prometheus).

<img width="256" alt="Screenshot 2023-10-01 at 09 37 44" src="https://github.com/distribution/distribution/assets/1392526/0a131935-26eb-43b3-9f2a-d5c526129c2b">


Closes https://github.com/distribution/distribution/issues/2935