### PR TITLE
Move dockerhub-readme workflow to the correct path

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/dockerhub-readme.yml'
+      - '.github/workflows/dockerhub-readme.yml'
       - 'docs/dockerhub.md'
 
 env:


### PR DESCRIPTION
https://github.com/distribution/distribution/pull/4087 added the `dockerhub-readme` workflow into `.github` path from where it can not be triggered:

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

> GitHub searches the .github/workflows directory in your repository for workflow files that are present in the associated commit SHA or Git ref of the event.


This PR addresses it and updates the workflow paths to the correct values.