### PR TITLE
fix: if reference exceeds max threshold return 400 and detail

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -224,11 +224,20 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 			msg = err.Code.Message()
 		}
 
-		tmpErrs.Errors = append(tmpErrs.Errors, Error{
+		tmpErr := Error{
 			Code:    err.Code,
 			Message: msg,
 			Detail:  err.Detail,
-		})
+		}
+
+		// if the detail contains error extract the error message
+		// otherwise json.Marshal will not serialize it at all
+		// https://github.com/golang/go/issues/10748
+		if detail, ok := tmpErr.Detail.(error); ok {
+			tmpErr.Detail = detail.Error()
+		}
+
+		tmpErrs.Errors = append(tmpErrs.Errors, tmpErr)
 	}
 
 	return json.Marshal(tmpErrs)

--- a/registry/storage/cache/memory/memory.go
+++ b/registry/storage/cache/memory/memory.go
@@ -47,6 +47,12 @@ func NewInMemoryBlobDescriptorCacheProvider(size int) cache.BlobDescriptorCacheP
 
 func (imbdcp *inMemoryBlobDescriptorCacheProvider) RepositoryScoped(repo string) (distribution.BlobDescriptorService, error) {
 	if _, err := reference.ParseNormalizedNamed(repo); err != nil {
+		if err == reference.ErrNameTooLong {
+			return nil, distribution.ErrRepositoryNameInvalid{
+				Name:   repo,
+				Reason: reference.ErrNameTooLong,
+			}
+		}
 		return nil, err
 	}
 

--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -50,6 +50,12 @@ func NewRedisBlobDescriptorCacheProvider(pool *redis.Client) cache.BlobDescripto
 // RepositoryScoped returns the scoped cache.
 func (rbds *redisBlobDescriptorService) RepositoryScoped(repo string) (distribution.BlobDescriptorService, error) {
 	if _, err := reference.ParseNormalizedNamed(repo); err != nil {
+		if err == reference.ErrNameTooLong {
+			return nil, distribution.ErrRepositoryNameInvalid{
+				Name:   repo,
+				Reason: reference.ErrNameTooLong,
+			}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
If the reference in the API request exceeds the threshold allowed by the reference package (**NOTE:** this isn't defined by distribution specification, only the `tag` length has a limit set to 128 see [here](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull)) we return 500 back to the client.

This commit makes sure we return `400` and the explanation of the error in the returned JSON payload.

Fixes: https://github.com/distribution/distribution/issues/2670

Example:
```shell
$ curl "http://localhost:5000/v2/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/manifests/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  -iv -L -s -X "GET"
*   Trying 127.0.0.1:5000...
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET /v2/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/manifests/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 400 Bad Request
HTTP/1.1 400 Bad Request
< Content-Type: application/json
Content-Type: application/json
< Docker-Distribution-Api-Version: registry/2.0
Docker-Distribution-Api-Version: registry/2.0
< Date: Wed, 22 Nov 2023 16:04:29 GMT
Date: Wed, 22 Nov 2023 16:04:29 GMT
< Content-Length: 810
Content-Length: 810

<
{"errors":[{"code":"NAME_INVALID","message":"invalid repository name","detail":"repository name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" invalid: repository name must not be more than 255 characters"}]}
```