### PR TITLE
fix: remove disabling of multipart combine small parts

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -59,6 +59,10 @@ Amazon S3 or S3 compatible services for object storage.
 
 `loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
 
+**NOTE:** Currently the S3 storage driver does not support S3 API compatible storage that
+does not allow combining the last part in the multipart upload into a part that is bigger
+than the preconfigured `chunkSize`.
+
 ## S3 permission scopes
 
 The following AWS policy is required by the registry for push and pull. Make sure to replace `S3_BUCKET_NAME` with the name of your bucket.

--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -59,9 +59,8 @@ Amazon S3 or S3 compatible services for object storage.
 
 `loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
 
-**NOTE:** Currently the S3 storage driver does not support S3 API compatible storage that
-does not allow combining the last part in the multipart upload into a part that is bigger
-than the preconfigured `chunkSize`.
+**NOTE:** Currently the S3 storage driver only supports S3 API compatible storage that
+allows parts of a multipart upload to vary in size. [Cloudflare R2 is not supported.](https://developers.cloudflare.com/r2/objects/multipart-objects/#limitations)
 
 ## S3 permission scopes
 

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -28,23 +28,22 @@ var (
 
 func init() {
 	var (
-		accessKey        = os.Getenv("AWS_ACCESS_KEY")
-		secretKey        = os.Getenv("AWS_SECRET_KEY")
-		bucket           = os.Getenv("S3_BUCKET")
-		encrypt          = os.Getenv("S3_ENCRYPT")
-		keyID            = os.Getenv("S3_KEY_ID")
-		secure           = os.Getenv("S3_SECURE")
-		skipVerify       = os.Getenv("S3_SKIP_VERIFY")
-		v4Auth           = os.Getenv("S3_V4_AUTH")
-		region           = os.Getenv("AWS_REGION")
-		objectACL        = os.Getenv("S3_OBJECT_ACL")
-		regionEndpoint   = os.Getenv("REGION_ENDPOINT")
-		forcePathStyle   = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
-		sessionToken     = os.Getenv("AWS_SESSION_TOKEN")
-		useDualStack     = os.Getenv("S3_USE_DUALSTACK")
-		combineSmallPart = os.Getenv("MULTIPART_COMBINE_SMALL_PART")
-		accelerate       = os.Getenv("S3_ACCELERATE")
-		logLevel         = os.Getenv("S3_LOGLEVEL")
+		accessKey      = os.Getenv("AWS_ACCESS_KEY")
+		secretKey      = os.Getenv("AWS_SECRET_KEY")
+		bucket         = os.Getenv("S3_BUCKET")
+		encrypt        = os.Getenv("S3_ENCRYPT")
+		keyID          = os.Getenv("S3_KEY_ID")
+		secure         = os.Getenv("S3_SECURE")
+		skipVerify     = os.Getenv("S3_SKIP_VERIFY")
+		v4Auth         = os.Getenv("S3_V4_AUTH")
+		region         = os.Getenv("AWS_REGION")
+		objectACL      = os.Getenv("S3_OBJECT_ACL")
+		regionEndpoint = os.Getenv("REGION_ENDPOINT")
+		forcePathStyle = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
+		sessionToken   = os.Getenv("AWS_SESSION_TOKEN")
+		useDualStack   = os.Getenv("S3_USE_DUALSTACK")
+		accelerate     = os.Getenv("S3_ACCELERATE")
+		logLevel       = os.Getenv("S3_LOGLEVEL")
 	)
 
 	var err error
@@ -93,14 +92,6 @@ func init() {
 			useDualStackBool, err = strconv.ParseBool(useDualStack)
 		}
 
-		multipartCombineSmallPart := true
-		if combineSmallPart != "" {
-			multipartCombineSmallPart, err = strconv.ParseBool(combineSmallPart)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		accelerateBool := true
 		if accelerate != "" {
 			accelerateBool, err = strconv.ParseBool(accelerate)
@@ -125,7 +116,6 @@ func init() {
 			defaultMultipartCopyChunkSize,
 			defaultMultipartCopyMaxConcurrency,
 			defaultMultipartCopyThresholdSize,
-			multipartCombineSmallPart,
 			rootDirectory,
 			storageClass,
 			driverName + "-test",


### PR DESCRIPTION
This reverts https://github.com/distribution/distribution/pull/3556

This feature is currently broken and requires more fundamental changes in the S3 driver. Until then it's better to remove it.

See https://github.com/distribution/distribution/pull/3940 for more detail about why we're doing this.