### PR TITLE
Update Docker Hub README and keep it in sync with this repository.

### DIFF
--- a/.github/dockerhub-readme.yml
+++ b/.github/dockerhub-readme.yml
@@ -1,0 +1,32 @@
+name: dockerhub-readme
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/dockerhub-readme.yml'
+      - 'docs/dockerhub.md'
+
+env:
+  DOCKERHUB_SLUG: distribution/distribution
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Update Docker Hub README
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_SLUG }}
+          readme-filepath: ./docs/dockerhub.md

--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -4,20 +4,6 @@ log:
   fields:
     service: registry
     environment: development
-  hooks:
-    - type: mail
-      disabled: true
-      levels:
-        - panic
-      options:
-        smtp:
-          addr: mail.example.com:25
-          username: mailuser
-          password: password
-          insecure: true
-        from: sender@example.com
-        to:
-          - errors@example.com
 storage:
     delete:
       enabled: true
@@ -37,33 +23,6 @@ http:
             path: /metrics
     headers:
         X-Content-Type-Options: [nosniff]
-redis:
-  addr: localhost:6379
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
-  dialtimeout: 10ms
-  readtimeout: 10ms
-  writetimeout: 10ms
-notifications:
-    events:
-        includereferences: true
-    endpoints:
-        - name: local-5003
-          url: http://localhost:5003/callback
-          headers:
-             Authorization: [Bearer <an example token>]
-          timeout: 1s
-          threshold: 10
-          backoff: 1s
-          disabled: true
-        - name: local-8083
-          url: http://localhost:8083/callback
-          timeout: 1s
-          threshold: 10
-          backoff: 1s
-          disabled: true
 health:
   storagedriver:
     enabled: true

--- a/docs/dockerhub.md
+++ b/docs/dockerhub.md
@@ -1,0 +1,56 @@
+# Distribution
+
+This repository provides container images for the Open Source Registry implementation for storing and distributing container artifacts in conformance with the
+[OCI Distribution Specification](https://github.com/opencontainers/distribution-spec).
+
+<img src="https://raw.githubusercontent.com/distribution/distribution/main/distribution-logo.svg" width="200px" />
+
+[![Build Status](https://github.com/distribution/distribution/workflows/CI/badge.svg?branch=main&event=push)](https://github.com/distribution/distribution/actions?query=workflow%3ACI)
+[![OCI Conformance](https://github.com/distribution/distribution/workflows/conformance/badge.svg)](https://github.com/distribution/distribution/actions?query=workflow%3Aconformance)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+
+## Quick start
+
+Run the registry locally with the [default configuration](https://github.com/distribution/distribution/blob/main/cmd/registry/config-dev.yml):
+```
+docker run -d -p 5000:5000 --restart always --name registry distribution/distribution:edge
+```
+
+*NOTE:* in order to run push/pull against the locally run registry you must allow
+your docker (containerd) engine to use _insecure_ registry by editing `/etc/docker/daemon.json` and subsequently restarting it
+```
+{
+     "insecure-registries": ["host.docker.internal:5000"]
+}
+```
+
+Now you are ready to use it:
+```
+docker pull alpine
+docker tag alpine localhost:5000/alpine
+docker push localhost:5000/alpine
+```
+
+⚠️  Beware the default configuration uses [`filesystem` storage driver](https://github.com/distribution/distribution/blob/main/docs/storage-drivers/filesystem.md)
+and the above example command does not mount a local filesystem volume into the running container.
+If you wish to mount the local filesystem to the `rootdirectory` of the
+`filesystem` storage driver run the following command:
+```
+docker run -d -p 5000:5000 $PWD/FS/PATH:/var/lib/registry --restart always --name registry distribution/distribution:edge
+```
+
+### Custom configuration
+
+If you don't wan to use the default configuration file, you can supply
+your own custom configuration file as follows:
+```
+docker run -d -p 5000:5000 $PWD/PATH/TO/config.yml:/etc/docker/registry/config.yml --restart always --name registry distribution/distribution:edge
+```
+
+## Communication
+
+For async communication and long-running discussions please use issues and pull requests
+on the [GitHub repo](https://github.com/distribution/distribution).
+
+For sync communication we have a #distribution channel in the [CNCF Slack](https://slack.cncf.io/)
+that everyone is welcome to join and chat about development.


### PR DESCRIPTION
This PR
* adds a new docs page (`docs/dockerhub.md`) that contains the new contents of the `README` for [`distribution/distribution` Docker Hub repository](https://hub.docker.com/r/distribution/distribution)
* updates the default configuration file that gets baked into the docker image which is published to Docker Hub -- there are a ton of options that produce a lot of logs that confuse the users who are just getting started with the image we distribute via the Docker Hub
* updates the CI with a new workflow job that keeps Docker Hub README in sync with the contents of the `docs/dockerhub.md` file

Closes https://github.com/distribution/distribution/issues/4014