### PR TITLE
cleanup: move init funcs to the top of the source

### DIFF
--- a/health/api/api.go
+++ b/health/api/api.go
@@ -9,6 +9,13 @@ import (
 
 var updater = health.NewStatusUpdater()
 
+// init sets up the two endpoints to bring the service up and down
+func init() {
+	health.Register("manual_http_status", updater)
+	http.HandleFunc("/debug/health/down", DownHandler)
+	http.HandleFunc("/debug/health/up", UpHandler)
+}
+
 // DownHandler registers a manual_http_status that always returns an Error
 func DownHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
@@ -25,11 +32,4 @@ func UpHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 	}
-}
-
-// init sets up the two endpoints to bring the service up and down
-func init() {
-	health.Register("manual_http_status", updater)
-	http.HandleFunc("/debug/health/down", DownHandler)
-	http.HandleFunc("/debug/health/up", UpHandler)
 }

--- a/health/health.go
+++ b/health/health.go
@@ -13,6 +13,12 @@ import (
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 )
 
+// Registers global /debug/health api endpoint, creates default registry
+func init() {
+	DefaultRegistry = NewRegistry()
+	http.HandleFunc("/debug/health", StatusHandler)
+}
+
 // A Registry is a collection of checks. Most applications will use the global
 // registry defined in DefaultRegistry. However, unit tests may need to create
 // separate registries to isolate themselves from other tests.
@@ -277,10 +283,4 @@ func statusResponse(w http.ResponseWriter, r *http.Request, status int, checks m
 	if _, err := w.Write(p); err != nil {
 		dcontext.GetLogger(r.Context()).Errorf("error writing health status response body: %v", err)
 	}
-}
-
-// Registers global /debug/health api endpoint, creates default registry
-func init() {
-	DefaultRegistry = NewRegistry()
-	http.HandleFunc("/debug/health", StatusHandler)
 }

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -9,6 +9,16 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
+var routeDescriptorsMap map[string]RouteDescriptor
+
+func init() {
+	routeDescriptorsMap = make(map[string]RouteDescriptor, len(routeDescriptors))
+
+	for _, descriptor := range routeDescriptors {
+		routeDescriptorsMap[descriptor.Name] = descriptor
+	}
+}
+
 var (
 	nameParameterDescriptor = ParameterDescriptor{
 		Name:        "name",
@@ -1599,14 +1609,4 @@ var routeDescriptors = []RouteDescriptor{
 			},
 		},
 	},
-}
-
-var routeDescriptorsMap map[string]RouteDescriptor
-
-func init() {
-	routeDescriptorsMap = make(map[string]RouteDescriptor, len(routeDescriptors))
-
-	for _, descriptor := range routeDescriptors {
-		routeDescriptorsMap[descriptor.Name] = descriptor
-	}
 }

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -45,6 +45,16 @@ var (
 	ErrAuthenticationFailure = errors.New("authentication failure")
 )
 
+// InitFunc is the type of an AccessController factory function and is used
+// to register the constructor for different AccesController backends.
+type InitFunc func(options map[string]interface{}) (AccessController, error)
+
+var accessControllers map[string]InitFunc
+
+func init() {
+	accessControllers = make(map[string]InitFunc)
+}
+
 // UserInfo carries information about
 // an autenticated/authorized client.
 type UserInfo struct {
@@ -102,16 +112,6 @@ type AccessController interface {
 // CredentialAuthenticator is an object which is able to authenticate credentials
 type CredentialAuthenticator interface {
 	AuthenticateUser(username, password string) error
-}
-
-// InitFunc is the type of an AccessController factory function and is used
-// to register the constructor for different AccesController backends.
-type InitFunc func(options map[string]interface{}) (AccessController, error)
-
-var accessControllers map[string]InitFunc
-
-func init() {
-	accessControllers = make(map[string]InitFunc)
 }
 
 // Register is used to register an InitFunc for

--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -23,6 +23,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func init() {
+	if err := auth.Register("htpasswd", auth.InitFunc(newAccessController)); err != nil {
+		logrus.Errorf("failed to register htpasswd auth: %v", err)
+	}
+}
+
 type accessController struct {
 	realm    string
 	path     string
@@ -149,10 +155,4 @@ func createHtpasswdFile(path string) error {
 		"password": pass,
 	}).Warnf("htpasswd is missing, provisioning with default user")
 	return nil
-}
-
-func init() {
-	if err := auth.Register("htpasswd", auth.InitFunc(newAccessController)); err != nil {
-		logrus.Errorf("failed to register htpasswd auth: %v", err)
-	}
 }

--- a/registry/auth/silly/access.go
+++ b/registry/auth/silly/access.go
@@ -16,6 +16,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// init registers the silly auth backend.
+func init() {
+	if err := auth.Register("silly", auth.InitFunc(newAccessController)); err != nil {
+		logrus.Errorf("failed to register silly auth: %v", err)
+	}
+}
+
 // accessController provides a simple implementation of auth.AccessController
 // that simply checks for a non-empty Authorization header. It is useful for
 // demonstration and testing.
@@ -84,11 +91,4 @@ func (ch challenge) SetHeaders(r *http.Request, w http.ResponseWriter) {
 
 func (ch challenge) Error() string {
 	return fmt.Sprintf("silly authentication challenge: %#v", ch)
-}
-
-// init registers the silly auth backend.
-func init() {
-	if err := auth.Register("silly", auth.InitFunc(newAccessController)); err != nil {
-		logrus.Errorf("failed to register silly auth: %v", err)
-	}
 }

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -17,6 +17,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// init handles registering the token auth backend.
+func init() {
+	if err := auth.Register("token", auth.InitFunc(newAccessController)); err != nil {
+		logrus.Errorf("tailed to register token auth: %v", err)
+	}
+}
+
 // accessSet maps a typed, named resource to
 // a set of actions requested or authorized.
 type accessSet map[auth.Resource]actionSet
@@ -336,11 +343,4 @@ func (ac *accessController) Authorized(req *http.Request, accessItems ...auth.Ac
 		User:      auth.UserInfo{Name: claims.Subject},
 		Resources: claims.resources(),
 	}, nil
-}
-
-// init handles registering the token auth backend.
-func init() {
-	if err := auth.Register("token", auth.InitFunc(newAccessController)); err != nil {
-		logrus.Errorf("tailed to register token auth: %v", err)
-	}
 }

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -20,12 +20,18 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-var sbsMu sync.Mutex
-var randSource rand.Rand
+var (
+	sbsMu      sync.Mutex
+	randSource rand.Rand
+)
 
 type statsBlobStore struct {
 	stats map[string]int
 	blobs distribution.BlobStore
+}
+
+func init() {
+	randSource = *rand.New(rand.NewSource(42))
 }
 
 func (sbs statsBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -193,10 +199,6 @@ func makeBlob(size int) []byte {
 		blob[i] = byte('A' + randSource.Int()%48)
 	}
 	return blob
-}
-
-func init() {
-	randSource = *rand.New(rand.NewSource(42))
 }
 
 func populate(t *testing.T, te *testEnv, blobCount, size, numUnique int) {

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -20,6 +20,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// init registers the cloudfront layerHandler backend.
+func init() {
+	if err := storagemiddleware.Register("cloudfront", newCloudFrontStorageMiddleware); err != nil {
+		logrus.Errorf("failed to register cloudfront middleware: %v", err)
+	}
+}
+
 // cloudFrontStorageMiddleware provides a simple implementation of layerHandler that
 // constructs temporary signed CloudFront URLs from the storagedriver layer URL,
 // then issues HTTP Temporary Redirects to this CloudFront content URL.
@@ -223,11 +230,4 @@ func (lh *cloudFrontStorageMiddleware) RedirectURL(r *http.Request, path string)
 		return "", err
 	}
 	return cfURL, nil
-}
-
-// init registers the cloudfront layerHandler backend.
-func init() {
-	if err := storagemiddleware.Register("cloudfront", newCloudFrontStorageMiddleware); err != nil {
-		logrus.Errorf("failed to register cloudfront middleware: %v", err)
-	}
 }

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -12,6 +12,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func init() {
+	if err := storagemiddleware.Register("redirect", newRedirectStorageMiddleware); err != nil {
+		logrus.Errorf("tailed to register redirect storage middleware: %v", err)
+	}
+}
+
 type redirectStorageMiddleware struct {
 	storagedriver.StorageDriver
 	scheme   string
@@ -50,10 +56,4 @@ func (r *redirectStorageMiddleware) RedirectURL(_ *http.Request, urlPath string)
 	}
 	u := &url.URL{Scheme: r.scheme, Host: r.host, Path: urlPath}
 	return u.String(), nil
-}
-
-func init() {
-	if err := storagemiddleware.Register("redirect", newRedirectStorageMiddleware); err != nil {
-		logrus.Errorf("tailed to register redirect storage middleware: %v", err)
-	}
 }

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -24,6 +24,14 @@ import (
 // Test hooks up gocheck into the "go test" runner.
 func Test(t *testing.T) { check.TestingT(t) }
 
+// randomBytes pre-allocates all of the memory sizes needed for the test. If
+// anything panics while accessing randomBytes, just make this number bigger.
+var randomBytes = make([]byte, 128<<20)
+
+func init() {
+	_, _ = crand.Read(randomBytes) // always returns len(randomBytes) and nil error
+}
+
 // RegisterSuite registers an in-process storage driver test suite with
 // the go test runner.
 func RegisterSuite(driverConstructor DriverConstructor, skipCheck SkipCheck) {
@@ -1341,14 +1349,6 @@ func randomFilename(length int64) string {
 		}
 	}
 	return string(b)
-}
-
-// randomBytes pre-allocates all of the memory sizes needed for the test. If
-// anything panics while accessing randomBytes, just make this number bigger.
-var randomBytes = make([]byte, 128<<20)
-
-func init() {
-	_, _ = crand.Read(randomBytes) // always returns len(randomBytes) and nil error
 }
 
 func randomContents(length int64) []byte {


### PR DESCRIPTION
We make sure they're not hiding at the bottom or in the middle which makes debugging an utter nightmare!