### PR TITLE
Hide our misuses of contexts from the public interface

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 )
 
@@ -279,7 +279,7 @@ func Handler(handler http.Handler) http.Handler {
 func statusResponse(w http.ResponseWriter, r *http.Request, status int, checks map[string]string) {
 	p, err := json.Marshal(checks)
 	if err != nil {
-		context.GetLogger(context.Background()).Errorf("error serializing health status: %v", err)
+		dcontext.GetLogger(dcontext.Background()).Errorf("error serializing health status: %v", err)
 		p, err = json.Marshal(struct {
 			ServerError string `json:"server_error"`
 		}{
@@ -288,7 +288,7 @@ func statusResponse(w http.ResponseWriter, r *http.Request, status int, checks m
 		status = http.StatusInternalServerError
 
 		if err != nil {
-			context.GetLogger(context.Background()).Errorf("error serializing health status failure message: %v", err)
+			dcontext.GetLogger(dcontext.Background()).Errorf("error serializing health status failure message: %v", err)
 			return
 		}
 	}
@@ -297,7 +297,7 @@ func statusResponse(w http.ResponseWriter, r *http.Request, status int, checks m
 	w.Header().Set("Content-Length", fmt.Sprint(len(p)))
 	w.WriteHeader(status)
 	if _, err := w.Write(p); err != nil {
-		context.GetLogger(context.Background()).Errorf("error writing health status response body: %v", err)
+		dcontext.GetLogger(dcontext.Background()).Errorf("error writing health status response body: %v", err)
 	}
 }
 

--- a/internal/client/repository_test.go
+++ b/internal/client/repository_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
@@ -108,7 +108,7 @@ func TestBlobServeBlob(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestBlobServeBlobHEAD(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
@@ -250,7 +250,7 @@ func TestBlobResume(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -307,7 +307,7 @@ func TestBlobDelete(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -327,7 +327,7 @@ func TestBlobFetch(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
@@ -382,7 +382,7 @@ func TestBlobExistsNoContentLength(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -406,7 +406,7 @@ func TestBlobExists(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
@@ -512,7 +512,7 @@ func TestBlobUploadChunked(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -622,7 +622,7 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -728,7 +728,7 @@ func TestBlobUploadMonolithicDockerUploadUUIDFromURL(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -833,7 +833,7 @@ func TestBlobUploadMonolithicNoDockerUploadUUID(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -891,7 +891,7 @@ func TestBlobMount(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1066,7 +1066,7 @@ func checkEqualManifest(m1, m2 *ocischema.DeserializedManifest) error {
 }
 
 func TestOCIManifestFetch(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo")
 	m1, dgst, pl := newRandomOCIManifest(t, 6)
 	var m testutil.RequestResponseMap
@@ -1149,7 +1149,7 @@ func TestManifestFetchWithEtag(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1171,7 +1171,7 @@ func TestManifestFetchWithEtag(t *testing.T) {
 }
 
 func TestManifestFetchWithAccept(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	repo, _ := reference.WithName("test.example.com/repo")
 	_, dgst, _ := newRandomOCIManifest(t, 6)
 	headers := make(chan []string, 1)
@@ -1258,7 +1258,7 @@ func TestManifestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	ms, err := r.Manifests(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -1315,7 +1315,7 @@ func TestManifestPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	ms, err := r.Manifests(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -1372,7 +1372,7 @@ func TestManifestTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	tagService := r.Tags(ctx)
 
 	tags, err := tagService.All(ctx)
@@ -1423,7 +1423,7 @@ func TestTagDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	ts := r.Tags(ctx)
 
 	if err := ts.Untag(ctx, tag); err != nil {
@@ -1460,7 +1460,7 @@ func TestObtainsErrorForMissingTag(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1487,7 +1487,7 @@ func TestObtainsManifestForTagWithoutHeaders(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1566,7 +1566,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	tagService := r.Tags(ctx)
 
 	tags, err := tagService.All(ctx)
@@ -1614,7 +1614,7 @@ func TestManifestUnauthorized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	ms, err := r.Manifests(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -1652,7 +1652,7 @@ func TestCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	numFilled, err := r.Repositories(ctx, entries, "")
 	if err != io.EOF {
 		t.Fatal(err)
@@ -1684,7 +1684,7 @@ func TestCatalogInParts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	numFilled, err := r.Repositories(ctx, entries, "")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/dcontext/context.go
+++ b/internal/dcontext/context.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"context"

--- a/internal/dcontext/doc.go
+++ b/internal/dcontext/doc.go
@@ -1,16 +1,16 @@
-// Package context provides several utilities for working with
+// Package dcontext provides several utilities for working with
 // Go's context in http requests. Primarily, the focus is on logging relevant
 // request information but this package is not limited to that purpose.
 //
 // The easiest way to get started is to get the background context:
 //
-//	ctx := context.Background()
+//	ctx := dcontext.Background()
 //
 // The returned context should be passed around your application and be the
 // root of all other context instances. If the application has a version, this
 // line should be called before anything else:
 //
-//	ctx := context.WithVersion(context.Background(), version)
+//	ctx := dcontext.WithVersion(dcontext.Background(), version)
 //
 // The above will store the version in the context and will be available to
 // the logger.
@@ -27,7 +27,7 @@
 // the context and reported with the logger. The following example would
 // return a logger that prints the version with each log message:
 //
-//	ctx := context.Context(context.Background(), "version", version)
+//	ctx := context.WithValue(dcontext.Background(), "version", version)
 //	GetLogger(ctx, "version").Infof("this log message has a version field")
 //
 // The above would print out a log message like this:
@@ -85,4 +85,4 @@
 // can be traced in log messages. Using the fields like "http.request.id", one
 // can analyze call flow for a particular request with a simple grep of the
 // logs.
-package context
+package dcontext

--- a/internal/dcontext/http.go
+++ b/internal/dcontext/http.go
@@ -40,16 +40,6 @@ func WithRequest(ctx context.Context, r *http.Request) context.Context {
 	}
 }
 
-// GetRequest returns the http request in the given context. Returns
-// ErrNoRequestContext if the context does not have an http request associated
-// with it.
-func GetRequest(ctx context.Context) (*http.Request, error) {
-	if r, ok := ctx.Value("http.request").(*http.Request); r != nil && ok {
-		return r, nil
-	}
-	return nil, ErrNoRequestContext
-}
-
 // GetRequestID attempts to resolve the current request id, if possible. An
 // error is return if it is not available on the context.
 func GetRequestID(ctx context.Context) string {

--- a/internal/dcontext/http.go
+++ b/internal/dcontext/http.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"context"

--- a/internal/dcontext/http_test.go
+++ b/internal/dcontext/http_test.go
@@ -2,9 +2,6 @@ package dcontext
 
 import (
 	"net/http"
-	"net/http/httptest"
-	"net/http/httputil"
-	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -218,71 +215,4 @@ func TestWithVars(t *testing.T) {
 			t.Fatalf("%q: %v != %v", tc.key, v, tc.expected)
 		}
 	}
-}
-
-// SingleHostReverseProxy will insert an X-Forwarded-For header, and can be used to test
-// RemoteAddr().  A fake RemoteAddr cannot be set on the HTTP request - it is overwritten
-// at the transport layer to 127.0.0.1:<port> .  However, as the X-Forwarded-For header
-// just contains the IP address, it is different enough for testing.
-func TestRemoteAddr(t *testing.T) {
-	var expectedRemote string
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
-		if r.RemoteAddr == expectedRemote {
-			t.Errorf("Unexpected matching remote addresses")
-		}
-
-		actualRemote := RemoteAddr(r)
-		if expectedRemote != actualRemote {
-			t.Errorf("Mismatching remote hosts: %v != %v", expectedRemote, actualRemote)
-		}
-
-		w.WriteHeader(200)
-	}))
-
-	defer backend.Close()
-	backendURL, err := url.Parse(backend.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	proxy := httputil.NewSingleHostReverseProxy(backendURL)
-	frontend := httptest.NewServer(proxy)
-	defer frontend.Close()
-
-	// X-Forwarded-For set by proxy
-	expectedRemote = "127.0.0.1"
-	proxyReq, err := http.NewRequest(http.MethodGet, frontend.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	resp, err := http.DefaultClient.Do(proxyReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// RemoteAddr in X-Real-Ip
-	getReq, err := http.NewRequest(http.MethodGet, backend.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedRemote = "1.2.3.4"
-	getReq.Header["X-Real-ip"] = []string{expectedRemote}
-	resp, err = http.DefaultClient.Do(getReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// Valid X-Real-Ip and invalid X-Forwarded-For
-	getReq.Header["X-forwarded-for"] = []string{"1.2.3"}
-	resp, err = http.DefaultClient.Do(getReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
 }

--- a/internal/dcontext/http_test.go
+++ b/internal/dcontext/http_test.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"net/http"

--- a/internal/dcontext/logger.go
+++ b/internal/dcontext/logger.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"context"

--- a/internal/dcontext/trace.go
+++ b/internal/dcontext/trace.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"context"

--- a/internal/dcontext/trace_test.go
+++ b/internal/dcontext/trace_test.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"runtime"

--- a/internal/dcontext/util.go
+++ b/internal/dcontext/util.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import (
 	"context"

--- a/internal/dcontext/version.go
+++ b/internal/dcontext/version.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import "context"
 

--- a/internal/dcontext/version_test.go
+++ b/internal/dcontext/version_test.go
@@ -1,4 +1,4 @@
-package context
+package dcontext
 
 import "testing"
 

--- a/internal/requestutil/util.go
+++ b/internal/requestutil/util.go
@@ -1,0 +1,51 @@
+package requestutil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func parseIP(ipStr string) net.IP {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		log.Warnf("invalid remote IP address: %q", ipStr)
+	}
+	return ip
+}
+
+// RemoteAddr extracts the remote address of the request, taking into
+// account proxy headers.
+func RemoteAddr(r *http.Request) string {
+	if prior := r.Header.Get("X-Forwarded-For"); prior != "" {
+		remoteAddr, _, _ := strings.Cut(prior, ",")
+		remoteAddr = strings.Trim(remoteAddr, " ")
+		if parseIP(remoteAddr) != nil {
+			return remoteAddr
+		}
+	}
+	// X-Real-Ip is less supported, but worth checking in the
+	// absence of X-Forwarded-For
+	if realIP := r.Header.Get("X-Real-Ip"); realIP != "" {
+		if parseIP(realIP) != nil {
+			return realIP
+		}
+	}
+
+	return r.RemoteAddr
+}
+
+// RemoteIP extracts the remote IP of the request, taking into
+// account proxy headers.
+func RemoteIP(r *http.Request) string {
+	addr := RemoteAddr(r)
+
+	// Try parsing it as "IP:port"
+	if ip, _, err := net.SplitHostPort(addr); err == nil {
+		return ip
+	}
+
+	return addr
+}

--- a/internal/requestutil/util_test.go
+++ b/internal/requestutil/util_test.go
@@ -1,0 +1,76 @@
+package requestutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+)
+
+// SingleHostReverseProxy will insert an X-Forwarded-For header, and can be used to test
+// RemoteAddr().  A fake RemoteAddr cannot be set on the HTTP request - it is overwritten
+// at the transport layer to 127.0.0.1:<port> .  However, as the X-Forwarded-For header
+// just contains the IP address, it is different enough for testing.
+func TestRemoteAddr(t *testing.T) {
+	var expectedRemote string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.RemoteAddr == expectedRemote {
+			t.Errorf("Unexpected matching remote addresses")
+		}
+
+		actualRemote := RemoteAddr(r)
+		if expectedRemote != actualRemote {
+			t.Errorf("Mismatching remote hosts: %v != %v", expectedRemote, actualRemote)
+		}
+
+		w.WriteHeader(200)
+	}))
+
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	// X-Forwarded-For set by proxy
+	expectedRemote = "127.0.0.1"
+	proxyReq, err := http.NewRequest(http.MethodGet, frontend.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(proxyReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// RemoteAddr in X-Real-Ip
+	getReq, err := http.NewRequest(http.MethodGet, backend.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRemote = "1.2.3.4"
+	getReq.Header["X-Real-ip"] = []string{expectedRemote}
+	resp, err = http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Valid X-Real-Ip and invalid X-Forwarded-For
+	getReq.Header["X-forwarded-for"] = []string{"1.2.3"}
+	resp, err = http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+}

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/internal/requestutil"
 	"github.com/distribution/reference"
 	events "github.com/docker/go-events"
 	"github.com/google/uuid"
@@ -49,7 +49,7 @@ func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request Re
 func NewRequestRecord(id string, r *http.Request) RequestRecord {
 	return RequestRecord{
 		ID:        id,
-		Addr:      dcontext.RemoteAddr(r),
+		Addr:      requestutil.RemoteAddr(r),
 		Host:      r.Host,
 		Method:    r.Method,
 		UserAgent: r.UserAgent(),

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/reference"
 	events "github.com/docker/go-events"
 	"github.com/google/uuid"
@@ -49,7 +49,7 @@ func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request Re
 func NewRequestRecord(id string, r *http.Request) RequestRecord {
 	return RequestRecord{
 		ID:        id,
-		Addr:      context.RemoteAddr(r),
+		Addr:      dcontext.RemoteAddr(r),
 		Host:      r.Host,
 		Method:    r.Method,
 		UserAgent: r.UserAgent(),

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/distribution/distribution/v3"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 )

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/cache/memory"

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -18,7 +18,7 @@
 //		resource := auth.Resource{Type: "customerOrder", Name: orderNumber}
 //		access := auth.Access{Resource: resource, Action: "update"}
 //
-//		if ctx, err := accessController.Authorized(ctx, access); err != nil {
+//		if ctx, err := accessController.Authorized(r, access); err != nil {
 //			if challenge, ok := err.(auth.Challenge) {
 //				// Let the challenge write the response.
 //				challenge.SetHeaders(r, w)
@@ -93,16 +93,15 @@ type Challenge interface {
 // and required access levels for a request. Implementations can support both
 // complete denial and http authorization challenges.
 type AccessController interface {
-	// Authorized returns a non-nil error if the context is granted access and
+	// Authorized returns a nil error if the request is granted access and
 	// returns a new authorized context. If one or more Access structs are
 	// provided, the requested access will be compared with what is available
-	// to the context. The given context will contain a "http.request" key with
-	// a `*http.Request` value. If the error is non-nil, access should always
-	// be denied. The error may be of type Challenge, in which case the caller
-	// may have the Challenge handle the request or choose what action to take
-	// based on the Challenge header or response status. The returned context
-	// object should have a "auth.user" value set to a UserInfo struct.
-	Authorized(ctx context.Context, access ...Access) (context.Context, error)
+	// to the request. Access is denied if the error is non-nil. The error may
+	// be of type Challenge, in which case the caller may have the Challenge
+	// handle the request or choose what action to take based on the Challenge
+	// header or response status. The returned context object should be derived
+	// from r.Context() and have a "auth.user" value set to a UserInfo struct.
+	Authorized(r *http.Request, access ...Access) (context.Context, error)
 }
 
 // CredentialAuthenticator is an object which is able to authenticate credentials

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -32,20 +32,9 @@
 package auth
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
-)
-
-const (
-	// UserKey is used to get the user object from
-	// a user context
-	UserKey = "auth.user"
-
-	// UserNameKey is used to get the user name from
-	// a user context
-	UserNameKey = "auth.user.name"
 )
 
 var (
@@ -113,63 +102,6 @@ type AccessController interface {
 // CredentialAuthenticator is an object which is able to authenticate credentials
 type CredentialAuthenticator interface {
 	AuthenticateUser(username, password string) error
-}
-
-// WithUser returns a context with the authorized user info.
-func WithUser(ctx context.Context, user UserInfo) context.Context {
-	return userInfoContext{
-		Context: ctx,
-		user:    user,
-	}
-}
-
-type userInfoContext struct {
-	context.Context
-	user UserInfo
-}
-
-func (uic userInfoContext) Value(key interface{}) interface{} {
-	switch key {
-	case UserKey:
-		return uic.user
-	case UserNameKey:
-		return uic.user.Name
-	}
-
-	return uic.Context.Value(key)
-}
-
-// WithResources returns a context with the authorized resources.
-func WithResources(ctx context.Context, resources []Resource) context.Context {
-	return resourceContext{
-		Context:   ctx,
-		resources: resources,
-	}
-}
-
-type resourceContext struct {
-	context.Context
-	resources []Resource
-}
-
-type resourceKey struct{}
-
-func (rc resourceContext) Value(key interface{}) interface{} {
-	if key == (resourceKey{}) {
-		return rc.resources
-	}
-
-	return rc.Context.Value(key)
-}
-
-// AuthorizedResources returns the list of resources which have
-// been authorized for this request.
-func AuthorizedResources(ctx context.Context) []Resource {
-	if resources, ok := ctx.Value(resourceKey{}).([]Resource); ok {
-		return resources
-	}
-
-	return nil
 }
 
 // InitFunc is the type of an AccessController factory function and is used

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -76,6 +76,12 @@ type Access struct {
 	Action string
 }
 
+// Grant describes the permitted level of access for an authorized request.
+type Grant struct {
+	User      UserInfo   // The authenticated user for the request.
+	Resources []Resource // The list of resources which have been authorized for the request.
+}
+
 // Challenge is a special error type which is used for HTTP 401 Unauthorized
 // responses and is able to write the response with WWW-Authenticate challenge
 // header values based on the error.
@@ -93,15 +99,15 @@ type Challenge interface {
 // and required access levels for a request. Implementations can support both
 // complete denial and http authorization challenges.
 type AccessController interface {
-	// Authorized returns a nil error if the request is granted access and
-	// returns a new authorized context. If one or more Access structs are
-	// provided, the requested access will be compared with what is available
-	// to the request. Access is denied if the error is non-nil. The error may
-	// be of type Challenge, in which case the caller may have the Challenge
-	// handle the request or choose what action to take based on the Challenge
-	// header or response status. The returned context object should be derived
-	// from r.Context() and have a "auth.user" value set to a UserInfo struct.
-	Authorized(r *http.Request, access ...Access) (context.Context, error)
+	// Authorized determines if the request is granted access. If one or more
+	// Access structs are provided, the requested access will be compared with
+	// what is available to the request.
+	//
+	// Return a Grant to grant the request access. Return an error to deny
+	// access. The error may be of type Challenge, in which case the caller may
+	// have the Challenge handle the request or choose what action to take based
+	// on the Challenge header or response status.
+	Authorized(r *http.Request, access ...Access) (*Grant, error)
 }
 
 // CredentialAuthenticator is an object which is able to authenticate credentials

--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 

--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -49,7 +49,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 	return &accessController{realm: realm.(string), path: path}, nil
 }
 
-func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.Access) (context.Context, error) {
+func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.Access) (*auth.Grant, error) {
 	username, password, ok := req.BasicAuth()
 	if !ok {
 		return nil, &challenge{
@@ -94,7 +94,7 @@ func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.
 		}
 	}
 
-	return auth.WithUser(req.Context(), auth.UserInfo{Name: username}), nil
+	return &auth.Grant{User: auth.UserInfo{Name: username}}, nil
 }
 
 // challenge implements the auth.Challenge interface.

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 
@@ -33,7 +33,7 @@ func TestBasicAccessController(t *testing.T) {
 		"realm": testRealm,
 		"path":  tempFile.Name(),
 	}
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	accessController, err := newAccessController(options)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestBasicAccessController(t *testing.T) {
 	userNumber := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithRequest(ctx, r)
+		ctx := dcontext.WithRequest(ctx, r)
 		authCtx, err := accessController.Authorized(ctx)
 		if err != nil {
 			switch err := err.(type) {

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 
@@ -33,7 +32,6 @@ func TestBasicAccessController(t *testing.T) {
 		"realm": testRealm,
 		"path":  tempFile.Name(),
 	}
-	ctx := dcontext.Background()
 
 	accessController, err := newAccessController(options)
 	if err != nil {
@@ -45,8 +43,7 @@ func TestBasicAccessController(t *testing.T) {
 	userNumber := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := dcontext.WithRequest(ctx, r)
-		authCtx, err := accessController.Authorized(ctx)
+		authCtx, err := accessController.Authorized(r)
 		if err != nil {
 			switch err := err.(type) {
 			case auth.Challenge:

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -43,7 +43,7 @@ func TestBasicAccessController(t *testing.T) {
 	userNumber := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authCtx, err := accessController.Authorized(r)
+		grant, err := accessController.Authorized(r)
 		if err != nil {
 			switch err := err.(type) {
 			case auth.Challenge:
@@ -55,13 +55,12 @@ func TestBasicAccessController(t *testing.T) {
 			}
 		}
 
-		userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
-		if !ok {
-			t.Fatal("basic accessController did not set auth.user context")
+		if grant == nil {
+			t.Fatal("basic accessController did not return auth grant")
 		}
 
-		if userInfo.Name != testUsers[userNumber] {
-			t.Fatalf("expected user name %q, got %q", testUsers[userNumber], userInfo.Name)
+		if grant.User.Name != testUsers[userNumber] {
+			t.Fatalf("expected user name %q, got %q", testUsers[userNumber], grant.User.Name)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/registry/auth/silly/access.go
+++ b/registry/auth/silly/access.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"strings"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 

--- a/registry/auth/silly/access.go
+++ b/registry/auth/silly/access.go
@@ -43,12 +43,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 
 // Authorized simply checks for the existence of the authorization header,
 // responding with a bearer challenge if it doesn't exist.
-func (ac *accessController) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {
-	req, err := dcontext.GetRequest(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.Access) (context.Context, error) {
 	if req.Header.Get("Authorization") == "" {
 		challenge := challenge{
 			realm:   ac.realm,
@@ -66,7 +61,7 @@ func (ac *accessController) Authorized(ctx context.Context, accessRecords ...aut
 		return nil, &challenge
 	}
 
-	ctx = auth.WithUser(ctx, auth.UserInfo{Name: "silly"})
+	ctx := auth.WithUser(req.Context(), auth.UserInfo{Name: "silly"})
 	ctx = dcontext.WithLogger(ctx, dcontext.GetLogger(ctx, auth.UserNameKey, auth.UserKey))
 
 	return ctx, nil

--- a/registry/auth/silly/access.go
+++ b/registry/auth/silly/access.go
@@ -8,12 +8,10 @@
 package silly
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
-	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 
@@ -43,7 +41,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 
 // Authorized simply checks for the existence of the authorization header,
 // responding with a bearer challenge if it doesn't exist.
-func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.Access) (context.Context, error) {
+func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.Access) (*auth.Grant, error) {
 	if req.Header.Get("Authorization") == "" {
 		challenge := challenge{
 			realm:   ac.realm,
@@ -61,10 +59,7 @@ func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.
 		return nil, &challenge
 	}
 
-	ctx := auth.WithUser(req.Context(), auth.UserInfo{Name: "silly"})
-	ctx = dcontext.WithLogger(ctx, dcontext.GetLogger(ctx, auth.UserNameKey, auth.UserKey))
-
-	return ctx, nil
+	return &auth.Grant{User: auth.UserInfo{Name: "silly"}}, nil
 }
 
 type challenge struct {

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 
@@ -16,8 +15,7 @@ func TestSillyAccessController(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := dcontext.WithRequest(dcontext.Background(), r)
-		authCtx, err := ac.Authorized(ctx)
+		authCtx, err := ac.Authorized(r)
 		if err != nil {
 			switch err := err.(type) {
 			case auth.Challenge:

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -15,7 +15,7 @@ func TestSillyAccessController(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authCtx, err := ac.Authorized(r)
+		grant, err := ac.Authorized(r)
 		if err != nil {
 			switch err := err.(type) {
 			case auth.Challenge:
@@ -27,13 +27,12 @@ func TestSillyAccessController(t *testing.T) {
 			}
 		}
 
-		userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
-		if !ok {
-			t.Fatal("silly accessController did not set auth.user context")
+		if grant == nil {
+			t.Fatal("silly accessController did not return auth grant")
 		}
 
-		if userInfo.Name != "silly" {
-			t.Fatalf("expected user name %q, got %q", "silly", userInfo.Name)
+		if grant.User.Name != "silly" {
+			t.Fatalf("expected user name %q, got %q", "silly", grant.User.Name)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 )
 
@@ -16,7 +16,7 @@ func TestSillyAccessController(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithRequest(context.Background(), r)
+		ctx := dcontext.WithRequest(dcontext.Background(), r)
 		authCtx, err := ac.Authorized(ctx)
 		if err != nil {
 			switch err := err.(type) {

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/json"
@@ -291,7 +290,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 
 // Authorized handles checking whether the given request is authorized
 // for actions on resources described by the given access items.
-func (ac *accessController) Authorized(req *http.Request, accessItems ...auth.Access) (context.Context, error) {
+func (ac *accessController) Authorized(req *http.Request, accessItems ...auth.Access) (*auth.Grant, error) {
 	challenge := &authChallenge{
 		realm:        ac.realm,
 		autoRedirect: ac.autoRedirect,
@@ -332,9 +331,10 @@ func (ac *accessController) Authorized(req *http.Request, accessItems ...auth.Ac
 		}
 	}
 
-	ctx := auth.WithResources(req.Context(), claims.resources())
-
-	return auth.WithUser(ctx, auth.UserInfo{Name: claims.Subject}), nil
+	return &auth.Grant{
+		User:      auth.UserInfo{Name: claims.Subject},
+		Resources: claims.resources(),
+	}, nil
 }
 
 // init handles registering the token auth backend.

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"strings"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 	"github.com/go-jose/go-jose/v3"
 )

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -465,7 +465,7 @@ func TestAccessController(t *testing.T) {
 		Action: "baz",
 	}
 
-	authCtx, err := accessController.Authorized(req, testAccess)
+	grant, err := accessController.Authorized(req, testAccess)
 	challenge, ok := err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -475,8 +475,8 @@ func TestAccessController(t *testing.T) {
 		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrTokenRequired)
 	}
 
-	if authCtx != nil {
-		t.Fatalf("expected nil auth context but got %s", authCtx)
+	if grant != nil {
+		t.Fatalf("expected nil auth grant but got %#v", grant)
 	}
 
 	// 2. Supply an invalid token.
@@ -500,7 +500,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(req, testAccess)
+	grant, err = accessController.Authorized(req, testAccess)
 	challenge, ok = err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -510,8 +510,8 @@ func TestAccessController(t *testing.T) {
 		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrTokenRequired)
 	}
 
-	if authCtx != nil {
-		t.Fatalf("expected nil auth context but got %s", authCtx)
+	if grant != nil {
+		t.Fatalf("expected nil auth grant but got %#v", grant)
 	}
 
 	// create a valid jwk
@@ -532,7 +532,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(req, testAccess)
+	grant, err = accessController.Authorized(req, testAccess)
 	challenge, ok = err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -542,8 +542,8 @@ func TestAccessController(t *testing.T) {
 		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrInsufficientScope)
 	}
 
-	if authCtx != nil {
-		t.Fatalf("expected nil auth context but got %s", authCtx)
+	if grant != nil {
+		t.Fatalf("expected nil auth grant but got %#v", grant)
 	}
 
 	// 4. Supply the token we need, or deserve, or whatever.
@@ -562,18 +562,13 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(req, testAccess)
+	grant, err = accessController.Authorized(req, testAccess)
 	if err != nil {
 		t.Fatalf("accessController returned unexpected error: %s", err)
 	}
 
-	userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
-	if !ok {
-		t.Fatal("token accessController did not set auth.user context")
-	}
-
-	if userInfo.Name != "foo" {
-		t.Fatalf("expected user name %q, got %q", "foo", userInfo.Name)
+	if grant.User.Name != "foo" {
+		t.Fatalf("expected user name %q, got %q", "foo", grant.User.Name)
 	}
 
 	// 5. Supply a token with full admin rights, which is represented as "*".

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -466,8 +465,7 @@ func TestAccessController(t *testing.T) {
 		Action: "baz",
 	}
 
-	ctx := dcontext.WithRequest(dcontext.Background(), req)
-	authCtx, err := accessController.Authorized(ctx, testAccess)
+	authCtx, err := accessController.Authorized(req, testAccess)
 	challenge, ok := err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -502,7 +500,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(ctx, testAccess)
+	authCtx, err = accessController.Authorized(req, testAccess)
 	challenge, ok = err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -534,7 +532,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(ctx, testAccess)
+	authCtx, err = accessController.Authorized(req, testAccess)
 	challenge, ok = err.(auth.Challenge)
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
@@ -564,7 +562,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	authCtx, err = accessController.Authorized(ctx, testAccess)
+	authCtx, err = accessController.Authorized(req, testAccess)
 	if err != nil {
 		t.Fatalf("accessController returned unexpected error: %s", err)
 	}
@@ -594,7 +592,7 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Raw))
 
-	_, err = accessController.Authorized(ctx, testAccess)
+	_, err = accessController.Authorized(req, testAccess)
 	if err != nil {
 		t.Fatalf("accessController returned unexpected error: %s", err)
 	}

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/auth"
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -466,7 +466,7 @@ func TestAccessController(t *testing.T) {
 		Action: "baz",
 	}
 
-	ctx := context.WithRequest(context.Background(), req)
+	ctx := dcontext.WithRequest(dcontext.Background(), req)
 	authCtx, err := accessController.Authorized(ctx, testAccess)
 	challenge, ok := err.(auth.Challenge)
 	if !ok {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -797,7 +797,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 		accessRecords = appendCatalogAccessRecord(accessRecords, r)
 	}
 
-	ctx, err := app.accessController.Authorized(context.Context, accessRecords...)
+	ctx, err := app.accessController.Authorized(r.WithContext(context.Context), accessRecords...)
 	if err != nil {
 		switch err := err.(type) {
 		case auth.Challenge:

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/configuration"
-	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/health"
 	"github.com/distribution/distribution/v3/health/checks"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	prometheus "github.com/distribution/distribution/v3/metrics"
 	"github.com/distribution/distribution/v3/notifications"
 	"github.com/distribution/distribution/v3/registry/api/errcode"

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -635,7 +635,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		}
 
 		// Add username to request logging
-		context.Context = dcontext.WithLogger(context.Context, dcontext.GetLogger(context.Context, auth.UserNameKey))
+		context.Context = dcontext.WithLogger(context.Context, dcontext.GetLogger(context.Context, userNameKey))
 
 		// sync up context on the request.
 		r = r.WithContext(context)
@@ -822,10 +822,10 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 		return fmt.Errorf("access controller returned neither an access grant nor an error")
 	}
 
-	ctx := auth.WithUser(context.Context, grant.User)
-	ctx = auth.WithResources(ctx, grant.Resources)
+	ctx := withUser(context.Context, grant.User)
+	ctx = withResources(ctx, grant.Resources)
 
-	dcontext.GetLogger(ctx, auth.UserNameKey).Info("authorized request")
+	dcontext.GetLogger(ctx, userNameKey).Info("authorized request")
 	// TODO(stevvooe): This pattern needs to be cleaned up a bit. One context
 	// should be replaced by another, rather than replacing the context on a
 	// mutable object.

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3/configuration"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	v2 "github.com/distribution/distribution/v3/registry/api/v2"
 	"github.com/distribution/distribution/v3/registry/auth"
@@ -25,7 +25,7 @@ import (
 // tested individually.
 func TestAppDispatcher(t *testing.T) {
 	driver := inmemory.New()
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	registry, err := storage.NewRegistry(ctx, driver, storage.BlobDescriptorCacheProvider(memorycache.NewInMemoryBlobDescriptorCacheProvider(0)), storage.EnableDelete, storage.EnableRedirect)
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
@@ -139,7 +139,7 @@ func TestAppDispatcher(t *testing.T) {
 // TestNewApp covers the creation of an application via NewApp with a
 // configuration.
 func TestNewApp(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	config := configuration.Configuration{
 		Storage: configuration.Storage{
 			"inmemory": nil,

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
@@ -53,7 +53,7 @@ type blobHandler struct {
 // GetBlob fetches the binary data from backend storage returns it in the
 // response.
 func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
-	context.GetLogger(bh).Debug("GetBlob")
+	dcontext.GetLogger(bh).Debug("GetBlob")
 	blobs := bh.Repository.Blobs(bh)
 	desc, err := blobs.Stat(bh, bh.Digest)
 	if err != nil {
@@ -66,7 +66,7 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := blobs.ServeBlob(bh, w, r, desc.Digest); err != nil {
-		context.GetLogger(bh).Debugf("unexpected error getting blob HTTP handler: %v", err)
+		dcontext.GetLogger(bh).Debugf("unexpected error getting blob HTTP handler: %v", err)
 		bh.Errors = append(bh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		return
 	}
@@ -74,7 +74,7 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 
 // DeleteBlob deletes a layer blob
 func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
-	context.GetLogger(bh).Debug("DeleteBlob")
+	dcontext.GetLogger(bh).Debug("DeleteBlob")
 
 	blobs := bh.Repository.Blobs(bh)
 	err := blobs.Delete(bh, bh.Digest)
@@ -88,7 +88,7 @@ func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 			return
 		default:
 			bh.Errors = append(bh.Errors, err)
-			context.GetLogger(bh).Errorf("Unknown error deleting blob: %s", err.Error())
+			dcontext.GetLogger(bh).Errorf("Unknown error deleting blob: %s", err.Error())
 			return
 		}
 	}

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/reference"

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -77,10 +77,20 @@ func getUploadUUID(ctx context.Context) (uuid string) {
 	return dcontext.GetStringValue(ctx, "vars.uuid")
 }
 
+const (
+	// userKey is used to get the user object from
+	// a user context
+	userKey = "auth.user"
+
+	// userNameKey is used to get the user name from
+	// a user context
+	userNameKey = "auth.user.name"
+)
+
 // getUserName attempts to resolve a username from the context and request. If
 // a username cannot be resolved, the empty string is returned.
 func getUserName(ctx context.Context, r *http.Request) string {
-	username := dcontext.GetStringValue(ctx, auth.UserNameKey)
+	username := dcontext.GetStringValue(ctx, userNameKey)
 
 	// Fallback to request user with basic auth
 	if username == "" {
@@ -92,4 +102,61 @@ func getUserName(ctx context.Context, r *http.Request) string {
 	}
 
 	return username
+}
+
+// withUser returns a context with the authorized user info.
+func withUser(ctx context.Context, user auth.UserInfo) context.Context {
+	return userInfoContext{
+		Context: ctx,
+		user:    user,
+	}
+}
+
+type userInfoContext struct {
+	context.Context
+	user auth.UserInfo
+}
+
+func (uic userInfoContext) Value(key interface{}) interface{} {
+	switch key {
+	case userKey:
+		return uic.user
+	case userNameKey:
+		return uic.user.Name
+	}
+
+	return uic.Context.Value(key)
+}
+
+// withResources returns a context with the authorized resources.
+func withResources(ctx context.Context, resources []auth.Resource) context.Context {
+	return resourceContext{
+		Context:   ctx,
+		resources: resources,
+	}
+}
+
+type resourceContext struct {
+	context.Context
+	resources []auth.Resource
+}
+
+type resourceKey struct{}
+
+func (rc resourceContext) Value(key interface{}) interface{} {
+	if key == (resourceKey{}) {
+		return rc.resources
+	}
+
+	return rc.Context.Value(key)
+}
+
+// authorizedResources returns the list of resources which have
+// been authorized for this request.
+func authorizedResources(ctx context.Context) []auth.Resource {
+	if resources, ok := ctx.Value(resourceKey{}).([]auth.Resource); ok {
+		return resources
+	}
+
+	return nil
 }

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	v2 "github.com/distribution/distribution/v3/registry/api/v2"
 	"github.com/distribution/distribution/v3/registry/auth"

--- a/registry/handlers/health_test.go
+++ b/registry/handlers/health_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
-	"github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/health"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 func TestFileHealthCheck(t *testing.T) {
@@ -39,7 +39,7 @@ func TestFileHealthCheck(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	app := NewApp(ctx, config)
 	healthRegistry := health.NewRegistry()
@@ -103,7 +103,7 @@ func TestTCPHealthCheck(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	app := NewApp(ctx, config)
 	healthRegistry := health.NewRegistry()
@@ -165,7 +165,7 @@ func TestHTTPHealthCheck(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	app := NewApp(ctx, config)
 	healthRegistry := health.NewRegistry()

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 // closeResources closes all the provided resources after running the target

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -13,7 +13,6 @@ import (
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
-	"github.com/distribution/distribution/v3/registry/auth"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/reference"
 	"github.com/gorilla/handlers"
@@ -394,7 +393,7 @@ func (imh *manifestHandler) applyResourcePolicy(manifest distribution.Manifest) 
 		return errcode.ErrorCodeDenied.WithMessage(fmt.Sprintf("registry does not allow %s manifest", class))
 	}
 
-	resources := auth.AuthorizedResources(imh)
+	resources := authorizedResources(imh)
 	n := imh.Repository.Named().Name()
 
 	var foundResource bool

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/manifest/schema2"

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/internal/client/auth"
 	"github.com/distribution/distribution/v3/internal/client/auth/challenge"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 const challengeHeader = "Docker-Distribution-Api-Version"
@@ -44,7 +44,7 @@ func configureAuth(username, password, remoteURL string) (auth.CredentialStore, 
 	}
 
 	for _, url := range authURLs {
-		context.GetLogger(context.Background()).Infof("Discovered token authentication URL: %s", url)
+		dcontext.GetLogger(dcontext.Background()).Infof("Discovered token authentication URL: %s", url)
 		creds[url] = userpass{
 			username: username,
 			password: password,

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/reference"
 )

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/reference"
 )

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/configuration"
-	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/internal/client"
 	"github.com/distribution/distribution/v3/internal/client/auth"
 	"github.com/distribution/distribution/v3/internal/client/auth/challenge"
 	"github.com/distribution/distribution/v3/internal/client/transport"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver"

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/reference"
 )

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/distribution/reference"
 )
@@ -40,7 +40,7 @@ func TestSchedule(t *testing.T) {
 	}
 
 	var mu sync.Mutex
-	s := New(context.Background(), inmemory.New(), "/ttl")
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
 	deleteFunc := func(repoName reference.Reference) error {
 		if len(remainingRepos) == 0 {
 			t.Fatalf("Incorrect expiry count")
@@ -123,14 +123,14 @@ func TestRestoreOld(t *testing.T) {
 		t.Fatalf("Error serializing test data: %s", err.Error())
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	pathToStatFile := "/ttl"
 	fs := inmemory.New()
 	err = fs.PutContent(ctx, pathToStatFile, serialized)
 	if err != nil {
 		t.Fatal("Unable to write serialized data to fs")
 	}
-	s := New(context.Background(), fs, "/ttl")
+	s := New(dcontext.Background(), fs, "/ttl")
 	s.OnBlobExpire(deleteFunc)
 	err = s.Start()
 	if err != nil {
@@ -165,7 +165,7 @@ func TestStopRestore(t *testing.T) {
 
 	fs := inmemory.New()
 	pathToStateFile := "/ttl"
-	s := New(context.Background(), fs, pathToStateFile)
+	s := New(dcontext.Background(), fs, pathToStateFile)
 	s.onBlobExpire = deleteFunc
 
 	err := s.Start()
@@ -181,7 +181,7 @@ func TestStopRestore(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// v2 will restore state from fs
-	s2 := New(context.Background(), fs, pathToStateFile)
+	s2 := New(dcontext.Background(), fs, pathToStateFile)
 	s2.onBlobExpire = deleteFunc
 	err = s2.Start()
 	if err != nil {
@@ -197,7 +197,7 @@ func TestStopRestore(t *testing.T) {
 }
 
 func TestDoubleStart(t *testing.T) {
-	s := New(context.Background(), inmemory.New(), "/ttl")
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
 	err := s.Start()
 	if err != nil {
 		t.Fatalf("Unable to start scheduler")

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -21,8 +21,8 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/distribution/distribution/v3/configuration"
-	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/health"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/handlers"
 	"github.com/distribution/distribution/v3/registry/listener"
 	"github.com/distribution/distribution/v3/version"

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"

--- a/registry/root.go
+++ b/registry/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 	"github.com/distribution/distribution/v3/version"

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/opencontainers/go-digest"
 )

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"

--- a/registry/storage/blobwriter_nonresumable.go
+++ b/registry/storage/blobwriter_nonresumable.go
@@ -4,7 +4,7 @@
 package storage
 
 import (
-	"github.com/distribution/distribution/v3/context"
+	"context"
 )
 
 // resumeHashAt is a noop when resumable digest support is disabled.

--- a/registry/storage/cache/cachedblobdescriptorstore.go
+++ b/registry/storage/cache/cachedblobdescriptorstore.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	prometheus "github.com/distribution/distribution/v3/metrics"
 	"github.com/opencontainers/go-digest"
 )

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -286,7 +287,7 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 // Move moves an object stored at sourcePath to destPath, removing the original
 // object.
 func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) error {
-	sourceBlobURL, err := d.URLFor(ctx, sourcePath, nil)
+	sourceBlobURL, err := d.signBlobURL(ctx, sourcePath)
 	if err != nil {
 		return err
 	}
@@ -366,18 +367,15 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	return nil
 }
 
-// URLFor returns a publicly accessible URL for the blob stored at given path
+// RedirectURL returns a publicly accessible URL for the blob stored at given path
 // for specified duration by making use of Azure Storage Shared Access Signatures (SAS).
 // See https://msdn.microsoft.com/en-us/library/azure/ee395415.aspx for more info.
-func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+func (d *driver) RedirectURL(req *http.Request, path string) (string, error) {
+	return d.signBlobURL(req.Context(), path)
+}
+
+func (d *driver) signBlobURL(ctx context.Context, path string) (string, error) {
 	expiresTime := time.Now().UTC().Add(20 * time.Minute) // default expiration
-	expires, ok := options["expiry"]
-	if ok {
-		t, ok := expires.(time.Time)
-		if ok {
-			expiresTime = t
-		}
-	}
 	blobName := d.blobName(path)
 	blobRef := d.client.NewBlobClient(blobName)
 	return d.azClient.SignBlobURL(ctx, blobRef.URL(), expiresTime)

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -40,6 +40,7 @@ package base
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
@@ -208,18 +209,18 @@ func (base *Base) Delete(ctx context.Context, path string) error {
 	return err
 }
 
-// URLFor wraps URLFor of underlying storage driver.
-func (base *Base) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	ctx, done := dcontext.WithTrace(ctx)
-	defer done("%s.URLFor(%q)", base.Name(), path)
+// RedirectURL wraps RedirectURL of the underlying storage driver.
+func (base *Base) RedirectURL(r *http.Request, path string) (string, error) {
+	ctx, done := dcontext.WithTrace(r.Context())
+	defer done("%s.RedirectURL(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return "", storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
 	}
 
 	start := time.Now()
-	str, e := base.StorageDriver.URLFor(ctx, path, options)
-	storageAction.WithValues(base.Name(), "URLFor").UpdateSince(start)
+	str, e := base.StorageDriver.RedirectURL(r.WithContext(ctx), path)
+	storageAction.WithValues(base.Name(), "RedirectURL").UpdateSince(start)
 	return str, base.setDriverName(e)
 }
 

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -42,7 +42,7 @@ import (
 	"io"
 	"time"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	prometheus "github.com/distribution/distribution/v3/metrics"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/docker/go-metrics"

--- a/registry/storage/driver/base/regulator.go
+++ b/registry/storage/driver/base/regulator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
@@ -172,13 +173,11 @@ func (r *regulator) Delete(ctx context.Context, path string) error {
 	return r.StorageDriver.Delete(ctx, path)
 }
 
-// URLFor returns a URL which may be used to retrieve the content stored at
-// the given path, possibly using the given options.
-// May return an ErrUnsupportedMethod in certain StorageDriver
-// implementations.
-func (r *regulator) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+// RedirectURL returns a URL which may be used to retrieve the content stored at
+// the given path.
+func (r *regulator) RedirectURL(req *http.Request, path string) (string, error) {
 	r.enter()
 	defer r.exit()
 
-	return r.StorageDriver.URLFor(ctx, path, options)
+	return r.StorageDriver.RedirectURL(req, path)
 }

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"time"
@@ -282,10 +283,9 @@ func (d *driver) Delete(ctx context.Context, subPath string) error {
 	return err
 }
 
-// URLFor returns a URL which may be used to retrieve the content stored at the given path.
-// May return an UnsupportedMethodErr in certain StorageDriver implementations.
-func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	return "", storagedriver.ErrUnsupportedMethod{}
+// RedirectURL returns a URL which may be used to retrieve the content stored at the given path.
+func (d *driver) RedirectURL(*http.Request, string) (string, error) {
+	return "", nil
 }
 
 // Walk traverses a filesystem defined within driver, starting

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/testsuites"
 	"golang.org/x/oauth2"

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"time"
 
@@ -236,10 +237,9 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	}
 }
 
-// URLFor returns a URL which may be used to retrieve the content stored at the given path.
-// May return an UnsupportedMethodErr in certain StorageDriver implementations.
-func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	return "", storagedriver.ErrUnsupportedMethod{}
+// RedirectURL returns a URL which may be used to retrieve the content stored at the given path.
+func (d *driver) RedirectURL(*http.Request, string) (string, error) {
+	return "", nil
 }
 
 // Walk traverses a filesystem defined within driver, starting

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudfront/sign"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	storagemiddleware "github.com/distribution/distribution/v3/registry/storage/driver/middleware"
 )

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -195,18 +196,18 @@ type S3BucketKeyer interface {
 	S3BucketKey(path string) string
 }
 
-// URLFor attempts to find a url which may be used to retrieve the file at the given path.
+// RedirectURL attempts to find a url which may be used to retrieve the file at the given path.
 // Returns an error if the file cannot be found.
-func (lh *cloudFrontStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+func (lh *cloudFrontStorageMiddleware) RedirectURL(r *http.Request, path string) (string, error) {
 	// TODO(endophage): currently only supports S3
 	keyer, ok := lh.StorageDriver.(S3BucketKeyer)
 	if !ok {
-		dcontext.GetLogger(ctx).Warn("the CloudFront middleware does not support this backend storage driver")
-		return lh.StorageDriver.URLFor(ctx, path, options)
+		dcontext.GetLogger(r.Context()).Warn("the CloudFront middleware does not support this backend storage driver")
+		return lh.StorageDriver.RedirectURL(r, path)
 	}
 
-	if eligibleForS3(ctx, lh.awsIPs) {
-		return lh.StorageDriver.URLFor(ctx, path, options)
+	if eligibleForS3(r, lh.awsIPs) {
+		return lh.StorageDriver.RedirectURL(r, path)
 	}
 
 	// Get signed cloudfront url.

--- a/registry/storage/driver/middleware/cloudfront/s3filter.go
+++ b/registry/storage/driver/middleware/cloudfront/s3filter.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 const (

--- a/registry/storage/driver/middleware/cloudfront/s3filter.go
+++ b/registry/storage/driver/middleware/cloudfront/s3filter.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/internal/requestutil"
 )
 
 const (
@@ -188,7 +189,7 @@ func parseIPFromRequest(ctx context.Context) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	ipStr := dcontext.RemoteIP(request)
+	ipStr := requestutil.RemoteIP(request)
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid ip address from requester: %s", ipStr)
@@ -208,7 +209,7 @@ func eligibleForS3(ctx context.Context, awsIPs *awsIPs) bool {
 			} else {
 				loggerField := map[interface{}]interface{}{
 					"user-client": request.UserAgent(),
-					"ip":          dcontext.RemoteIP(request),
+					"ip":          requestutil.RemoteIP(request),
 				}
 				if awsIPs.contains(addr) {
 					dcontext.GetLoggerWithFields(ctx, loggerField).Info("request from the allowed AWS region, skipping CloudFront")

--- a/registry/storage/driver/middleware/cloudfront/s3filter_test.go
+++ b/registry/storage/driver/middleware/cloudfront/s3filter_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 // Rather than pull in all of testify

--- a/registry/storage/driver/middleware/cloudfront/s3filter_test.go
+++ b/registry/storage/driver/middleware/cloudfront/s3filter_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -11,8 +10,6 @@ import (
 	"reflect" // used as a replacement for testify
 	"testing"
 	"time"
-
-	"github.com/distribution/distribution/v3/internal/dcontext"
 )
 
 // Rather than pull in all of testify
@@ -269,29 +266,22 @@ func TestEligibleForS3(t *testing.T) {
 		}},
 		initialized: true,
 	}
-	empty := context.TODO()
-	makeContext := func(ip string) context.Context {
-		req := &http.Request{
-			RemoteAddr: ip,
-		}
-
-		return dcontext.WithRequest(empty, req)
-	}
 
 	tests := []struct {
-		Context  context.Context
-		Expected bool
+		RemoteAddr string
+		Expected   bool
 	}{
-		{Context: empty, Expected: false},
-		{Context: makeContext("192.168.1.2"), Expected: true},
-		{Context: makeContext("192.168.0.2"), Expected: false},
+		{RemoteAddr: "", Expected: false},
+		{RemoteAddr: "192.168.1.2", Expected: true},
+		{RemoteAddr: "192.168.0.2", Expected: false},
 	}
 
 	for _, tc := range tests {
 		tc := tc
-		t.Run(fmt.Sprintf("Client IP = %v", tc.Context.Value("http.request.ip")), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Client IP = %v", tc.RemoteAddr), func(t *testing.T) {
 			t.Parallel()
-			assertEqual(t, tc.Expected, eligibleForS3(tc.Context, ips))
+			req := &http.Request{RemoteAddr: tc.RemoteAddr}
+			assertEqual(t, tc.Expected, eligibleForS3(req, ips))
 		})
 	}
 }
@@ -305,29 +295,22 @@ func TestEligibleForS3WithAWSIPNotInitialized(t *testing.T) {
 		}},
 		initialized: false,
 	}
-	empty := context.TODO()
-	makeContext := func(ip string) context.Context {
-		req := &http.Request{
-			RemoteAddr: ip,
-		}
-
-		return dcontext.WithRequest(empty, req)
-	}
 
 	tests := []struct {
-		Context  context.Context
-		Expected bool
+		RemoteAddr string
+		Expected   bool
 	}{
-		{Context: empty, Expected: false},
-		{Context: makeContext("192.168.1.2"), Expected: false},
-		{Context: makeContext("192.168.0.2"), Expected: false},
+		{RemoteAddr: "", Expected: false},
+		{RemoteAddr: "192.168.1.2", Expected: false},
+		{RemoteAddr: "192.168.0.2", Expected: false},
 	}
 
 	for _, tc := range tests {
 		tc := tc
-		t.Run(fmt.Sprintf("Client IP = %v", tc.Context.Value("http.request.ip")), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Client IP = %v", tc.RemoteAddr), func(t *testing.T) {
 			t.Parallel()
-			assertEqual(t, tc.Expected, eligibleForS3(tc.Context, ips))
+			req := &http.Request{RemoteAddr: tc.RemoteAddr}
+			assertEqual(t, tc.Expected, eligibleForS3(req, ips))
 		})
 	}
 }

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 
@@ -42,7 +42,7 @@ func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[st
 	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host, basePath: u.Path}, nil
 }
 
-func (r *redirectStorageMiddleware) URLFor(ctx context.Context, urlPath string, options map[string]interface{}) (string, error) {
+func (r *redirectStorageMiddleware) RedirectURL(_ *http.Request, urlPath string) (string, error) {
 	if r.basePath != "" {
 		urlPath = path.Join(r.basePath, urlPath)
 	}

--- a/registry/storage/driver/middleware/redirect/middleware_test.go
+++ b/registry/storage/driver/middleware/redirect/middleware_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -37,7 +36,7 @@ func (s *MiddlewareSuite) TestHttpsPort(c *check.C) {
 	c.Assert(m.scheme, check.Equals, "https")
 	c.Assert(m.host, check.Equals, "example.com:5443")
 
-	url, err := middleware.URLFor(context.TODO(), "/rick/data", nil)
+	url, err := middleware.RedirectURL(nil, "/rick/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "https://example.com:5443/rick/data")
 }
@@ -53,7 +52,7 @@ func (s *MiddlewareSuite) TestHTTP(c *check.C) {
 	c.Assert(m.scheme, check.Equals, "http")
 	c.Assert(m.host, check.Equals, "example.com")
 
-	url, err := middleware.URLFor(context.TODO(), "morty/data", nil)
+	url, err := middleware.RedirectURL(nil, "morty/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "http://example.com/morty/data")
 }
@@ -71,12 +70,12 @@ func (s *MiddlewareSuite) TestPath(c *check.C) {
 	c.Assert(m.host, check.Equals, "example.com")
 	c.Assert(m.basePath, check.Equals, "/path")
 
-	// call URLFor() with no leading slash
-	url, err := middleware.URLFor(context.TODO(), "morty/data", nil)
+	// call RedirectURL() with no leading slash
+	url, err := middleware.RedirectURL(nil, "morty/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
-	// call URLFor() with leading slash
-	url, err = middleware.URLFor(context.TODO(), "/morty/data", nil)
+	// call RedirectURL() with leading slash
+	url, err = middleware.RedirectURL(nil, "/morty/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
 
@@ -91,12 +90,12 @@ func (s *MiddlewareSuite) TestPath(c *check.C) {
 	c.Assert(m.host, check.Equals, "example.com")
 	c.Assert(m.basePath, check.Equals, "/path/")
 
-	// call URLFor() with no leading slash
-	url, err = middleware.URLFor(context.TODO(), "morty/data", nil)
+	// call RedirectURL() with no leading slash
+	url, err = middleware.RedirectURL(nil, "morty/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
-	// call URLFor() with leading slash
-	url, err = middleware.URLFor(context.TODO(), "/morty/data", nil)
+	// call RedirectURL() with leading slash
+	url, err = middleware.RedirectURL(nil, "/morty/data")
 	c.Assert(err, check.Equals, nil)
 	c.Assert(url, check.Equals, "https://example.com/path/morty/data")
 }

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -36,7 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/base"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1036,30 +1036,13 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	return nil
 }
 
-// URLFor returns a URL which may be used to retrieve the content stored at the given path.
-// May return an UnsupportedMethodErr in certain StorageDriver implementations.
-func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	methodString := http.MethodGet
-	method, ok := options["method"]
-	if ok {
-		methodString, ok = method.(string)
-		if !ok || (methodString != http.MethodGet && methodString != http.MethodHead) {
-			return "", storagedriver.ErrUnsupportedMethod{}
-		}
-	}
-
+// RedirectURL returns a URL which may be used to retrieve the content stored at the given path.
+func (d *driver) RedirectURL(r *http.Request, path string) (string, error) {
 	expiresIn := 20 * time.Minute
-	expires, ok := options["expiry"]
-	if ok {
-		et, ok := expires.(time.Time)
-		if ok {
-			expiresIn = time.Until(et)
-		}
-	}
 
 	var req *request.Request
 
-	switch methodString {
+	switch r.Method {
 	case http.MethodGet:
 		req, _ = d.S3.GetObjectRequest(&s3.GetObjectInput{
 			Bucket: aws.String(d.Bucket),
@@ -1071,7 +1054,7 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 			Key:    aws.String(d.s3Path(path)),
 		})
 	default:
-		panic("unreachable")
+		return "", nil
 	}
 
 	return req.Presign(expiresIn)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/testsuites"
 )
@@ -180,7 +180,7 @@ func TestEmptyRootList(t *testing.T) {
 
 	filename := "/test"
 	contents := []byte("contents")
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	err = rootedDriver.PutContent(ctx, filename, contents)
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
@@ -209,7 +209,7 @@ func TestStorageClass(t *testing.T) {
 
 	rootDir := t.TempDir()
 	contents := []byte("contents")
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	// We don't need to test all the storage classes, just that its selectable.
 	// The first 3 are common to AWS and MinIO, so use those.
@@ -377,7 +377,7 @@ func TestDelete(t *testing.T) {
 		// init file structure matching objs
 		var created []string
 		for _, p := range objs {
-			err := drvr.PutContent(context.Background(), p, []byte("content "+p))
+			err := drvr.PutContent(dcontext.Background(), p, []byte("content "+p))
 			if err != nil {
 				fmt.Printf("unable to init file %s: %s\n", p, err)
 				continue
@@ -390,7 +390,7 @@ func TestDelete(t *testing.T) {
 	cleanup := func(objs []string) {
 		var lastErr error
 		for _, p := range objs {
-			err := drvr.Delete(context.Background(), p)
+			err := drvr.Delete(dcontext.Background(), p)
 			if err != nil {
 				switch err.(type) {
 				case storagedriver.PathNotFoundError:
@@ -409,7 +409,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			objs := init()
 
-			err := drvr.Delete(context.Background(), tc.delete)
+			err := drvr.Delete(dcontext.Background(), tc.delete)
 
 			if tc.err != nil {
 				if err == nil {
@@ -437,7 +437,7 @@ func TestDelete(t *testing.T) {
 				return false
 			}
 			for _, path := range objs {
-				stat, err := drvr.Stat(context.Background(), path)
+				stat, err := drvr.Stat(dcontext.Background(), path)
 				if err != nil {
 					switch err.(type) {
 					case storagedriver.PathNotFoundError:
@@ -491,7 +491,7 @@ func TestWalk(t *testing.T) {
 	// create file structure matching fileset above
 	created := make([]string, 0, len(fileset))
 	for _, p := range fileset {
-		err := drvr.PutContent(context.Background(), p, []byte("content "+p))
+		err := drvr.PutContent(dcontext.Background(), p, []byte("content "+p))
 		if err != nil {
 			fmt.Printf("unable to create file %s: %s\n", p, err)
 			continue
@@ -503,7 +503,7 @@ func TestWalk(t *testing.T) {
 	defer func() {
 		var lastErr error
 		for _, p := range created {
-			err := drvr.Delete(context.Background(), p)
+			err := drvr.Delete(dcontext.Background(), p)
 			if err != nil {
 				_ = fmt.Errorf("cleanup failed for path %s: %s", p, err)
 				lastErr = err
@@ -692,7 +692,7 @@ func TestWalk(t *testing.T) {
 			tc.from = "/"
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			err := drvr.Walk(context.Background(), tc.from, func(fileInfo storagedriver.FileInfo) error {
+			err := drvr.Walk(dcontext.Background(), tc.from, func(fileInfo storagedriver.FileInfo) error {
 				walked = append(walked, fileInfo.Path())
 				return tc.fn(fileInfo)
 			}, tc.options...)
@@ -718,7 +718,7 @@ func TestOverThousandBlobs(t *testing.T) {
 		t.Fatalf("unexpected error creating driver with standard storage: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	for i := 0; i < 1005; i++ {
 		filename := "/thousandfiletest/file" + strconv.Itoa(i)
 		contents := []byte("contents")
@@ -746,7 +746,7 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 		t.Fatalf("unexpected error creating driver: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	sourcePath := "/source"
 	destPath := "/dest"
 
@@ -795,7 +795,7 @@ func TestListObjectsV2(t *testing.T) {
 		t.Fatalf("unexpected error creating driver: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	n := 6
 	prefix := "/test-list-objects-v2"
 	var filePaths []string

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -92,11 +93,10 @@ type StorageDriver interface {
 	// Delete recursively deletes all objects stored at "path" and its subpaths.
 	Delete(ctx context.Context, path string) error
 
-	// URLFor returns a URL which may be used to retrieve the content stored at
-	// the given path, possibly using the given options.
-	// May return an ErrUnsupportedMethod in certain StorageDriver
-	// implementations.
-	URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error)
+	// RedirectURL returns a URL which the client of the request r may use
+	// to retrieve the content stored at path. Returning the empty string
+	// signals that the request may not be redirected.
+	RedirectURL(r *http.Request, path string) (string, error)
 
 	// Walk traverses a filesystem defined within driver, starting
 	// from the given path, calling f on each file.

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"sort"
@@ -733,9 +734,9 @@ func (suite *DriverSuite) TestDelete(c *check.C) {
 	c.Assert(strings.Contains(err.Error(), suite.Name()), check.Equals, true)
 }
 
-// TestURLFor checks that the URLFor method functions properly, but only if it
-// is implemented
-func (suite *DriverSuite) TestURLFor(c *check.C) {
+// TestRedirectURL checks that the RedirectURL method functions properly,
+// but only if it is implemented
+func (suite *DriverSuite) TestRedirectURL(c *check.C) {
 	filename := randomPath(32)
 	contents := randomContents(32)
 
@@ -744,8 +745,8 @@ func (suite *DriverSuite) TestURLFor(c *check.C) {
 	err := suite.StorageDriver.PutContent(suite.ctx, filename, contents)
 	c.Assert(err, check.IsNil)
 
-	url, err := suite.StorageDriver.URLFor(suite.ctx, filename, nil)
-	if _, ok := err.(storagedriver.ErrUnsupportedMethod); ok {
+	url, err := suite.StorageDriver.RedirectURL(httptest.NewRequest(http.MethodGet, filename, nil), filename)
+	if url == "" && err == nil {
 		return
 	}
 	c.Assert(err, check.IsNil)
@@ -758,8 +759,8 @@ func (suite *DriverSuite) TestURLFor(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(read, check.DeepEquals, contents)
 
-	url, err = suite.StorageDriver.URLFor(suite.ctx, filename, map[string]interface{}{"method": http.MethodHead})
-	if _, ok := err.(storagedriver.ErrUnsupportedMethod); ok {
+	url, err = suite.StorageDriver.RedirectURL(httptest.NewRequest(http.MethodHead, filename, nil), filename)
+	if url == "" && err == nil {
 		return
 	}
 	c.Assert(err, check.IsNil)

--- a/registry/storage/filereader_test.go
+++ b/registry/storage/filereader_test.go
@@ -7,13 +7,13 @@ import (
 	mrand "math/rand"
 	"testing"
 
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/opencontainers/go-digest"
 )
 
 func TestSimpleRead(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	content := make([]byte, 1<<20)
 	n, err := crand.Read(content)
 	if err != nil {
@@ -55,7 +55,7 @@ func TestFileReaderSeek(t *testing.T) {
 	repititions := 1024
 	path := "/patterned"
 	content := bytes.Repeat([]byte(pattern), repititions)
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	if err := driver.PutContent(ctx, path, content); err != nil {
 		t.Fatalf("error putting patterned content: %v", err)
@@ -156,7 +156,7 @@ func TestFileReaderSeek(t *testing.T) {
 // read method, with an io.EOF error.
 func TestFileReaderNonExistentFile(t *testing.T) {
 	driver := inmemory.New()
-	fr, err := newFileReader(context.Background(), driver, "/doesnotexist", 10)
+	fr, err := newFileReader(dcontext.Background(), driver, "/doesnotexist", 10)
 	if err != nil {
 		t.Fatalf("unexpected error initializing reader: %v", err)
 	}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/reference"
 	"github.com/google/uuid"

--- a/registry/storage/manifestlisthandler.go
+++ b/registry/storage/manifestlisthandler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/opencontainers/go-digest"

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
 	"github.com/distribution/distribution/v3/manifest/ocischema"

--- a/registry/storage/ociindexhandler.go
+++ b/registry/storage/ociindexhandler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/opencontainers/go-digest"
 )

--- a/registry/storage/ocimanifesthandler.go
+++ b/registry/storage/ocimanifesthandler.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -34,7 +34,7 @@ type manifestURLs struct {
 type RegistryOption func(*registry) error
 
 // EnableRedirect is a functional option for NewRegistry. It causes the backend
-// blob server to attempt using (StorageDriver).URLFor to serve all blobs.
+// blob server to attempt using (StorageDriver).RedirectURL to serve all blobs.
 func EnableRedirect(registry *registry) error {
 	registry.blobServer.redirect = true
 	return nil
@@ -102,7 +102,7 @@ func BlobDescriptorCacheProvider(blobDescriptorCacheProvider cache.BlobDescripto
 // NewRegistry creates a new registry instance from the provided driver. The
 // resulting registry may be shared by multiple goroutines but is cheap to
 // allocate. If the Redirect option is specified, the backend blob server will
-// attempt to use (StorageDriver).URLFor to serve all blobs.
+// attempt to use (StorageDriver).RedirectURL to serve all blobs.
 func NewRegistry(ctx context.Context, driver storagedriver.StorageDriver, options ...RegistryOption) (distribution.Namespace, error) {
 	// create global statter
 	statter := &blobStatter{

--- a/registry/storage/schema2manifesthandler.go
+++ b/registry/storage/schema2manifesthandler.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/distribution/distribution/v3"
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/opencontainers/go-digest"
 )

--- a/registry/storage/schema2manifesthandler_test.go
+++ b/registry/storage/schema2manifesthandler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVerifyManifestForeignLayer(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	inmemoryDriver := inmemory.New()
 	registry := createRegistry(t, inmemoryDriver,
 		ManifestURLsAllowRegexp(regexp.MustCompile("^https?://foo")),
@@ -152,7 +152,7 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 }
 
 func TestVerifyManifestBlobLayerAndConfig(t *testing.T) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	inmemoryDriver := inmemory.New()
 	registry := createRegistry(t, inmemoryDriver,
 		ManifestURLsAllowRegexp(regexp.MustCompile("^https?://foo")),

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/opencontainers/go-digest"
 )

--- a/testutil/manifests.go
+++ b/testutil/manifests.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/opencontainers/go-digest"
@@ -12,7 +12,7 @@ import (
 
 // MakeManifestList constructs a manifest list out of a list of manifest digests
 func MakeManifestList(blobstatter distribution.BlobStatter, manifestDigests []digest.Digest) (*manifestlist.DeserializedManifestList, error) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 
 	manifestDescriptors := make([]manifestlist.ManifestDescriptor, 0, len(manifestDigests))
 	for _, manifestDigest := range manifestDigests {
@@ -39,7 +39,7 @@ func MakeManifestList(blobstatter distribution.BlobStatter, manifestDigests []di
 // MakeSchema2Manifest constructs a schema 2 manifest from a given list of digests and returns
 // the digest of the manifest
 func MakeSchema2Manifest(repository distribution.Repository, digests []digest.Digest) (distribution.Manifest, error) {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	blobStore := repository.Blobs(ctx)
 
 	var configJSON []byte

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -96,7 +96,7 @@ func CreateRandomLayers(n int) (map[digest.Digest]io.ReadSeeker, error) {
 
 // UploadBlobs lets you upload blobs to a repository
 func UploadBlobs(repository distribution.Repository, layers map[digest.Digest]io.ReadSeeker) error {
-	ctx := context.Background()
+	ctx := dcontext.Background()
 	for dgst, rs := range layers {
 		wr, err := repository.Blobs(ctx).Create(ctx)
 		if err != nil {


### PR DESCRIPTION
Our `context` package is a big pile of sadness which breaks most of the context usage rules and encourages bad practices. And tragically our bad habits around contexts have leaked into a couple of our extension-point interfaces: `auth.AccessController` and `storage.StorageDriver`. Modify the interfaces such that implementations are no longer required to abuse contexts, and unexport the pile of sadness.