### PR TITLE
[release/2.8 backport] Ignore self reference object on empty prefix

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1007,6 +1007,11 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 		}
 
 		for _, file := range objects.Contents {
+			// empty prefixes are listed as objects inside its own prefix.
+			// https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html
+			if strings.HasSuffix(*file.Key, "/") {
+				continue
+			}
 			walkInfos = append(walkInfos, walkInfoContainer{
 				FileInfoFields: storagedriver.FileInfoFields{
 					IsDir:   false,

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -161,6 +162,39 @@ func TestEmptyRootList(t *testing.T) {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
 		}
+	}
+}
+
+// TestWalkEmptySubDirectory assures we list an empty sub directory only once when walking
+// through its parent directory.
+func TestWalkEmptySubDirectory(t *testing.T) {
+	if skipS3() != "" {
+		t.Skip(skipS3())
+	}
+
+	drv, err := s3DriverConstructor("", s3.StorageClassStandard)
+	if err != nil {
+		t.Fatalf("unexpected error creating rooted driver: %v", err)
+	}
+
+	// create an empty sub directory.
+	s3driver := drv.StorageDriver.(*driver)
+	if _, err := s3driver.S3.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(os.Getenv("S3_BUCKET")),
+		Key:    aws.String("/testdir/emptydir/"),
+	}); err != nil {
+		t.Fatalf("error creating empty directory: %s", err)
+	}
+
+	bucketFiles := []string{}
+	s3driver.Walk(context.Background(), "/testdir", func(fileInfo storagedriver.FileInfo) error {
+		bucketFiles = append(bucketFiles, fileInfo.Path())
+		return nil
+	})
+
+	expected := []string{"/testdir/emptydir"}
+	if !reflect.DeepEqual(bucketFiles, expected) {
+		t.Errorf("expecting files %+v, found %+v instead", expected, bucketFiles)
 	}
 }
 


### PR DESCRIPTION
Backport of the following PR to the `release/2.8` branch:
- #3302

(cherry-picked from commit 87cbd09fa7ffbdc1b8eb2ab5098a5e91e815c216)

Without this fix, the S3 backend causes the registry to crash immediately after starting PurgeUploads. 
This affects downsteams like https://github.com/goharbor/harbor (which I am a user of, but not speaking for).

References:
- #2908
- #3180