### PR TITLE
docs: remove blank line

### DIFF
--- a/docs/spec/auth/jwt.md
+++ b/docs/spec/auth/jwt.md
@@ -159,7 +159,6 @@ Token has 3 main parts:
         </dt>
         <dd>
             An array of access entry objects with the following fields:
-
             <dl>
                 <dt>
                     <code>type</code>


### PR DESCRIPTION
This blank line confuses the markdown parser to think
that this is an indented code block.

Before:
![image](https://github.com/distribution/distribution/assets/35727626/78329173-2d12-4aec-abdb-aacdadfadac8)

After:
![image](https://github.com/distribution/distribution/assets/35727626/5c272060-e2ac-4909-83de-d3b45467f8e9)


Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
