### PR TITLE
cleanup: make byte sizes easier to understand

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -24,7 +24,7 @@ import (
 const (
 	defaultArch         = "amd64"
 	defaultOS           = "linux"
-	maxManifestBodySize = 4 << 20
+	maxManifestBodySize = 4 * 1024 * 1024
 	imageClass          = "image"
 )
 

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -320,7 +320,7 @@ func TestProxyStoreServeMany(t *testing.T) {
 func TestProxyStoreServeBig(t *testing.T) {
 	te := makeTestEnv(t, "foo/bar")
 
-	blobSize := 2 << 20
+	blobSize := 2 * 1024 * 1024
 	blobCount := 4
 	numUnique := 2
 	populate(t, te, blobCount, blobSize, numUnique)

--- a/registry/storage/filereader.go
+++ b/registry/storage/filereader.go
@@ -15,7 +15,7 @@ import (
 // set this correctly, so we may want to leave it to the driver. For
 // out of process drivers, we'll have to optimize this buffer size for
 // local communication.
-const fileReaderBufferSize = 4 << 20
+const fileReaderBufferSize = 4 * 1024 * 1024
 
 // remoteFileReader provides a read seeker interface to files stored in
 // storagedriver. Used to implement part of layer interface and will be used

--- a/registry/storage/io.go
+++ b/registry/storage/io.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxBlobGetSize = 4 << 20
+	maxBlobGetSize = 4 * 1024 * 1024
 )
 
 func getContent(ctx context.Context, driver driver.StorageDriver, p string) ([]byte, error) {


### PR DESCRIPTION
This is a followup to https://github.com/distribution/distribution/pull/4139