### PR TITLE
Plumb contexts into storage driver factories and middlewares

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -1377,7 +1377,7 @@ const (
 	repositoryWithGenericStorageError = "genericstorageerr"
 )
 
-func (factory *storageManifestErrDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func (factory *storageManifestErrDriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	// Initialize the mock driver
 	errGenericStorage := errors.New("generic storage error")
 	return &mockErrorDriver{

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -116,7 +116,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	storageParams["useragent"] = fmt.Sprintf("distribution/%s %s", version.Version, runtime.Version())
 
 	var err error
-	app.driver, err = factory.Create(config.Storage.Type(), storageParams)
+	app.driver, err = factory.Create(app, config.Storage.Type(), storageParams)
 	if err != nil {
 		// TODO(stevvooe): Move the creation of a service into a protected
 		// method, where this is created lazily. Its status can be queried via

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -148,7 +148,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 
 	startUploadPurger(app, app.driver, dcontext.GetLogger(app), purgeConfig)
 
-	app.driver, err = applyStorageMiddleware(app.driver, config.Middleware["storage"])
+	app.driver, err = applyStorageMiddleware(app, app.driver, config.Middleware["storage"])
 	if err != nil {
 		panic(err)
 	}
@@ -938,9 +938,9 @@ func applyRepoMiddleware(ctx context.Context, repository distribution.Repository
 }
 
 // applyStorageMiddleware wraps a storage driver with the configured middlewares
-func applyStorageMiddleware(driver storagedriver.StorageDriver, middlewares []configuration.Middleware) (storagedriver.StorageDriver, error) {
+func applyStorageMiddleware(ctx context.Context, driver storagedriver.StorageDriver, middlewares []configuration.Middleware) (storagedriver.StorageDriver, error) {
 	for _, mw := range middlewares {
-		smw, err := storagemiddleware.Get(mw.Name, mw.Options, driver)
+		smw, err := storagemiddleware.Get(ctx, mw.Name, mw.Options, driver)
 		if err != nil {
 			return nil, fmt.Errorf("unable to configure storage middleware (%s): %v", mw.Name, err)
 		}

--- a/registry/root.go
+++ b/registry/root.go
@@ -53,16 +53,16 @@ var GCCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		driver, err := factory.Create(config.Storage.Type(), config.Storage.Parameters())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to construct %s driver: %v", config.Storage.Type(), err)
-			os.Exit(1)
-		}
-
 		ctx := dcontext.Background()
 		ctx, err = configureLogging(ctx, config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to configure logging with config: %s", err)
+			os.Exit(1)
+		}
+
+		driver, err := factory.Create(ctx, config.Storage.Type(), config.Storage.Parameters())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to construct %s driver: %v", config.Storage.Type(), err)
 			os.Exit(1)
 		}
 

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -46,16 +46,16 @@ func init() {
 
 type azureDriverFactory struct{}
 
-func (factory *azureDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func (factory *azureDriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	params, err := NewParameters(parameters)
 	if err != nil {
 		return nil, err
 	}
-	return New(params)
+	return New(ctx, params)
 }
 
 // New constructs a new Driver from parameters
-func New(params *Parameters) (*Driver, error) {
+func New(ctx context.Context, params *Parameters) (*Driver, error) {
 	azClient, err := newAzureClient(params)
 	if err != nil {
 		return nil, err

--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -68,7 +68,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return New(params)
+		return New(context.Background(), params)
 	}
 
 	// Skip Azure storage driver tests if environment variable parameters are not provided

--- a/registry/storage/driver/factory/factory.go
+++ b/registry/storage/driver/factory/factory.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"context"
 	"fmt"
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
@@ -23,7 +24,7 @@ type StorageDriverFactory interface {
 	// Create returns a new storagedriver.StorageDriver with the given parameters
 	// Parameters will vary by driver and may be ignored
 	// Each parameter key must only consist of lowercase letters and numbers
-	Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error)
+	Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error)
 }
 
 // Register makes a storage driver available by the provided name.
@@ -46,12 +47,12 @@ func Register(name string, factory StorageDriverFactory) {
 // parameters. To use a driver, the StorageDriverFactory must first be
 // registered with the given name. If no drivers are found, an
 // InvalidStorageDriverError is returned
-func Create(name string, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func Create(ctx context.Context, name string, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	driverFactory, ok := driverFactories[name]
 	if !ok {
 		return nil, InvalidStorageDriverError{name}
 	}
-	return driverFactory.Create(parameters)
+	return driverFactory.Create(ctx, parameters)
 }
 
 // InvalidStorageDriverError records an attempt to construct an unregistered storage driver

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -40,7 +40,7 @@ func init() {
 // filesystemDriverFactory implements the factory.StorageDriverFactory interface
 type filesystemDriverFactory struct{}
 
-func (factory *filesystemDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func (factory *filesystemDriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	return FromParameters(parameters)
 }
 

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -87,8 +87,8 @@ func init() {
 type gcsDriverFactory struct{}
 
 // Create StorageDriver from parameters
-func (factory *gcsDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
-	return FromParameters(parameters)
+func (factory *gcsDriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+	return FromParameters(ctx, parameters)
 }
 
 var _ storagedriver.StorageDriver = &driver{}
@@ -118,8 +118,7 @@ type baseEmbed struct {
 // FromParameters constructs a new Driver with a given parameters map
 // Required parameters:
 // - bucket
-func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
-	ctx := context.TODO()
+func FromParameters(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	bucket, ok := parameters["bucket"]
 	if !ok || fmt.Sprint(bucket) == "" {
 		return nil, fmt.Errorf("No bucket parameter provided")
@@ -229,11 +228,11 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 		gcs:            gcs,
 	}
 
-	return New(params)
+	return New(ctx, params)
 }
 
 // New constructs a new driver
-func New(params driverParameters) (storagedriver.StorageDriver, error) {
+func New(ctx context.Context, params driverParameters) (storagedriver.StorageDriver, error) {
 	rootDirectory := strings.Trim(params.rootDirectory, "/")
 	if rootDirectory != "" {
 		rootDirectory += "/"

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -21,7 +21,7 @@ func init() {
 // inMemoryDriverFacotry implements the factory.StorageDriverFactory interface.
 type inMemoryDriverFactory struct{}
 
-func (factory *inMemoryDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func (factory *inMemoryDriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	return New(), nil
 }
 

--- a/registry/storage/driver/middleware/cloudfront/middleware_test.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -15,7 +16,7 @@ var _ = check.Suite(&MiddlewareSuite{})
 
 func (s *MiddlewareSuite) TestNoConfig(c *check.C) {
 	options := make(map[string]interface{})
-	_, err := newCloudFrontStorageMiddleware(nil, options)
+	_, err := newCloudFrontStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.ErrorMatches, "no baseurl provided")
 }
 
@@ -48,7 +49,7 @@ pZeMRablbPQdp8/1NyIwimq1VlG0ohQ4P6qhW7E09ZMC
 	defer os.Remove(file.Name())
 	options["privatekey"] = file.Name()
 	options["keypairid"] = "test"
-	storageDriver, err := newCloudFrontStorageMiddleware(nil, options)
+	storageDriver, err := newCloudFrontStorageMiddleware(context.Background(), nil, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -19,7 +19,7 @@ type redirectStorageMiddleware struct {
 
 var _ storagedriver.StorageDriver = &redirectStorageMiddleware{}
 
-func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
+func newRedirectStorageMiddleware(ctx context.Context, sd storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
 	o, ok := options["baseurl"]
 	if !ok {
 		return nil, fmt.Errorf("no baseurl provided")

--- a/registry/storage/driver/middleware/redirect/middleware_test.go
+++ b/registry/storage/driver/middleware/redirect/middleware_test.go
@@ -15,21 +15,21 @@ var _ = check.Suite(&MiddlewareSuite{})
 
 func (s *MiddlewareSuite) TestNoConfig(c *check.C) {
 	options := make(map[string]interface{})
-	_, err := newRedirectStorageMiddleware(nil, options)
+	_, err := newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.ErrorMatches, "no baseurl provided")
 }
 
 func (s *MiddlewareSuite) TestMissingScheme(c *check.C) {
 	options := make(map[string]interface{})
 	options["baseurl"] = "example.com"
-	_, err := newRedirectStorageMiddleware(nil, options)
+	_, err := newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.ErrorMatches, "no scheme specified for redirect baseurl")
 }
 
 func (s *MiddlewareSuite) TestHttpsPort(c *check.C) {
 	options := make(map[string]interface{})
 	options["baseurl"] = "https://example.com:5443"
-	middleware, err := newRedirectStorageMiddleware(nil, options)
+	middleware, err := newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.Equals, nil)
 
 	m, ok := middleware.(*redirectStorageMiddleware)
@@ -45,7 +45,7 @@ func (s *MiddlewareSuite) TestHttpsPort(c *check.C) {
 func (s *MiddlewareSuite) TestHTTP(c *check.C) {
 	options := make(map[string]interface{})
 	options["baseurl"] = "http://example.com"
-	middleware, err := newRedirectStorageMiddleware(nil, options)
+	middleware, err := newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.Equals, nil)
 
 	m, ok := middleware.(*redirectStorageMiddleware)
@@ -62,7 +62,7 @@ func (s *MiddlewareSuite) TestPath(c *check.C) {
 	// basePath: end with no slash
 	options := make(map[string]interface{})
 	options["baseurl"] = "https://example.com/path"
-	middleware, err := newRedirectStorageMiddleware(nil, options)
+	middleware, err := newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.Equals, nil)
 
 	m, ok := middleware.(*redirectStorageMiddleware)
@@ -82,7 +82,7 @@ func (s *MiddlewareSuite) TestPath(c *check.C) {
 
 	// basePath: end with slash
 	options["baseurl"] = "https://example.com/path/"
-	middleware, err = newRedirectStorageMiddleware(nil, options)
+	middleware, err = newRedirectStorageMiddleware(context.Background(), nil, options)
 	c.Assert(err, check.Equals, nil)
 
 	m, ok = middleware.(*redirectStorageMiddleware)

--- a/registry/storage/driver/middleware/storagemiddleware.go
+++ b/registry/storage/driver/middleware/storagemiddleware.go
@@ -1,6 +1,7 @@
 package storagemiddleware
 
 import (
+	"context"
 	"fmt"
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
@@ -8,7 +9,7 @@ import (
 
 // InitFunc is the type of a StorageMiddleware factory function and is
 // used to register the constructor for different StorageMiddleware backends.
-type InitFunc func(storageDriver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error)
+type InitFunc func(ctx context.Context, storageDriver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error)
 
 var storageMiddlewares map[string]InitFunc
 
@@ -28,10 +29,10 @@ func Register(name string, initFunc InitFunc) error {
 }
 
 // Get constructs a StorageMiddleware with the given options using the named backend.
-func Get(name string, options map[string]interface{}, storageDriver storagedriver.StorageDriver) (storagedriver.StorageDriver, error) {
+func Get(ctx context.Context, name string, options map[string]interface{}, storageDriver storagedriver.StorageDriver) (storagedriver.StorageDriver, error) {
 	if storageMiddlewares != nil {
 		if initFunc, exists := storageMiddlewares[name]; exists {
-			return initFunc(storageDriver, options)
+			return initFunc(ctx, storageDriver, options)
 		}
 	}
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -150,8 +150,8 @@ func init() {
 // s3DriverFactory implements the factory.StorageDriverFactory interface
 type s3DriverFactory struct{}
 
-func (factory *s3DriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
-	return FromParameters(parameters)
+func (factory *s3DriverFactory) Create(ctx context.Context, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+	return FromParameters(ctx, parameters)
 }
 
 var _ storagedriver.StorageDriver = &driver{}
@@ -189,7 +189,7 @@ type Driver struct {
 // - region
 // - bucket
 // - encrypt
-func FromParameters(parameters map[string]interface{}) (*Driver, error) {
+func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Driver, error) {
 	// Providing no values for these is valid in case the user is authenticating
 	// with an IAM on an ec2 instance (in which case the instance credentials will
 	// be summoned when GetAuth is called)
@@ -468,7 +468,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		getS3LogLevelFromParam(parameters["loglevel"]),
 	}
 
-	return New(params)
+	return New(ctx, params)
 }
 
 func getS3LogLevelFromParam(param interface{}) aws.LogLevelType {
@@ -529,7 +529,7 @@ func getParameterAsInt64(parameters map[string]interface{}, name string, default
 
 // New constructs a new Driver with the given AWS credentials, region, encryption flag, and
 // bucketName
-func New(params DriverParameters) (*Driver, error) {
+func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 	if !params.V4Auth &&
 		(params.RegionEndpoint == "" ||
 			strings.Contains(params.RegionEndpoint, "s3.amazonaws.com")) {

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -141,7 +141,7 @@ func init() {
 			getS3LogLevelFromParam(logLevel),
 		}
 
-		return New(parameters)
+		return New(context.Background(), parameters)
 	}
 
 	// Skip S3 storage driver tests if environment variable parameters are not provided


### PR DESCRIPTION
- Related to #4110 

Make it possible to cancel constructing storage drivers and storage middlewares e.g. if they block making network requests.