### PR TITLE
Bump minio version and test less storage classes

### DIFF
--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -210,7 +210,10 @@ func TestStorageClass(t *testing.T) {
 	rootDir := t.TempDir()
 	contents := []byte("contents")
 	ctx := context.Background()
-	for _, storageClass := range s3StorageClasses {
+
+	// We don't need to test all the storage classes, just that its selectable.
+	// The first 3 are common to AWS and MinIO, so use those.
+	for _, storageClass := range s3StorageClasses[:3] {
 		filename := "/test-" + storageClass
 		s3Driver, err := s3DriverConstructor(rootDir, storageClass)
 		if err != nil {

--- a/tests/docker-compose-storage.yml
+++ b/tests/docker-compose-storage.yml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: docker.io/minio/minio:RELEASE.2023-09-20T22-49-55Z
+    image: docker.io/minio/minio:RELEASE.2023-10-16T04-13-43Z
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -17,7 +17,7 @@ services:
       - ./miniodata/distribution:/data:Z
 
   minio-init:
-    image: docker.io/minio/mc:RELEASE.2023-02-16T19-20-11Z
+    image: docker.io/minio/mc:RELEASE.2023-10-14T01-57-03Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
This fixes some of the tests for minio.

The walk tests needs a version of minio that contains https://github.com/minio/minio/pull/18099

The storage classes minio supports are a subset of the s3 classes.