### PR TITLE
Update dockerhub-readme GH Action

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Update Docker Hub README
         uses: peter-evans/dockerhub-description@v3
         with:


### PR DESCRIPTION
We were missing GitHub checkout step before running the update which is now causing the CI to fail on merge to `main` with the following error:

```
Error: ENOENT: no such file or directory, open './docs/dockerhub.md'
```