### PR TITLE
[release/2.8 backport] reference: fix broken alias for DomainRegexp

### DIFF
--- a/reference/regexp_deprecated.go
+++ b/reference/regexp_deprecated.go
@@ -20,7 +20,7 @@ var DigestRegexp = reference.DigestRegexp
 // Deprecated: use [reference.DomainRegexp].
 //
 // [RFC 6874]: https://www.rfc-editor.org/rfc/rfc6874.
-var DomainRegexp = reference.DigestRegexp
+var DomainRegexp = reference.DomainRegexp
 
 // IdentifierRegexp is the format for string identifier used as a
 // content addressable identifier using sha256. These identifiers


### PR DESCRIPTION
- backport of https://github.com/distribution/distribution/pull/4113
- relates to / introduced in https://github.com/distribution/distribution/pull/4031
- relates to https://github.com/distribution/distribution/pull/4063

An incorrect alias snuck into 152af63ec5c569f074e9cf5d0e409d6928e034d8 (https://github.com/distribution/distribution/pull/4031), and DomainRegexp was aliased to the regex for digests (DigestRegexp).

This didn't affect this repository, as it didn't use the aliases and migrated to the new module, but does affect user of the old module that depend on the aliases.



(cherry picked from commit c8c2bc279cee5d3f81e589d59ca02e683e650835)