### PR TITLE
Add context to storagedriver.(Filewriter).Commit()

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -57,7 +57,7 @@ func (bw *blobWriter) StartedAt() time.Time {
 func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
 	dcontext.GetLogger(ctx).Debug("(*blobWriter).Commit")
 
-	if err := bw.fileWriter.Commit(); err != nil {
+	if err := bw.fileWriter.Commit(ctx); err != nil {
 		return distribution.Descriptor{}, err
 	}
 

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -544,7 +544,7 @@ func (w *writer) Cancel(ctx context.Context) error {
 	return err
 }
 
-func (w *writer) Commit() error {
+func (w *writer) Commit(ctx context.Context) error {
 	if w.closed {
 		return fmt.Errorf("already closed")
 	} else if w.committed {

--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -120,7 +120,7 @@ func TestCommitAfterMove(t *testing.T) {
 		t.Fatalf("writer.Write: unexpected error: %v", err)
 	}
 
-	err = writer.Commit()
+	err = writer.Commit(ctx)
 	if err != nil {
 		t.Fatalf("writer.Commit: unexpected error: %v", err)
 	}

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -142,7 +142,7 @@ func (d *driver) PutContent(ctx context.Context, subPath string, contents []byte
 		writer.Cancel(ctx)
 		return err
 	}
-	return writer.Commit()
+	return writer.Commit(ctx)
 }
 
 // Reader retrieves an io.ReadCloser for the content stored at "path" with a
@@ -397,7 +397,7 @@ func (fw *fileWriter) Cancel(ctx context.Context) error {
 	return os.Remove(fw.file.Name())
 }
 
-func (fw *fileWriter) Commit() error {
+func (fw *fileWriter) Commit(ctx context.Context) error {
 	if fw.closed {
 		return fmt.Errorf("already closed")
 	} else if fw.committed {

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -460,12 +460,11 @@ func putContentsClose(wc *storage.Writer, contents []byte) error {
 // Commit flushes all content written to this FileWriter and makes it
 // available for future calls to StorageDriver.GetContent and
 // StorageDriver.Reader.
-func (w *writer) Commit() error {
+func (w *writer) Commit(ctx context.Context) error {
 	if err := w.checkClosed(); err != nil {
 		return err
 	}
 	w.closed = true
-	ctx := context.TODO()
 
 	// no session started yet just perform a simple upload
 	if w.sessionURI == "" {

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -4,6 +4,7 @@
 package gcs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -122,7 +123,7 @@ func TestCommitEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("driver.Writer: unexpected error: %v", err)
 	}
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	if err != nil {
 		t.Fatalf("writer.Commit: unexpected error: %v", err)
 	}
@@ -169,7 +170,7 @@ func TestCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writer.Write: unexpected error: %v", err)
 	}
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	if err != nil {
 		t.Fatalf("writer.Commit: unexpected error: %v", err)
 	}

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -320,7 +320,7 @@ func (w *writer) Cancel(ctx context.Context) error {
 	return w.d.root.delete(w.f.path())
 }
 
-func (w *writer) Commit() error {
+func (w *writer) Commit(ctx context.Context) error {
 	if w.closed {
 		return fmt.Errorf("already closed")
 	} else if w.committed {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -123,7 +123,7 @@ type FileWriter interface {
 	// Commit flushes all content written to this FileWriter and makes it
 	// available for future calls to StorageDriver.GetContent and
 	// StorageDriver.Reader.
-	Commit() error
+	Commit(context.Context) error
 }
 
 // PathRegexp is the regular expression which each file path must match. A

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -291,7 +291,7 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(written, check.Equals, fileSize)
 
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = writer.Close()
 	c.Assert(err, check.IsNil)
@@ -446,7 +446,7 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(fullContents[curSize:])))
 
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = writer.Close()
 	c.Assert(err, check.IsNil)
@@ -484,7 +484,7 @@ func (suite *DriverSuite) TestWriteZeroByteStreamThenAppend(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Close the Writer
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = writer.Close()
 	c.Assert(err, check.IsNil)
@@ -512,7 +512,7 @@ func (suite *DriverSuite) TestWriteZeroByteStreamThenAppend(c *check.C) {
 	c.Assert(nn, check.Equals, int64(len(contentsChunk1)))
 
 	// Close the AppendWriter
-	err = awriter.Commit()
+	err = awriter.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = awriter.Close()
 	c.Assert(err, check.IsNil)
@@ -561,7 +561,7 @@ func (suite *DriverSuite) TestWriteZeroByteContentThenAppend(c *check.C) {
 	c.Assert(nn, check.Equals, int64(len(contentsChunk1)))
 
 	// Close the AppendWriter
-	err = awriter.Commit()
+	err = awriter.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = awriter.Close()
 	c.Assert(err, check.IsNil)
@@ -1156,7 +1156,7 @@ func (suite *DriverSuite) benchmarkStreamFiles(c *check.C, size int64) {
 		c.Assert(err, check.IsNil)
 		c.Assert(written, check.Equals, size)
 
-		err = writer.Commit()
+		err = writer.Commit(context.Background())
 		c.Assert(err, check.IsNil)
 		err = writer.Close()
 		c.Assert(err, check.IsNil)
@@ -1248,7 +1248,7 @@ func (suite *DriverSuite) testFileStreams(c *check.C, size int64) {
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, size)
 
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = writer.Close()
 	c.Assert(err, check.IsNil)
@@ -1284,7 +1284,7 @@ func (suite *DriverSuite) writeReadCompareStreams(c *check.C, filename string, c
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(contents)))
 
-	err = writer.Commit()
+	err = writer.Commit(context.Background())
 	c.Assert(err, check.IsNil)
 	err = writer.Close()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This PR changes `storagedriver.Filewriter` interface by adding `context.Context` as an argument to the `Commit` interface func.

We pass the context appropriately where need be throughout the `distribution` codebase to all the writers and tests.

In the case of the S3 storage driver we pass the `context` down to the driver `writer` and update all the AWS SDK calls in the `writer` with their `WithContext` variant. See this PR for more context (pun intended): https://github.com/distribution/distribution/pull/4066

PTAL @corhere, would love to get your thoughts/ideas on this.