### PR TITLE
fix: don't override storage driver useragent if it's set

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -113,7 +113,9 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	if storageParams == nil {
 		storageParams = make(configuration.Parameters)
 	}
-	storageParams["useragent"] = fmt.Sprintf("distribution/%s %s", version.Version, runtime.Version())
+	if storageParams["useragent"] == "" {
+		storageParams["useragent"] = fmt.Sprintf("distribution/%s %s", version.Version, runtime.Version())
+	}
 
 	var err error
 	app.driver, err = factory.Create(app, config.Storage.Type(), storageParams)


### PR DESCRIPTION
We are overriding whatever value is set in the storage driver `useragent` config.

Let's.....NOT do that and only override it if it's not set.

PTAL @Jamstah @thaJeztah 