### PR TITLE
refactor: optimise s3 driver Stat method costs

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -761,6 +761,20 @@ func (d *driver) Writer(ctx context.Context, path string, appendParam bool) (sto
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
+	headResponse, err := d.S3.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(d.Bucket),
+		Key:    aws.String(d.s3Path(path)),
+	})
+	if err == nil {
+		fi := storagedriver.FileInfoFields{
+			Path:    path,
+			IsDir:   false,
+			Size:    *headResponse.ContentLength,
+			ModTime: *headResponse.LastModified,
+		}
+		return storagedriver.FileInfoInternal{FileInfoFields: fi}, nil
+	}
+
 	resp, err := d.S3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
 		Bucket:  aws.String(d.Bucket),
 		Prefix:  aws.String(d.s3Path(path)),


### PR DESCRIPTION
Stat makes S3 `List` calls which are added to the S3 costs. 

S3 does not charge for `HEAD` calls so why not optimise the Stat call with the HEAD call instead of using the List.