### PR TITLE
[release/2.8 backport] Option to configure proxy cache TTL

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -650,6 +650,11 @@ type Proxy struct {
 
 	// Password of the hub user
 	Password string `yaml:"password"`
+
+	// TTL is the expiry time of the content and will be cleaned up when it expires
+	// if not set, defaults to 7 * 24 hours
+	// If set to zero, will never expire cache
+	TTL *time.Duration `yaml:"ttl,omitempty"`
 }
 
 // Parse parses an input configuration yaml document into a Configuration struct

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,7 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: [username]
   password: [password]
+  ttl: 168h
 compatibility:
   schema1:
     signingkeyfile: /etc/registry/key.json
@@ -1132,6 +1133,7 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: [username]
   password: [password]
+  ttl: 168h
 ```
 
 The `proxy` structure allows a registry to be configured as a pull-through cache
@@ -1145,6 +1147,7 @@ is unsupported.
 | `remoteurl`| yes     | The URL for the repository on Docker Hub.             |
 | `username` | no      | The username registered with Docker Hub which has access to the repository. |
 | `password` | no      | The password used to authenticate to Docker Hub using the username specified in `username`. |
+| `ttl`      | no      | Expire proxy cache configured in "storage" after this time. Cache 168h(7 days) by default, set to 0 to disable cache expiration, The suffix is one of `ns`, `us`, `ms`, `s`, `m`, or `h`. If you specify a value but omit the suffix, the value is interpreted as a number of nanoseconds. |
 
 
 To enable pulling private repositories (e.g. `batman/robin`) specify the

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
@@ -18,6 +19,7 @@ type proxyBlobStore struct {
 	localStore     distribution.BlobStore
 	remoteStore    distribution.BlobService
 	scheduler      *scheduler.TTLExpirationScheduler
+	ttl            *time.Duration
 	repositoryName reference.Named
 	authChallenger authChallenger
 }
@@ -146,7 +148,10 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 
-		pbs.scheduler.AddBlob(blobRef, repositoryTTL)
+		if pbs.scheduler != nil && pbs.ttl != nil {
+			pbs.scheduler.AddBlob(blobRef, *pbs.ttl)
+		}
+
 	}(dgst)
 
 	_, err = pbs.copyContent(ctx, dgst, w)

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -258,6 +258,18 @@ func TestProxyStoreGet(t *testing.T) {
 
 }
 
+func TestProxyStoreGetWithoutScheduler(t *testing.T) {
+	te := makeTestEnv(t, "foo/bar")
+	te.store.scheduler = nil
+
+	populate(t, te, 1, 10, 1)
+
+	_, err := te.store.Get(te.ctx, te.inRemote[0].Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestProxyStoreStat(t *testing.T) {
 	te := makeTestEnv(t, "foo/bar")
 

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -11,15 +11,13 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// todo(richardscothern): from cache control header or config
-const repositoryTTL = 24 * 7 * time.Hour
-
 type proxyManifestStore struct {
 	ctx             context.Context
 	localManifests  distribution.ManifestService
 	remoteManifests distribution.ManifestService
 	repositoryName  reference.Named
 	scheduler       *scheduler.TTLExpirationScheduler
+	ttl             *time.Duration
 	authChallenger  authChallenger
 }
 
@@ -77,7 +75,10 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 			return nil, err
 		}
 
-		pms.scheduler.AddManifest(repoBlob, repositoryTTL)
+		if pms.scheduler != nil && pms.ttl != nil {
+			pms.scheduler.AddManifest(repoBlob, *pms.ttl)
+		}
+
 		// Ensure the manifest blob is cleaned up
 		//pms.scheduler.AddBlob(blobRef, repositoryTTL)
 

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -273,3 +273,24 @@ func TestProxyManifests(t *testing.T) {
 	}
 
 }
+
+func TestProxyManifestsWithoutScheduler(t *testing.T) {
+	name := "foo/bar"
+	env := newManifestStoreTestEnv(t, name, "latest")
+	env.manifests.scheduler = nil
+
+	ctx := context.Background()
+	exists, err := env.manifests.Exists(ctx, env.manifestDigest)
+	if err != nil {
+		t.Fatalf("Error checking existence")
+	}
+	if !exists {
+		t.Errorf("Unexpected non-existent manifest")
+	}
+
+	// Get - should succeed without scheduler
+	_, err = env.manifests.Get(ctx, env.manifestDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
@@ -20,10 +21,13 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
+var repositoryTTL = 24 * 7 * time.Hour
+
 // proxyingRegistry fetches content from a remote registry and caches it locally
 type proxyingRegistry struct {
 	embedded       distribution.Namespace // provides local registry functionality
 	scheduler      *scheduler.TTLExpirationScheduler
+	ttl            *time.Duration
 	remoteURL      url.URL
 	authChallenger authChallenger
 }
@@ -36,61 +40,76 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}
 
 	v := storage.NewVacuum(ctx, driver)
-	s := scheduler.New(ctx, driver, "/scheduler-state.json")
-	s.OnBlobExpire(func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
 
-		repo, err := registry.Repository(ctx, r)
+	var s *scheduler.TTLExpirationScheduler
+	var ttl *time.Duration
+	if config.TTL == nil {
+		// Default TTL is 7 days
+		ttl = &repositoryTTL
+	} else if *config.TTL > 0 {
+		ttl = config.TTL
+	} else {
+		// TTL is disabled, never expire
+		ttl = nil
+	}
+
+	if ttl != nil {
+		s = scheduler.New(ctx, driver, "/scheduler-state.json")
+		s.OnBlobExpire(func(ref reference.Reference) error {
+			var r reference.Canonical
+			var ok bool
+			if r, ok = ref.(reference.Canonical); !ok {
+				return fmt.Errorf("unexpected reference type : %T", ref)
+			}
+
+			repo, err := registry.Repository(ctx, r)
+			if err != nil {
+				return err
+			}
+
+			blobs := repo.Blobs(ctx)
+
+			// Clear the repository reference and descriptor caches
+			err = blobs.Delete(ctx, r.Digest())
+			if err != nil {
+				return err
+			}
+
+			err = v.RemoveBlob(r.Digest().String())
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		s.OnManifestExpire(func(ref reference.Reference) error {
+			var r reference.Canonical
+			var ok bool
+			if r, ok = ref.(reference.Canonical); !ok {
+				return fmt.Errorf("unexpected reference type : %T", ref)
+			}
+
+			repo, err := registry.Repository(ctx, r)
+			if err != nil {
+				return err
+			}
+
+			manifests, err := repo.Manifests(ctx)
+			if err != nil {
+				return err
+			}
+			err = manifests.Delete(ctx, r.Digest())
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+
+		err = s.Start()
 		if err != nil {
-			return err
+			return nil, err
 		}
-
-		blobs := repo.Blobs(ctx)
-
-		// Clear the repository reference and descriptor caches
-		err = blobs.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-
-		err = v.RemoveBlob(r.Digest().String())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	s.OnManifestExpire(func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		manifests, err := repo.Manifests(ctx)
-		if err != nil {
-			return err
-		}
-		err = manifests.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-
-	err = s.Start()
-	if err != nil {
-		return nil, err
 	}
 
 	cs, err := configureAuth(config.Username, config.Password, config.RemoteURL)
@@ -101,6 +120,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	return &proxyingRegistry{
 		embedded:  registry,
 		scheduler: s,
+		ttl:       ttl,
 		remoteURL: *remoteURL,
 		authChallenger: &remoteAuthChallenger{
 			remoteURL: *remoteURL,
@@ -161,6 +181,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			localStore:     localRepo.Blobs(ctx),
 			remoteStore:    remoteRepo.Blobs(ctx),
 			scheduler:      pr.scheduler,
+			ttl:            pr.ttl,
 			repositoryName: name,
 			authChallenger: pr.authChallenger,
 		},
@@ -170,6 +191,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			remoteManifests: remoteManifests,
 			ctx:             ctx,
 			scheduler:       pr.scheduler,
+			ttl:             pr.ttl,
 			authChallenger:  pr.authChallenger,
 		},
 		name: name,


### PR DESCRIPTION
Currently when registry is run as proxy it tries to cleanup unused blobs from its cache after 7 days which is hard-coded. This PR makes that value configurable. One can disable caching using this option.

Continue https://github.com/distribution/distribution/pull/3238
Fixes https://github.com/distribution/distribution/issues/2736
Fixes https://github.com/distribution/distribution/issues/2367
Fixes https://github.com/distribution/distribution/issues/3704
Fixes https://github.com/distribution/distribution/issues/3879

(cherry picked from commit 8fe4ca4)

- backport of #3880
- mitigates #2367; pull-through caches may disable the TTL to reliably pull/avoid pruning.