### PR TITLE
[release/2.8 backport] docs: remove blank line

### DIFF
--- a/docs/spec/auth/jwt.md
+++ b/docs/spec/auth/jwt.md
@@ -159,7 +159,6 @@ Token has 3 main parts:
         </dt>
         <dd>
             An array of access entry objects with the following fields:
-
             <dl>
                 <dt>
                     <code>type</code>


### PR DESCRIPTION
This blank line confuses the markdown parser to think
that this is an indented code block.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
(cherry picked from commit 6183f230920c6bfd907a7fad1270bcb0c1baf317)
