### PR TITLE
dockerfile: keep context mount as read only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS build
 ARG TARGETPLATFORM
 ARG LDFLAGS="-s -w"
 ARG BUILDTAGS="include_gcs"
-RUN --mount=type=bind,target=/src,rw \
+RUN --mount=type=bind,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=type=bind,source=/tmp/.ldflags,target=/tmp/.ldflags,from=version \


### PR DESCRIPTION
This is not necessary to make this mount writable. This will improve cache efficiency as well.