### PR TITLE
feat: add tparallel linter to improve handling (parallel) tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - bodyclose
     - prealloc
     - errcheck
+    - tparallel
 
 linters-settings:
   revive:

--- a/internal/dcontext/trace_test.go
+++ b/internal/dcontext/trace_test.go
@@ -34,7 +34,7 @@ func TestWithTrace(t *testing.T) {
 	}
 
 	ctx, done := WithTrace(Background())
-	defer done("this will be emitted at end of test")
+	t.Cleanup(func() { done("this will be emitted at end of test") })
 
 	tests := append(base, valueTestCase{
 		key:      "trace.func",

--- a/registry/storage/driver/errors_test.go
+++ b/registry/storage/driver/errors_test.go
@@ -33,6 +33,7 @@ func TestErrorFormat(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
+	t.Parallel()
 	drvName := "foo"
 
 	testCases := []struct {


### PR DESCRIPTION
This linter both prevents parallel test races as well as suggests parallel tests where appropriate:
See: https://github.com/moricho/tparallel

**NOTE:** the updated tests in this PR are the result of running the new linter