### PR TITLE
Update docs GHA and renamed a doc file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+name: docs
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -7,6 +9,8 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/docs.yml
+      - dockerfiles/docs.Dockerfile
       - docs/**
   workflow_dispatch:
 
@@ -20,6 +24,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build docs
@@ -31,6 +38,13 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=docs
             *.cache-to=type=gha,scope=docs,mode=max
+        env:
+          DOCS_BASEURL: ${{ steps.pages.outputs.base_path }}
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "./build/docs" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -95,8 +95,15 @@ target "image-all" {
   ]
 }
 
+variable "DOCS_BASEURL" {
+  default = null
+}
+
 target "_common_docs" {
   dockerfile = "./dockerfiles/docs.Dockerfile"
+  args = {
+    DOCS_BASEURL = DOCS_BASEURL
+  }
 }
 
 target "docs-export" {

--- a/dockerfiles/docs.Dockerfile
+++ b/dockerfiles/docs.Dockerfile
@@ -16,8 +16,9 @@ COPY --from=hugo $GOPATH/bin/hugo /bin/hugo
 WORKDIR /src
 
 FROM build-base AS build
+ARG DOCS_BASEURL=/
 RUN --mount=type=bind,rw,source=docs,target=. \
-    hugo --gc --minify --destination /out
+    hugo --gc --minify --destination /out -b $DOCS_BASEURL
 
 FROM build-base AS server
 COPY docs .


### PR DESCRIPTION
We are missing GH pages setup step in the docs GHA

I went down the rabbit hole of GH pages and came across this:
* https://github.com/actions/upload-pages-artifact/issues/6

Which made me think we may be missing this:
* https://github.com/actions/starter-workflows/blob/b1df8a546ed4d0f27d46aaf2f8ac1118bc522638/pages/hugo.yml#L46-L48

We also rename `dockerhub.md` to `distirbution.md`.