### PR TITLE
fix: use http.DefaultTransport in S3 client

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -560,9 +560,8 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 	}
 
 	if params.SkipVerify {
-		httpTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		awsConfig.WithHTTPClient(&http.Client{
 			Transport: httpTransport,
 		})


### PR DESCRIPTION
Unfortunately one of the changes we merged (https://github.com/distribution/distribution/pull/3841) broke the support for [http.ProxyFromEnvironment](https://pkg.go.dev/net/http#ProxyFromEnvironment) that was provided when we used the `distribution` client `transport` package.

This PR attempts to fix that by cloning the `http.DefaultTransport` and updating it accordingly.

Fixes: https://github.com/distribution/distribution/issues/4112