### PR TITLE
Add filepath.clean in host path

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"path/filepath"
 
 	"github.com/distribution/reference"
 	"github.com/gorilla/mux"
@@ -68,7 +69,7 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 				scheme = fproto
 			}
 			if fhost := forwardedHeader["host"]; len(fhost) > 0 {
-				host = fhost
+				host = filepath.Clean(fhost)
 			}
 		}
 	} else {


### PR DESCRIPTION
Was going through the code and I think it would be better to provide a path after passing through `filepath.Clean()`. Therefore, I made the required changes.
Please let me know your thoughts on the same.