### PR TITLE
feat: push distribution images to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   DOCKERHUB_SLUG: distribution/distribution
+  GHCR_SLUG: ghcr.io/${{ github.repository }}
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -50,6 +51,7 @@ jobs:
   build:
     permissions:
       contents: write # to create GitHub release (softprops/action-gh-release)
+      packages: write # so we can push the image to GHCR
 
     runs-on: ubuntu-latest
     needs:
@@ -67,6 +69,7 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_SLUG }}
+            ${{ env.GHCR_SLUG }}
           ### versioning strategy
           ### push semver tag v3.2.1 on main (default branch)
           # distribution/distribution:3.2.1
@@ -85,7 +88,7 @@ jobs:
             type=edge
           labels: |
             org.opencontainers.image.title=Distribution
-            org.opencontainers.image.description=The toolkit to pack, ship, store, and deliver container content
+            org.opencontainers.image.description=The toolkit to pack, ship, store, and distribute container content
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -96,6 +99,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Log in to GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       -
         name: Build artifacts
         uses: docker/bake-action@v2


### PR DESCRIPTION
This enables pushing distribution images into GHCR.

**NOTE:** This is in addition to the Docker Hub push which remains in place unchanged

Closes https://github.com/distribution/distribution/issues/4125

PTAL @crazy-max 😄 