### PR TITLE
release: prep for the v3 alpha-1 release

### DIFF
--- a/releases/v3.0.0.toml
+++ b/releases/v3.0.0.toml
@@ -1,0 +1,2938 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "registry"
+github_repo = "distribution/distribution"
+
+# previous release
+previous = "v2.8.3"
+
+pre_release = true
+
+preface = """\
+Welcome to the 3.0.0-alpha.1 release of registry!
+
+This is the first major release in years! It's an accumulation of effort
+that's bringing major improvements in performance, features, security and
+general code quality. This release also deprecates support for some storage
+drivers and image formats.
+
+See the changelog below for full list of changes.
+
+### Deprecated
+
+* Image Manifest v2 Schema v1
+* `oss` and `swift` storage drivers
+* `docker/libtrust` has been replaced with `go-jose/go-jose`
+* `reference` package has been moved to a dedicated repository (see below)
+* `client` is no longer supported as a standalone package
+
+### Notable Changes
+
+* `reference` package has been moved to a dedicated repository: https://github.com/distribution/reference
+* Go module has changed from `docker/distribution` to `distribution/distribution/v3`
+* Major performance improvements across all supported storage drivers
+* Major dependencies updates (see the full list below)
+* Online documentation is available on https://distribution.github.io/distribution/
+
+### Changes
+<details><summary>2590 commits</summary>
+<p>
+  * [`4a360f9d`](https://github.com/distribution/distribution/commit/4a360f9da2933734680991d497b847498f2c9f45) fix: remove disabling of multipart combine small parts (#4193)
+  * [`7fb303e9`](https://github.com/distribution/distribution/commit/7fb303e92220310327439b2c0bfb6fdc114e40bf) Update s3.md
+  * [`7ba91015`](https://github.com/distribution/distribution/commit/7ba91015f5f2dcc9f536ff762519fd57ad95e600) fix: remove disabling of multipart combine small parts
+  * [`1c55d110`](https://github.com/distribution/distribution/commit/1c55d1109143cd79e83a69aab822b27db3568386) build(deps): bump golang.org/x/crypto from 0.15.0 to 0.17.0 (#4197)
+  * [`dcee8e93`](https://github.com/distribution/distribution/commit/dcee8e93a38b04f01ab5f11dcf66a38f22a4d156) build(deps): bump golang.org/x/crypto from 0.15.0 to 0.17.0
+  * [`01e6f33b`](https://github.com/distribution/distribution/commit/01e6f33b31213bbe59eb1526ba17be70a9c00298) update: S3 driver docs (#4194)
+  * [`290dba5d`](https://github.com/distribution/distribution/commit/290dba5d47eccca2e3b90443fc108ab483df3d8a) update: S3 driver docs
+  * [`35bda965`](https://github.com/distribution/distribution/commit/35bda965214748e7748e84f9ba59cad0bdd60ec5) fix: don't override storage driver useragent if it's set (#4195)
+  * [`2f98b771`](https://github.com/distribution/distribution/commit/2f98b7717107546be6c37a92068c420fb0a734d9) fix: don't override storage driver useragent if it's set
+  * [`dfeaad7e`](https://github.com/distribution/distribution/commit/dfeaad7e3bbe3bfa2d913dfe37f7f233dbf62b09) fix: use http.DefaultTransport in S3 client (#4190)
+  * [`def497a8`](https://github.com/distribution/distribution/commit/def497a8aa5fc11b3eedd04ecf98e132c5342bce) update: add tests for S3 driver client SkipVerify settings
+  * [`8fa7a81c`](https://github.com/distribution/distribution/commit/8fa7a81cb26469b3f33344c1e47efcae37df4a11) fix: use http.DefaultTransport in S3 client
+  * [`79ef555f`](https://github.com/distribution/distribution/commit/79ef555f8a43d94a98a3056b10e09c1bc9a90684) Update the gotcha in the proxy guide (#4164)
+  * [`4f84c086`](https://github.com/distribution/distribution/commit/4f84c086fd944242cb882a8141f76bb55d42af10) Update the gotcha in the proxy guide
+  * [`b8fb08e0`](https://github.com/distribution/distribution/commit/b8fb08e0a14646eb5439fa7915e017cb1176c173) testing: replace legacy `gopkg.in/check.v1` (#4185)
+  * [`3f3e61e2`](https://github.com/distribution/distribution/commit/3f3e61e2998454a6315ea32f55a2a52ad8d227f9) fix: update incorrect godoc comment for (writer).Writer()
+  * [`4baddbc6`](https://github.com/distribution/distribution/commit/4baddbc6087442615ec0dff1027c6ccef1a4cb27) fix: update S3 storage driver writer
+  * [`80cbd744`](https://github.com/distribution/distribution/commit/80cbd744cc5abf230ea458432bcf558fe2acfea2) refactor: apply suggestions from code review
+  * [`ed5d4934`](https://github.com/distribution/distribution/commit/ed5d49340538ae39946dee61b8b7d566c8873336) refactor: apply suggestions from code review
+  * [`bcbf0431`](https://github.com/distribution/distribution/commit/bcbf0431d14630fda0770c3d2ce8d68886bbfce1) testing: replace legacy `gopkg.in/check.v1`
+  * [`bdf70a1e`](https://github.com/distribution/distribution/commit/bdf70a1e462dad2f441ad2331a9352ce45ce5c5c) Otel tracing MVP (#4188)
+  * [`68ac02b5`](https://github.com/distribution/distribution/commit/68ac02b549cc60ec9c1450c0c04a87a98619c67c) Otel tracing MVP: fixed gofmt
+  * [`fb7cdf89`](https://github.com/distribution/distribution/commit/fb7cdf8900f7f24222e06a70b630c7b716346160) Otel tracing MVP
+  * [`0e3018f2`](https://github.com/distribution/distribution/commit/0e3018f2cfc491763b912d26fd0abdcc1c5e19ba) Otel tracing MVP: vendor changes
+  * [`514da7ce`](https://github.com/distribution/distribution/commit/514da7ce0ded2ef70c4aa66f6304761e77de4ee4) Update nginx.md (#4187)
+  * [`a1b262f0`](https://github.com/distribution/distribution/commit/a1b262f0837eadf17a49b0eb6e20e18f4bd4e9a6) Update nginx.md
+  * [`c087d195`](https://github.com/distribution/distribution/commit/c087d1956f8c864513bade32583371dc4d049360) update: remove gcs storage driver build tags (#4186)
+  * [`1054d157`](https://github.com/distribution/distribution/commit/1054d157bf27ecc9e83d682077b3b2fae44676b3) update: remove gcs storage driver build tags
+  * [`04e3bdaa`](https://github.com/distribution/distribution/commit/04e3bdaa7c6304d14970f13c01f0a8ded8289e8d) update: bump Go version (#4176)
+  * [`f3ba0acd`](https://github.com/distribution/distribution/commit/f3ba0acd24049b1d2fe995a73563228afd554888) update: bump Go runtime to 1.21.5 and the rest to latest 1.20
+  * [`2cf41640`](https://github.com/distribution/distribution/commit/2cf416400eaee0a57f5aefb9fc0d453f3d5f6663) update: missed the CI workflow
+  * [`f08898c2`](https://github.com/distribution/distribution/commit/f08898c2c3d7f7688820d1f4c283a7553a858697) update: bump Go version
+  * [`60e7e878`](https://github.com/distribution/distribution/commit/60e7e878893a09e947ba1dd484bf6ea181bd97e2) vendor: github.com/spf13/cobra v1.8.0 (#4182)
+  * [`1f6afab6`](https://github.com/distribution/distribution/commit/1f6afab6e0c713d08f5e7a0ddb3017f3fb5f3c85) vendor: github.com/spf13/cobra v1.8.0
+  * [`8a0c1b75`](https://github.com/distribution/distribution/commit/8a0c1b754f935b2ab9a5c63d24e2683ffa83cebd) update: AWS Go SDK bump to the latest release (#4177)
+  * [`6f84e878`](https://github.com/distribution/distribution/commit/6f84e87803301f7b844bf7ce09f1be4f3b351831) update: AWS Go SDK bump to the latest release
+  * [`a2613975`](https://github.com/distribution/distribution/commit/a2613975a1bd435ef0bfde73fa217579c3515e55) vendor: github.com/sirupsen/logrus v1.9.3 (#4179)
+  * [`d6dd652f`](https://github.com/distribution/distribution/commit/d6dd652f5a33abe3e219536e9619cbb365b64aee) vendor: github.com/sirupsen/logrus v1.9.3
+  * [`3b58737b`](https://github.com/distribution/distribution/commit/3b58737bb66d2c938e2e12339a8423d8df8eae43) vendor: github.com/gorilla/mux v1.8.1 (#4180)
+  * [`db187ae5`](https://github.com/distribution/distribution/commit/db187ae55ccc37db0d7d1f5273ac7a612288badf) vendor: github.com/gorilla/mux v1.8.1
+  * [`641306d9`](https://github.com/distribution/distribution/commit/641306d94680b6143161107a377cbdd9fa1d89a5) vendor: github.com/klauspost/compress v1.17.4 (#4181)
+  * [`79976446`](https://github.com/distribution/distribution/commit/79976446f70c9f97b1aefe556c208674138e1b2b) vendor: github.com/klauspost/compress v1.17.4
+  * [`d5a1cf68`](https://github.com/distribution/distribution/commit/d5a1cf6816065691e162b50160a01a8bfead9b8b) cleanup: move init funcs to the top of the source (#4172)
+  * [`d8ff41a3`](https://github.com/distribution/distribution/commit/d8ff41a344682288fc0998fab8953dac4b011c6a) cleanup: move init funcs to the top of the source
+  * [`30b642eb`](https://github.com/distribution/distribution/commit/30b642ebf6d01b327b831d64d88e954362ca94b1) feat: add tparallel linter to improve handling (parallel) tests (#4173)
+  * [`b3681c4c`](https://github.com/distribution/distribution/commit/b3681c4cd34e6e2e4519910c612711436d27f5fc) feat: add tparallel linter to improve handling parallel tests
+  * [`f71b3289`](https://github.com/distribution/distribution/commit/f71b32894a5e713db85fb9cfa73034d02751a532) remove uuid package (#4157)
+  * [`bb156255`](https://github.com/distribution/distribution/commit/bb1562556165f4f4473b5afb95ac04f9b6534884) remove uuid package
+  * [`d9abc517`](https://github.com/distribution/distribution/commit/d9abc517e81a9aedafcd79e27c1d189b8237a05c) Plumb contexts into health checks (#4141)
+  * [`f2cbfe24`](https://github.com/distribution/distribution/commit/f2cbfe24024f11bab018155d058172cf2eebd21b) health: improve periodic polling of checks
+  * [`a1b49d3d`](https://github.com/distribution/distribution/commit/a1b49d3d1786be4a124b2749b599fd3ddea5afd8) health: plumb contexts into health checks
+  * [`8b889c04`](https://github.com/distribution/distribution/commit/8b889c04bdeab05d2c851e798399f0860442bc42) health: use request context when logging
+  * [`97f8a6c9`](https://github.com/distribution/distribution/commit/97f8a6c959bebfd3992be6a6c1c626f3eb5cf0a7) fix: if reference exceeds max threshold return 400 and detail (#4168)
+  * [`35abc922`](https://github.com/distribution/distribution/commit/35abc92237e2c7dd2c02486cc42624a7e7c247a2) fix: if reference exceeds the threshold return 400 and detail
+  * [`96582fcf`](https://github.com/distribution/distribution/commit/96582fcfd94d7536adc84781aa10b29b240a1f3f) fix: invalid conversion when using Content-Range in client (#4166)
+  * [`f33e5a69`](https://github.com/distribution/distribution/commit/f33e5a69da7f5476dd5662aac25eacd8ee92ecd0) fix: invalid conversion when using Content-Range in client
+  * [`cd0ad552`](https://github.com/distribution/distribution/commit/cd0ad552df26a2dfcfd3377c574ad3c414522e18) dockerfile: keep context mount as read only (#4167)
+  * [`d0b78f5e`](https://github.com/distribution/distribution/commit/d0b78f5e1ce03382fa8373da93e515e0a8b426c0) dockerfile: keep context mount as read only
+  * [`06505be5`](https://github.com/distribution/distribution/commit/06505be5d587cf8cecbf2540df2c730fcc830f46) build(deps): bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1 (#4165)
+  * [`b8b390f4`](https://github.com/distribution/distribution/commit/b8b390f4cdd4d3016104ffe583c98fca87898658) build(deps): bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1
+  * [`62d826c7`](https://github.com/distribution/distribution/commit/62d826c705b655c2318d94b29ebbf41f584039a9) docs: fix typo in mirror.md (#4163)
+  * [`c90b0b26`](https://github.com/distribution/distribution/commit/c90b0b2649e7e1924a89c3ae59b5b540a3473a02) docs: fix typo in mirror.md
+  * [`17872ebb`](https://github.com/distribution/distribution/commit/17872ebbc09f107008a167bbf9e1d4ae26345a9b) feat(linter): enable errcheck linter in golangci-lint (#4158)
+  * [`7ce129d6`](https://github.com/distribution/distribution/commit/7ce129d63b10e8a8cd8b22fbb5525ab77d5fb3a6) feat(linter): enable errcheck linter in golangci-lint
+  * [`13fe08d8`](https://github.com/distribution/distribution/commit/13fe08d87b766610775fc92ee022ed7c271bfcc4) Fix proxy statistics (#4045)
+  * [`bf933f54`](https://github.com/distribution/distribution/commit/bf933f546f013c815d14e5a8cc9cbc2036509eb7) Fix proxy statistics
+  * [`9610a1e6`](https://github.com/distribution/distribution/commit/9610a1e618a878e5daa6745aa70ff769d3418051) refactor: gcs storage driver (#4120)
+  * [`e001fad0`](https://github.com/distribution/distribution/commit/e001fad0b5e6f2bd0a5aff4fbb634a59336841b6) refactor: gcs storage driver
+  * [`28c8bc6c`](https://github.com/distribution/distribution/commit/28c8bc6c0e4b5dfc380e0fa3058d4877fabdfa4a) fix: fix broken build (#4150)
+  * [`7686bdc2`](https://github.com/distribution/distribution/commit/7686bdc294654baea0d0e4ed538b9cb9ec0b8ad6) fix: fix broken build
+  * [`bd0e4769`](https://github.com/distribution/distribution/commit/bd0e4769109e2f2dd7ed448eb8d9387251196d73) Hide our misuses of contexts from the public interface (#4128)
+  * [`f7e5eaae`](https://github.com/distribution/distribution/commit/f7e5eaae702413ccaa59bb5aae09ea370fb1a894) internal/dcontext: drop GetRequest() function
+  * [`f089932d`](https://github.com/distribution/distribution/commit/f089932de0a69492ce67ab01bb0d59ecac881ef8) storage/driver: replace URLFor method
+  * [`868faeec`](https://github.com/distribution/distribution/commit/868faeec6761a3b20c3d62cd0be57087ce04d528) registry: unexport auth-related context utilities
+  * [`bd80d759`](https://github.com/distribution/distribution/commit/bd80d7590d1ca49ddb169dd54d655114b8de45a7) reg/auth: remove contexts from Authorized method
+  * [`49e22cbf`](https://github.com/distribution/distribution/commit/49e22cbf3e29b09a0c816fbfdead278ee8bed2b4) registry/auth: pass request to AccessController
+  * [`9157226e`](https://github.com/distribution/distribution/commit/9157226e7bf3dbe440fa1563ff662cd3b9b39e34) Extract request utilities into its own package
+  * [`d0f5aa67`](https://github.com/distribution/distribution/commit/d0f5aa670becaa83b757239e05e0224c248c135b) Move context package internal
+  * [`c1005c54`](https://github.com/distribution/distribution/commit/c1005c54a1ff301f130830d743db23cb8638a280) docs: remove unused go.mod (#4115)
+  * [`186d522d`](https://github.com/distribution/distribution/commit/186d522da97d4643234a5de6f03f69698fc5a219) docs: remove unused go.mod
+  * [`c1869cc7`](https://github.com/distribution/distribution/commit/c1869cc7e74d5f2759ac1ec23066e2758cddee74) cleanup: make byte sizes easier to understand (#4148)
+  * [`74306515`](https://github.com/distribution/distribution/commit/743065153621e4b64fe50c4a19bf67fe1ee88a9d) cleanup: make blob sizes easier to understand
+  * [`ecb475a2`](https://github.com/distribution/distribution/commit/ecb475a2324f7b5ed28b8cfec25798fd4a07273e) feat: push distribution images to GHCR (#4130)
+  * [`3831c8cc`](https://github.com/distribution/distribution/commit/3831c8ccb4ff467fffa4ca96f62f09346e22a41f) feat: push distribution images to GHCR
+  * [`1d7526de`](https://github.com/distribution/distribution/commit/1d7526dea08f621495aa45fb6c574d0cf5f1e361) cleanup: make chunk sizes easier to understand and change writer append (#4139)
+  * [`852de2c2`](https://github.com/distribution/distribution/commit/852de2c2bb3fdcf93a5ac4e02276637c748f2038) cleanup: make chunk sizes easier to understand and change writer append
+  * [`d153e1dc`](https://github.com/distribution/distribution/commit/d153e1dc5bc61d033d7cbf5f9412f6f0546a2ea1) cleanup: a small Azure driver cleanup (#4138)
+  * [`e8e46b21`](https://github.com/distribution/distribution/commit/e8e46b219520ad6e5fe49694009dde31b85eb0cf) cleanup: a small Azure driver cleanup
+  * [`6814691c`](https://github.com/distribution/distribution/commit/6814691c197a4a559aeaf0eff5c0f48545965f6a) Plumb contexts into storage driver factories and middlewares (#4142)
+  * [`b4dc4f34`](https://github.com/distribution/distribution/commit/b4dc4f3474e445910148f4a70103fd7186460b49) storage/driver: plumb contexts into middlewares
+  * [`b45b6d18`](https://github.com/distribution/distribution/commit/b45b6d18b8248c4a79c27621e1e83054894b248e) storage/driver: plumb contexts into factories
+  * [`6c694cbc`](https://github.com/distribution/distribution/commit/6c694cbcf607f87a51d1e777e36bdc651461a464) ci: add cloud storage driver integration tests to CI (#4121)
+  * [`da92c34a`](https://github.com/distribution/distribution/commit/da92c34ae934e6ff8dc960e193a63c16e82d5804) ci: add cloud storage driver integration tests to CI
+  * [`daf3d00a`](https://github.com/distribution/distribution/commit/daf3d00a32b76310182cbd664d82367ff0529138) Add prometheus proxy related metrics (#4047)
+  * [`2ce5c81f`](https://github.com/distribution/distribution/commit/2ce5c81f4745e1b64ab07eb66d0500dcad77edeb) Address PR review feedback
+  * [`9861a46d`](https://github.com/distribution/distribution/commit/9861a46d99d8278915bf38f3d6f3213d5d8793fa) Add prometheus proxy related metrics
+  * [`d8d14ca3`](https://github.com/distribution/distribution/commit/d8d14ca36374830e3f7451740bbc76326c055a58) Switch to github.com/google/uuid (#4132)
+  * [`ef8651ec`](https://github.com/distribution/distribution/commit/ef8651ec2a9796204c5728de44ca3af1b33919a4) Switch to github.com/google/uuid
+  * [`5064789f`](https://github.com/distribution/distribution/commit/5064789f2ad2eecf2fd32a0a3b40aa6f714a0640) docs: fix rendering issues for raw html and images (#4136)
+  * [`e5f16bea`](https://github.com/distribution/distribution/commit/e5f16beae76c2d32b6d54725b353d30faeebef9f) docs: remove unused images
+  * [`57a6fa46`](https://github.com/distribution/distribution/commit/57a6fa46b204374a2519a302f9d09cc562071317) docs: fix broken image references
+  * [`9d12b47b`](https://github.com/distribution/distribution/commit/9d12b47bbb296f3d031906484277db9afbf0e2b8) docs: allow unsafe HTML
+  * [`3612f5e4`](https://github.com/distribution/distribution/commit/3612f5e488d7d7fdf0c830d2ba5fe555a653ca82) Bump google.golang.org/grpc from 1.53.0 to 1.56.3 (#4133)
+  * [`32316367`](https://github.com/distribution/distribution/commit/32316367c8957ba2efbab3057163d1ba0c844e9f) Bump google.golang.org/grpc from 1.53.0 to 1.56.3
+  * [`66bedcf1`](https://github.com/distribution/distribution/commit/66bedcf1a3bfd24ccf36cb625c68773e508411cf) Delete reference package (#4127)
+  * [`6999f230`](https://github.com/distribution/distribution/commit/6999f230d18e4da3880621456c19c8d4d3b6592e) Delete reference package
+  * [`03a778c1`](https://github.com/distribution/distribution/commit/03a778c1f5305162254eab818c672e6211679323) Make our UUID package internal (#4129)
+  * [`8a86dc61`](https://github.com/distribution/distribution/commit/8a86dc61fff135ba1910e3b570953c3296398816) Make our UUID package internal
+  * [`f3ce7c46`](https://github.com/distribution/distribution/commit/f3ce7c46bd3e681f27d172ba51795435bc596693) Move registry client internal (#4126)
+  * [`cc23fdac`](https://github.com/distribution/distribution/commit/cc23fdacffec257f28a040928f379227bad75602) Move registry client internal
+  * [`708bc6f3`](https://github.com/distribution/distribution/commit/708bc6f3e92dd35eaabc31a4a1bbf006270b9e50) Make S3 tests pass with MinIO (#4107)
+  * [`eac19987`](https://github.com/distribution/distribution/commit/eac199875e122b68b7b360d761b191a4a8ef1c54) Remove test for nested file delete on S3
+  * [`647ec33c`](https://github.com/distribution/distribution/commit/647ec33c3385449ced9942acef6b345a457142a2) Bump minio version and test less storage classes
+  * [`dfd191e7`](https://github.com/distribution/distribution/commit/dfd191e7d26ce6664680591c22561bd6488449a5) Replace docker/libtrust with go-jose/go-jose (#4096)
+  * [`fe21f439`](https://github.com/distribution/distribution/commit/fe21f439118f74781a3088f6553332443f5d552e) feat: replace docker/libtrust with go-jose/go-jose
+  * [`5aee8e19`](https://github.com/distribution/distribution/commit/5aee8e191766b2c5d600e9da7860890a00e0f51b) feat: Add context to storagedriver.(Filewriter).Commit() (#4109)
+  * [`cb0d083d`](https://github.com/distribution/distribution/commit/cb0d083d8d7b33668f874c519cb13867216eb4fa) feat: Add context to storagedriver.(Filewriter).Commit()
+  * [`5ad2c45b`](https://github.com/distribution/distribution/commit/5ad2c45b8cf6c39558b8c3eb8a22cb82a9c8ec7c) update to go1.20.10, test go1.21.3 (#4116)
+  * [`46d13ff7`](https://github.com/distribution/distribution/commit/46d13ff75bfbe7abe232ae8e45933d7088227352) update to go1.20.10, test go1.21.3
+  * [`9cc6e5b2`](https://github.com/distribution/distribution/commit/9cc6e5b27f8d1d566ebef440b2bb0c5dad45c26b) update to go1.20.9, test go1.21.2
+  * [`5592968c`](https://github.com/distribution/distribution/commit/5592968cbc1cfef8eb18f7e25975de019ce79087) reference: fix broken alias for DomainRegexp (#4113)
+  * [`c8c2bc27`](https://github.com/distribution/distribution/commit/c8c2bc279cee5d3f81e589d59ca02e683e650835) reference: fix broken alias for DomainRegexp
+  * [`d2424373`](https://github.com/distribution/distribution/commit/d24243730fad0fa858da3e26dbb7b720ee72aa2a) refactor: Storage driver errors (#4108)
+  * [`ea417229`](https://github.com/distribution/distribution/commit/ea4172290221b67c1f41b3fa8c6a10c3fbc44c0f) refactor: Storage driver errors
+  * [`915ad2d5`](https://github.com/distribution/distribution/commit/915ad2d5a6073cb976f94941a4f8891a692af704) json encode storage driver enclosed error (#4099)
+  * [`fee6faef`](https://github.com/distribution/distribution/commit/fee6faef7078527be280bbb6eaad6766b1db8c01) json encode storage driver enclosed error
+  * [`1d410148`](https://github.com/distribution/distribution/commit/1d410148efe6d1b7fd56457507a9dd465b105ec4) Update dockerhub-readme GH Action (#4105)
+  * [`4f506663`](https://github.com/distribution/distribution/commit/4f506663d349f4c009d86a52719a11e14ff82d80) Update dockerhub-readme GH Action
+  * [`71217a0c`](https://github.com/distribution/distribution/commit/71217a0c7bbfaabb9829a8092054c5e7619cfd44) Update docs GHA and renamed a doc file (#4102)
+  * [`777ad032`](https://github.com/distribution/distribution/commit/777ad03208f01efe69b4568e96335a6e0f92c8a0) Update docs GHA
+  * [`078c0546`](https://github.com/distribution/distribution/commit/078c0546a45e228a87df11d488f493bd516d997b) Add annotation for descriptor (#4106)
+  * [`4dce8b86`](https://github.com/distribution/distribution/commit/4dce8b866e3a565fa2ab076e0b079e1b73f86a5a) Add annotation for descriptor
+  * [`c78d6f99`](https://github.com/distribution/distribution/commit/c78d6f99ae5505e4328a323221ad012eacdf0754) Move dockerhub-readme workflow to the correct path (#4103)
+  * [`dc07c428`](https://github.com/distribution/distribution/commit/dc07c42810670f8a1472c20516a7f44279776752) Move dockerhub-readme workflow to the correct path
+  * [`ebba01ef`](https://github.com/distribution/distribution/commit/ebba01efeacc31a55640ee1efc858ea4e327c479) docs: add hugo website (#4101)
+  * [`a66f6c37`](https://github.com/distribution/distribution/commit/a66f6c37cbbcead86240ad9d1269e47fc788626f) ci: add github pages workflow for docs
+  * [`c3ae793f`](https://github.com/distribution/distribution/commit/c3ae793f855f17d3361d8fb869f97d6a04948079) And other content...
+  * [`83dd4ff0`](https://github.com/distribution/distribution/commit/83dd4ff0a6cf56ed205c7ee80923cd55f3b9c44a) Cleanup of naming in docs
+  * [`31707d54`](https://github.com/distribution/distribution/commit/31707d54f33e1d196906fbd64b00ce2b92a1623e) docs: add github link in header
+  * [`1596da68`](https://github.com/distribution/distribution/commit/1596da6813df63e9ada28091b8dc51bd383b9590) docs: add tests
+  * [`b911020c`](https://github.com/distribution/distribution/commit/b911020c1f93704e5a7ff0d25258b1c3d8e2f547) docs: fix markup and broken links
+  * [`e2ae76f1`](https://github.com/distribution/distribution/commit/e2ae76f1f2f7da82043a2e25b7fc9733c3a6217c) docs: add hugo site
+  * [`fe98c998`](https://github.com/distribution/distribution/commit/fe98c998600a74aea33daa582d444d71022cb86b) Bump golang.org/x/net from 0.8.0 to 0.17.0 (#4100)
+  * [`758c0f9d`](https://github.com/distribution/distribution/commit/758c0f9d77f098070cca4c9b16ddc59d19fe30ae) Bump golang.org/x/net from 0.8.0 to 0.17.0
+* docs: remove blank line ([#4091](https://github.com/distribution/distribution/pull/4091))
+  * [`6183f230`](https://github.com/distribution/distribution/commit/6183f230920c6bfd907a7fad1270bcb0c1baf317) docs: remove blank line
+* registry: add loglevel support for aws s3 storage driver ([#4076](https://github.com/distribution/distribution/pull/4076))
+  * [`3df7e28f`](https://github.com/distribution/distribution/commit/3df7e28f44c6ead452de6724470609f01de8fc42) registry: add loglevel support for aws s3 storage driver
+* refactor redis cache ([#4081](https://github.com/distribution/distribution/pull/4081))
+  * [`46a9da16`](https://github.com/distribution/distribution/commit/46a9da160e46f09bde0928dbb1b11fd87e7602b9) refactor redis cache
+* Update Docker Hub README and keep it in sync with this repository. ([#4087](https://github.com/distribution/distribution/pull/4087))
+  * [`f2a72d7f`](https://github.com/distribution/distribution/commit/f2a72d7f77e3a5ae7430f41e48c85870f008de49) Update Docker Hub README and keep it in sync with this repository.
+* Properly indent prometheus docs ([#4086](https://github.com/distribution/distribution/pull/4086))
+  * [`504a3baf`](https://github.com/distribution/distribution/commit/504a3bafc565683d2ef1dfdc080668c58185e8f2) Properly indent prometheus docs
+* Add few more sentences for the debug endpoint ([#4089](https://github.com/distribution/distribution/pull/4089))
+  * [`993af6fe`](https://github.com/distribution/distribution/commit/993af6fefde99791d842533fa3d23c0764b46ebd) Add few more sentences for the debug endpoint
+* Optimise push in S3 driver ([#4066](https://github.com/distribution/distribution/pull/4066))
+  * [`4fce3c00`](https://github.com/distribution/distribution/commit/4fce3c0028eaf3282a035efb9b099b7dd8aecfaf) Move completedParts type back to the original position
+  * [`b888b14b`](https://github.com/distribution/distribution/commit/b888b14b3984f5bdbec7305a807fcdc8afa9b980) Optimise push in S3 driver
+* use manifestTagsPathSpec for listing all tags ([#4077](https://github.com/distribution/distribution/pull/4077))
+  * [`6c724a1a`](https://github.com/distribution/distribution/commit/6c724a1a95c520b96bce231165e64d08b7820af3) use manifestTagsPathSpec for listing all tags
+* fix comment typos ([#4080](https://github.com/distribution/distribution/pull/4080))
+  * [`dca71db9`](https://github.com/distribution/distribution/commit/dca71db976af3e6127660110c25e92a2ef14293b) fix comment typos
+* driver testsuite: Add zero byte file checks ([#4072](https://github.com/distribution/distribution/pull/4072))
+  * [`71c532e6`](https://github.com/distribution/distribution/commit/71c532e60ce1a4dd550c848d992a8eabf66f81d1) driver testsuite: Add zero byte file checks
+* Add make targets to allow starting local cloud storage environment. ([#4069](https://github.com/distribution/distribution/pull/4069))
+  * [`a5c04b36`](https://github.com/distribution/distribution/commit/a5c04b3688ec65cc8713a4e53810f98e6b1f0d92) Update Makefile
+  * [`cf956106`](https://github.com/distribution/distribution/commit/cf95610635126d4814996044b5c4a9ea9d1d4d55) Update BUILDING.md
+  * [`98ffc56a`](https://github.com/distribution/distribution/commit/98ffc56af7428651c0e1f7cb79c641c515113ee9) Only set COMPOSE if it doesnt have a value
+  * [`14361b3a`](https://github.com/distribution/distribution/commit/14361b3ab5f5b724f2ee153ab9fa697a62cd86dc) Update Makefile and docker-compose
+  * [`8e630ae2`](https://github.com/distribution/distribution/commit/8e630ae2a5906330b41f4736f90851cf57349a04) Update BUILDING.md readme file.
+  * [`ecf492ab`](https://github.com/distribution/distribution/commit/ecf492ab5c61f2c9c2c847c00239dc5a95092bb0) Update tests/docker-compose-storage.yml
+  * [`dfb8514a`](https://github.com/distribution/distribution/commit/dfb8514a9f41c0a153feca18ad1d4dfc7960d4c2) Update Makefile
+  * [`6f05474f`](https://github.com/distribution/distribution/commit/6f05474fe057e92e54ea00685c4e756eb240acf5) Update tests/docker-compose-storage.yml
+  * [`8af25245`](https://github.com/distribution/distribution/commit/8af25245f37fc1cd39a3a5bcfc594937bc3b609c) Update tests/docker-compose-storage.yml
+  * [`075d81d7`](https://github.com/distribution/distribution/commit/075d81d7bf0fdca8dc8f0b652c2507181755f33b) Update Makefile
+  * [`6b0c3918`](https://github.com/distribution/distribution/commit/6b0c391865feeb5be5ad0ae50b53442ad624e38d) Update Makefile
+  * [`797b1e39`](https://github.com/distribution/distribution/commit/797b1e392751608b03d1d17083fd04a52712dbed) Add make targets to allow starting local cloud storage environment.
+* docs: remove README.md that point to Docker's repo ([#4073](https://github.com/distribution/distribution/pull/4073))
+  * [`0b72b0b8`](https://github.com/distribution/distribution/commit/0b72b0b8c76fbd3ef0ffe9d36bfb7bd6fcd8defb) docs: remove README.md that point to Docker's repo
+* add repositoriesRootPathSpec in pathFor documentation ([#4070](https://github.com/distribution/distribution/pull/4070))
+  * [`a0d9279e`](https://github.com/distribution/distribution/commit/a0d9279e8fbf53595241a79914c14ff225cf591f) add repositoriesRootPathSpec in pathFor documentation
+* remove go build directive for older go version ([#4071](https://github.com/distribution/distribution/pull/4071))
+  * [`06acf2de`](https://github.com/distribution/distribution/commit/06acf2def51b39593c86d7208ac7f480356e7efb) remove go build directive for older go version
+* Do not close HTTP request body in HTTP handler ([#4067](https://github.com/distribution/distribution/pull/4067))
+  * [`f4d5210b`](https://github.com/distribution/distribution/commit/f4d5210b25e934b2910676e0b340a2e11766819c) Do not close HTTP request body in HTTP handler
+* document resource class deprecation ([#4061](https://github.com/distribution/distribution/pull/4061))
+  * [`ca1b8753`](https://github.com/distribution/distribution/commit/ca1b87537479894b312512b7ab215303cac1641e) document resource class deprecation
+* remove not exist function name in comment ([#4062](https://github.com/distribution/distribution/pull/4062))
+  * [`34654f6c`](https://github.com/distribution/distribution/commit/34654f6c4a8dfd65314fc703577c437a2d37b70c) remove not exist function name in comment
+* Support systemd socket-activation ([#4020](https://github.com/distribution/distribution/pull/4020))
+  * [`a9399e9e`](https://github.com/distribution/distribution/commit/a9399e9ea2716177118656dbcd18de8b0ebfec33) Improve socket-activation message
+  * [`9721db95`](https://github.com/distribution/distribution/commit/9721db9504e7c7cc00d25549ee7ea43fcf6707be) Add info message regarding socket-activation
+  * [`741f9bb5`](https://github.com/distribution/distribution/commit/741f9bb56414b22e109559b2b75c0ab84e0725ab) Add documentation for socket activation
+  * [`2435def4`](https://github.com/distribution/distribution/commit/2435def4740d8d173ad14e591863a7822ed8cbd9) Support systemd socket-activation
+* optimize: avoid redundant blob fetching ([#3569](https://github.com/distribution/distribution/pull/3569))
+  * [`17952924`](https://github.com/distribution/distribution/commit/17952924f34aa3a9d063c7cfbfbb0dfaab648d78) avoid redundant blob fetching
+* registry/api: move all errors to "errcode" package, and split "Register" to internal / exported ([#4040](https://github.com/distribution/distribution/pull/4040))
+  * [`0104adf4`](https://github.com/distribution/distribution/commit/0104adf4a8c0471244863bb9aa53089dc4cbfa74) registry/api/errcode: split Register to internal / exported
+  * [`292e30bc`](https://github.com/distribution/distribution/commit/292e30bc6110956df9271de1d69c38f46d10046c) registry/api: move all errors to "errcode" package
+* registry/client: combine SuccessStatus and HandleErrorResponse ([#4052](https://github.com/distribution/distribution/pull/4052))
+  * [`c8ba5d70`](https://github.com/distribution/distribution/commit/c8ba5d70818a61f90bf27ac00dce76d15a8e25a3) registry/client: combine SuccessStatus and HandleErrorResponse
+* update to go1.20.8 ([#4055](https://github.com/distribution/distribution/pull/4055))
+  * [`23115ff6`](https://github.com/distribution/distribution/commit/23115ff63469c10afaf0b103c85047245821d23e) update to go1.20.8
+* Bump github.com/cyphar/filepath-securejoin from 0.2.3 to 0.2.4 ([#4049](https://github.com/distribution/distribution/pull/4049))
+  * [`e4dd28b8`](https://github.com/distribution/distribution/commit/e4dd28b886f4af1a7452a3a45237d1eb1be61f79) Bump github.com/cyphar/filepath-securejoin from 0.2.3 to 0.2.4
+* Remove libtrust from handler tests ([#4042](https://github.com/distribution/distribution/pull/4042))
+  * [`612a30a7`](https://github.com/distribution/distribution/commit/612a30a7e717ed71ef929b0d67620798b67566ec) Remove libtrust from handler tests
+* Remove duplicate code that instruments Redis otel ([#4041](https://github.com/distribution/distribution/pull/4041))
+  * [`6baa31a2`](https://github.com/distribution/distribution/commit/6baa31a2734074217dac4433eee49ecef009570f) Remove duplicate code that instruments Redis OTLP
+* Enable prealloc linter ([#4037](https://github.com/distribution/distribution/pull/4037))
+  * [`823cd4a3`](https://github.com/distribution/distribution/commit/823cd4a370e2aa7fe9d4bccc0cae9940bb88fa84) Add a comment why prealloc linter is disabled when configuring endpoints
+  * [`10898006`](https://github.com/distribution/distribution/commit/108980064305fc67affd9cb45886e828aac9563a) Preallocate created slice in S3 tests
+  * [`a9d31ec7`](https://github.com/distribution/distribution/commit/a9d31ec7b911a4247cba6b9acc645b11171bbb07) Avoid unnecessary type assertion in mfs driver
+  * [`59fd8656`](https://github.com/distribution/distribution/commit/59fd8656ac3c4f34de9dbb93e9fae90f7f1ec9f2) Enable prealloc linter
+* Propagate storage driver context to S3 API calls ([#4036](https://github.com/distribution/distribution/pull/4036))
+  * [`dcdd8bb7`](https://github.com/distribution/distribution/commit/dcdd8bb7400657dc0ec893ce25db142a6f20faed) Propagate storage driver context to S3 API calls
+* Remove outdated docs ([#4035](https://github.com/distribution/distribution/pull/4035))
+  * [`06341600`](https://github.com/distribution/distribution/commit/063416007408525cb2598dd38b164baf883fdb56) Remove outdated docs
+* Add note on custom storage drivers ([#4034](https://github.com/distribution/distribution/pull/4034))
+  * [`8c7eea76`](https://github.com/distribution/distribution/commit/8c7eea76211a5b565aaaf1f5cb15d1d653af9129) Add note on custom storage drivers
+* go.mod: remove outdated comment ([#4033](https://github.com/distribution/distribution/pull/4033))
+  * [`acf804a2`](https://github.com/distribution/distribution/commit/acf804a2dd559b21413a644b1a837eff9a03aa68) go.mod: remove outdated comment
+* deprecate reference package, migrate to github.com/distribution/reference ([#4031](https://github.com/distribution/distribution/pull/4031))
+  * [`152af63e`](https://github.com/distribution/distribution/commit/152af63ec5c569f074e9cf5d0e409d6928e034d8) deprecate reference package, migrate to github.com/distribution/reference
+* Work with the storage driver to minimise work when paging ([#3685](https://github.com/distribution/distribution/pull/3685))
+  * [`e22f7cbc`](https://github.com/distribution/distribution/commit/e22f7cbc73017e759f8d7be00f4f8605bbb24e14) Pass the last paging flag to storage drivers
+* fix typos in registry/storage/paths.go ([#4030](https://github.com/distribution/distribution/pull/4030))
+  * [`2513dd1f`](https://github.com/distribution/distribution/commit/2513dd1f9691b9926d8b36dfa1d47648ee64b8fb) fix typos in registry/storage/paths.go
+* remove duplicated code ([#4028](https://github.com/distribution/distribution/pull/4028))
+  * [`eda5fe2d`](https://github.com/distribution/distribution/commit/eda5fe2d67c484396fffd3fdad31f37f450b5685) remove duplicated code
+* feat!: remove schema1 manifest and config options ([#4023](https://github.com/distribution/distribution/pull/4023))
+  * [`0742b566`](https://github.com/distribution/distribution/commit/0742b56677a04d00a97fd298663ab09f80b7583c) feat!: remove schema1 manifest
+* Don't make a new buffer for catalog listing ([#4022](https://github.com/distribution/distribution/pull/4022))
+  * [`a41613ba`](https://github.com/distribution/distribution/commit/a41613ba3ab004719155db48e38897843dd7ece7) Don't make a new buffer for catalog listing
+* Add username to create redis client ([#4027](https://github.com/distribution/distribution/pull/4027))
+  * [`b889cc2e`](https://github.com/distribution/distribution/commit/b889cc2eb47e1a201b37f3cec24bd49b65dc0232) Add username to create redis client
+* Replace redigo with redis-go ([#4019](https://github.com/distribution/distribution/pull/4019))
+  * [`fcbc25e7`](https://github.com/distribution/distribution/commit/fcbc25e7896b6ea115d1f62107483c9325b4a305) Replace redigo with redis-go
+* Dont parse errors as JSON unless Content-Type is set to JSON ([#4013](https://github.com/distribution/distribution/pull/4013))
+  * [`45b7b9ce`](https://github.com/distribution/distribution/commit/45b7b9cec3a45cbf3343ce773fd5c88bc50f8a7f) Dont parse errors as JSON unless Content-Type is set to JSON
+* Remove references to schema1 pacakge from storage ([#4002](https://github.com/distribution/distribution/pull/4002))
+  * [`c7bdabad`](https://github.com/distribution/distribution/commit/c7bdabadcf34334368d80aaf1ea9495a3118ee94) add back getKeys + cleanup manifeststore test
+  * [`f9bc9220`](https://github.com/distribution/distribution/commit/f9bc9220eb49e04ff9ba8a4a9139a380ce127979) feat(storage)!: remove schema1 except manifeststore_test
+* Update to go 1.20 ([#4021](https://github.com/distribution/distribution/pull/4021))
+  * [`1a3e73cb`](https://github.com/distribution/distribution/commit/1a3e73cb84fd7ccb4f061f95507357cc63b6eb0e) Handle rand deprecations in go 1.20
+  * [`0eb8fee8`](https://github.com/distribution/distribution/commit/0eb8fee87ecac7b7436c936c853f39c8f5eb9fb0) Update to go 1.20
+* Small Makefie update ([#4018](https://github.com/distribution/distribution/pull/4018))
+  * [`d0c0b7bd`](https://github.com/distribution/distribution/commit/d0c0b7bdd517d8289179d667fa72486419e58c74) Update Makefile
+  * [`506cb451`](https://github.com/distribution/distribution/commit/506cb451c54ae49da5665b4437be18dab7352a78) Small Makefie update
+* Scorecard Badge Viewer Improvement ([#4017](https://github.com/distribution/distribution/pull/4017))
+  * [`be7f29b4`](https://github.com/distribution/distribution/commit/be7f29b41d6bcd374a665d67fbc986c8cfafa790) Fix: use new scorecard badge viewer
+* Update milosgajdos maintainer email ([#4016](https://github.com/distribution/distribution/pull/4016))
+  * [`a9a5b22b`](https://github.com/distribution/distribution/commit/a9a5b22b6fb4ae9a273c83bac1a74098bde092c1) Update milosgajdos maintainer email
+* Remove bugsnag ([#4000](https://github.com/distribution/distribution/pull/4000))
+  * [`3e4c4ead`](https://github.com/distribution/distribution/commit/3e4c4ead4c3aa07c27f95f2a5c92c6d5c2f9dcdb) Remove bugsnag
+* fix typo in comment and log ([#4012](https://github.com/distribution/distribution/pull/4012))
+  * [`1284c487`](https://github.com/distribution/distribution/commit/1284c487812f7fdf41afa227164fa2d30d2fc772) fix typo in comment and log
+* Enable OpenSSF Scorecard Github Action ([#3740](https://github.com/distribution/distribution/pull/3740))
+  * [`10b8a247`](https://github.com/distribution/distribution/commit/10b8a247e40ba1c3f5a65f0d10b52a42a0e8fc84) fix: upgrade scorecard action to 2.0.6
+  * [`77239356`](https://github.com/distribution/distribution/commit/77239356262291527f889fcef49956a572431ffa) chore: enable scorecard action and badge
+* S3 tests ([#3713](https://github.com/distribution/distribution/pull/3713))
+  * [`7622d0a4`](https://github.com/distribution/distribution/commit/7622d0a4534886072b17f58754cd1d1924a22d19) Don't return the from of a walk
+  * [`f7bdd912`](https://github.com/distribution/distribution/commit/f7bdd9127bc0afc71d7cc0facd440d8c81276232) Don't test the OUTPOSTS storage class
+  * [`6ceb904c`](https://github.com/distribution/distribution/commit/6ceb904c3ef529b13e6e9276977cff84be4a3b87) Don't check returned storage class if we use NONE
+  * [`2d316a12`](https://github.com/distribution/distribution/commit/2d316a12d36f2c11f64acc55b64408f4c26347c5) We don't use gocheck in these tests
+  * [`f78d81e7`](https://github.com/distribution/distribution/commit/f78d81e78a20fda60efb4a29848f77d99dd0513b) Remove test as S3 does not support empty directories
+* Remove schema1 references from registry client ([#4007](https://github.com/distribution/distribution/pull/4007))
+  * [`df2787c6`](https://github.com/distribution/distribution/commit/df2787c6cf8faeb0edcc3dbc8815b02c805132e6) Update test asserts
+  * [`11c341a3`](https://github.com/distribution/distribution/commit/11c341a369f92cc971789720c033984ed5d17fc8) Remove schema1 references from registry client
+* s3: add interface assertion ([#4008](https://github.com/distribution/distribution/pull/4008))
+  * [`5b3be398`](https://github.com/distribution/distribution/commit/5b3be398701517100f417b4949bba6b7c824a7df) s3: add interface assertion
+* Enable bodyclose linter ([#4006](https://github.com/distribution/distribution/pull/4006))
+  * [`3dbfbc72`](https://github.com/distribution/distribution/commit/3dbfbc7255d8cd6656fbb8d08298052073f2a1c6) Enable bodyclose linter
+* Remove NewRelic ([#4001](https://github.com/distribution/distribution/pull/4001))
+  * [`77c33cd2`](https://github.com/distribution/distribution/commit/77c33cd24300fa92ea342c9dc57a85c1bf260851) remove NewRelic
+* Revert 3902 ([#4004](https://github.com/distribution/distribution/pull/4004))
+  * [`37a213dc`](https://github.com/distribution/distribution/commit/37a213dc4b2aaebc0c1a8077bf8f0cf82d67df8e) Revert "optimize catalog last param"
+  * [`8fd504de`](https://github.com/distribution/distribution/commit/8fd504debe08833a9f58e7281b1f048598a4f1d5) Revert "Rename catalog funcs and update their godocs."
+  * [`ad111050`](https://github.com/distribution/distribution/commit/ad11105052ce28c66aeb57d0a563be251309232d) Revert "removed redundant check"
+  * [`8e4a8517`](https://github.com/distribution/distribution/commit/8e4a8517c5b3d7c2af7c1b418c5e353c21379017) Revert "fix: resolve most comments"
+* Small update of API docs ([#3998](https://github.com/distribution/distribution/pull/3998))
+  * [`279fa01b`](https://github.com/distribution/distribution/commit/279fa01b2afdf612ffca6dddc33473947499c544) Small update of API docs
+* remove contrib folder ([#4003](https://github.com/distribution/distribution/pull/4003))
+  * [`6fea5489`](https://github.com/distribution/distribution/commit/6fea54890d0870e33348f18af7bdf4aedf0def7b) remove contrib folder
+* Regroup direct and indirect dependencies ([#3997](https://github.com/distribution/distribution/pull/3997))
+  * [`c0a15e64`](https://github.com/distribution/distribution/commit/c0a15e6448fcaec736a46622d55f323005458dcd) Regroup direct and indirect dependencies
+* Add some secure compilation options, especially PIE and RELRO. ([#3623](https://github.com/distribution/distribution/pull/3623))
+  * [`18b2b9f4`](https://github.com/distribution/distribution/commit/18b2b9f45557c7c90ace9fae059ecb5c6603bb42) Added some secure compilation options PIE
+  * [`69b1e011`](https://github.com/distribution/distribution/commit/69b1e01166fb92bd0aa700360465eb3abefaa24c) Added some secure compilation options, especially PIE and RELRO.
+* Remove waynr from MAINTAINERS ([#3995](https://github.com/distribution/distribution/pull/3995))
+  * [`f48e0ecd`](https://github.com/distribution/distribution/commit/f48e0ecd2a9d84b0ca3fdd40f34c42b9f7efe87c) Remove waynr from MAINTAINERS
+* Optimise catalog function rebase of #3145 ([#3902](https://github.com/distribution/distribution/pull/3902))
+  * [`6a5846b3`](https://github.com/distribution/distribution/commit/6a5846b32eb9f9b750c492d4eca1112bdb6855a9) fix: resolve most comments
+  * [`0f846853`](https://github.com/distribution/distribution/commit/0f846853feb903585d5733e7aa6b56d564b03e3d) removed redundant check
+  * [`230cc72a`](https://github.com/distribution/distribution/commit/230cc72a8b3a7d724365f449ab14da61b9112eae) Rename catalog funcs and update their godocs.
+  * [`65f4ce4d`](https://github.com/distribution/distribution/commit/65f4ce4d9397fbec875e985d7169186ac94c8ac2) optimize catalog last param
+* Update github.com/hashicorp/golang-lru to v2 ([#3993](https://github.com/distribution/distribution/pull/3993))
+  * [`0f006548`](https://github.com/distribution/distribution/commit/0f006548a1e5e192f2889227fd7f2eb6006bdd29) update golang-lru to v2
+* Remove references to schema1 pacakge from handlers ([#3987](https://github.com/distribution/distribution/pull/3987))
+  * [`40c56bf1`](https://github.com/distribution/distribution/commit/40c56bf1b6fb7715d05286742753e8c32ffafaba) Keep returning image for default arch to old clients fetching lists
+  * [`f517191d`](https://github.com/distribution/distribution/commit/f517191da1e2844f84f115d60969de9eae3f87ec) Add small update to api tests
+  * [`7e39a7c6`](https://github.com/distribution/distribution/commit/7e39a7c6dcdbc988354b9933a0767ca4e6e814cd) Remove references to schema1 pacakge from handlers
+* Propose James Hewitt as a new reviewer ([#3994](https://github.com/distribution/distribution/pull/3994))
+  * [`e51cfa66`](https://github.com/distribution/distribution/commit/e51cfa660500a23df2ed8210d135ab9e0d478dad) Add James Hewitt as a reviewer
+* fix(deps): update module github.com/aws/aws-sdk-go to v1.44.325 ([#3990](https://github.com/distribution/distribution/pull/3990))
+  * [`9d862f09`](https://github.com/distribution/distribution/commit/9d862f098274fbad4fb82086293d64034183794f) fix(deps): update module github.com/aws/aws-sdk-go to v1.44.325
+* Remove oss storage driver and alicdn storage driver middleware ([#3985](https://github.com/distribution/distribution/pull/3985))
+  * [`3f1859af`](https://github.com/distribution/distribution/commit/3f1859af26406461ddb4eed5addd8430d2f0c73a) Remove oss storage driver and alicdn storage driver middleware
+* Remove SWIFT storage driver ([#3982](https://github.com/distribution/distribution/pull/3982))
+  * [`c6b9944a`](https://github.com/distribution/distribution/commit/c6b9944ab11db3fa79f585085e502dacd85df668) Remove SWIFT storage driver
+* Fix Azure tests ([#3983](https://github.com/distribution/distribution/pull/3983))
+  * [`46ff5f85`](https://github.com/distribution/distribution/commit/46ff5f852811c2c37066770effd9b297a2a0d78c) Fix Azure tests
+* Set Content-Type header in registry client ReadFrom ([#3981](https://github.com/distribution/distribution/pull/3981))
+  * [`24de708d`](https://github.com/distribution/distribution/commit/24de708d229e4b67fb434151895e909f31aa08e6) Set Content-Type header in registry client ReadFrom
+* Added support for configuring array values with environment variables ([#3511](https://github.com/distribution/distribution/pull/3511))
+  * [`0cf87b1f`](https://github.com/distribution/distribution/commit/0cf87b1fd17ab8d086559e75b7e1a828605bfaed) Fix the code and update tests that verify the new code works
+  * [`916b94eb`](https://github.com/distribution/distribution/commit/916b94eb3aac698918e79a7b8592ac0ce5b74012) Added support for configuring array values with environment variables #3511
+* Remove references to schema1 pacakge from notifications package ([#3976](https://github.com/distribution/distribution/pull/3976))
+  * [`565dafa4`](https://github.com/distribution/distribution/commit/565dafa48c6aaa16de758210534109f6b7e994c6) Remove references to schema1 pacakge from notifications package
+* Cleanup storage cache metrics ([#2897](https://github.com/distribution/distribution/pull/2897))
+  * [`c19adfdf`](https://github.com/distribution/distribution/commit/c19adfdf060a4f4dc0a76aadce157a9a065aee4d) Cleanup storage cache metrics
+* Remove references to schema1 pacakge from proxy package ([#3977](https://github.com/distribution/distribution/pull/3977))
+  * [`ae0001f5`](https://github.com/distribution/distribution/commit/ae0001f54dcc88834e331ecc4def812b36c8e950) Remove references to schema1 pacakge from proxy package
+* GitHub Workflows security hardening ([#3741](https://github.com/distribution/distribution/pull/3741))
+  * [`10975dea`](https://github.com/distribution/distribution/commit/10975deab8078629492cebfe7e177256652eabd0) build: harden codeql-analysis.yml permissions
+  * [`e09a9f2d`](https://github.com/distribution/distribution/commit/e09a9f2dc2750caa4deb6e98e0204337327fdf87) build: harden e2e.yml permissions
+  * [`c26fe145`](https://github.com/distribution/distribution/commit/c26fe145ca6693d91b4759e3f15ee487a27aed3c) build: harden conformance.yml permissions
+  * [`1ca9af01`](https://github.com/distribution/distribution/commit/1ca9af0184327ef6ae55e529e54be22e6a90501b) build: harden fossa.yml permissions
+  * [`feaa75c5`](https://github.com/distribution/distribution/commit/feaa75c5291559059b516d8cd976174558cc06d9) build: harden validate.yml permissions
+  * [`1667a668`](https://github.com/distribution/distribution/commit/1667a668565562bf2f68ab722b7ef4ad3f08863a) build: harden build.yml permissions
+* Drop docker prefix from storage driver API user agent ([#3979](https://github.com/distribution/distribution/pull/3979))
+  * [`02a92efb`](https://github.com/distribution/distribution/commit/02a92efba8ef441c771e4493341a278f05e87fda) Drop docker prefix from storage driver API user agent
+* Propose David van der Spek as a new reviewer ([#3980](https://github.com/distribution/distribution/pull/3980))
+  * [`c1147cc1`](https://github.com/distribution/distribution/commit/c1147cc11febab77069ee7117bc8bccbfb73e6a7) Add David van der Spek as a new reviewer
+* feat: added support for redis username configuration ([#3974](https://github.com/distribution/distribution/pull/3974))
+  * [`32a476b8`](https://github.com/distribution/distribution/commit/32a476b840435958d622e7489a3fbaebae9cc701) feat: added support for redis username configuration
+* Update Code of Conduct ([#3971](https://github.com/distribution/distribution/pull/3971))
+  * [`e7505464`](https://github.com/distribution/distribution/commit/e7505464ce7ea9c5da158a2cd7c0b36eb4f014be) Update Code of Conduct
+* Update OCI conformance workflow check ([#3973](https://github.com/distribution/distribution/pull/3973))
+  * [`b3ca53df`](https://github.com/distribution/distribution/commit/b3ca53dfe6b9af5867007920b67deb525ec4bbc9) Update OCI conformance workflow check
+* Fix json formatting in registry api docs ([#3801](https://github.com/distribution/distribution/pull/3801))
+  * [`89384541`](https://github.com/distribution/distribution/commit/89384541cce6c78401b53355589c4fdc5b56469c) Fix json formatting in registry api docs
+* Split OCI Image Index from Docker Manifest List ([#3869](https://github.com/distribution/distribution/pull/3869))
+  * [`9d1a8fc9`](https://github.com/distribution/distribution/commit/9d1a8fc929be3281ee5e915c0951d2b73e4a9a2c) Remove duplicated platform field from oci index
+  * [`973bfbb6`](https://github.com/distribution/distribution/commit/973bfbb676963aacb6c114943e461a18b74dfe24) Fix Go Idioms
+  * [`88646f54`](https://github.com/distribution/distribution/commit/88646f54da4c507a7624acfc88eec0a2efc0f69d) Support annotations in the OCI Image Index
+  * [`e72294d0`](https://github.com/distribution/distribution/commit/e72294d07594e683507b7a8053f62ead4285a036) Split OCI Image Index from Docker Manifest List
+* Add information about security ([#3739](https://github.com/distribution/distribution/pull/3739))
+  * [`434cc087`](https://github.com/distribution/distribution/commit/434cc087cc65c2650bf673f3fc02c5dd6e1cb899) Bump to 2.8.x as the current version
+  * [`d141b657`](https://github.com/distribution/distribution/commit/d141b657348e2f7bf47a6a02ae7e0552ea884950) We already had instructions for this, use them.
+  * [`7e51e717`](https://github.com/distribution/distribution/commit/7e51e717fb983f2620203420c800a4edcad58abc) Add information about security
+* Added support for specifying ACME-server by using REGISTRY_HTTP_TLS_LETSENCRYPT_DIRECTORYURL ([#3942](https://github.com/distribution/distribution/pull/3942))
+  * [`4bbe0ba0`](https://github.com/distribution/distribution/commit/4bbe0ba080b0fe1df9a11e6955803ed69b92e280) Added support for specifying ACME-server by using REGISTRY_HTTP_TLS_LETSENCRYPT_DIRECTORYURL
+* Make redirect middleware can use path ([#3206](https://github.com/distribution/distribution/pull/3206))
+  * [`316e1c6b`](https://github.com/distribution/distribution/commit/316e1c6b82bd2f84e3fe534254c5db7c58e42813) Get rid of unnecessary import alias
+  * [`a3eb9564`](https://github.com/distribution/distribution/commit/a3eb956464cdfac3133987efe2ad529623e109f8) use path.Join() for building path
+  * [`a1cfd267`](https://github.com/distribution/distribution/commit/a1cfd267c8ff193d8b6a00a9c83a56faa346f89c) Make redirect middleware can use path
+* Option to configure proxy cache TTL ([#3880](https://github.com/distribution/distribution/pull/3880))
+  * [`8fe4ca40`](https://github.com/distribution/distribution/commit/8fe4ca4038e4cae82e8e3fc69cb424bf03ef4adc) Option to configure proxy cache TTL
+* Centered logo in README.md ([#3957](https://github.com/distribution/distribution/pull/3957))
+  * [`e7b1bfb9`](https://github.com/distribution/distribution/commit/e7b1bfb9114c71a8687cbcf4a41396b6beef65c5) Centered logo in README.md
+* docs: fix typo ([#3955](https://github.com/distribution/distribution/pull/3955))
+  * [`dedc8fa7`](https://github.com/distribution/distribution/commit/dedc8fa7cc427f4bfc29c56835737286b41a06c6) docs: fix typo
+* Update to golang 1.19.10 ([#3952](https://github.com/distribution/distribution/pull/3952))
+  * [`36dd5b79`](https://github.com/distribution/distribution/commit/36dd5b79ca81c7d945fb701d8eb958c0e212e24c) Update to golang 1.19.10
+* Enable Go build tags ([#3950](https://github.com/distribution/distribution/pull/3950))
+  * [`6b388b1b`](https://github.com/distribution/distribution/commit/6b388b1ba604bf5b970bbb41878f97cc3fc93376) Enable Go build tags
+* Use docker-compose spec v3 in nginx receipt ([#3872](https://github.com/distribution/distribution/pull/3872))
+  * [`c624b9ed`](https://github.com/distribution/distribution/commit/c624b9eda7d193856216ee0013468777a16f2e8a) Use docker-compose spec v3 in nginx receipt
+* registry/handlers/app: log healthcheck error before return ([#3948](https://github.com/distribution/distribution/pull/3948))
+  * [`87081252`](https://github.com/distribution/distribution/commit/87081252bad11fad7c9232f1d3dd39dfe383b35f) registry/handlers/app: log healthcheck error before return
+* Fix path not found error in Azure  ([#3936](https://github.com/distribution/distribution/pull/3936))
+  * [`2b72c4d1`](https://github.com/distribution/distribution/commit/2b72c4d1ca06a40e014a6e3dc01feae6e17441a6) registry/storage/driver/azure: fix Move method
+* Add content cache required changes to distribution ([#2752](https://github.com/distribution/distribution/pull/2752))
+  * [`db1d0cbf`](https://github.com/distribution/distribution/commit/db1d0cbf35668eb28fa7544c18e04e6fd199f5e1) Add registry middleware access to storage drivers
+* Add option to enable caller information in logger ([#3934](https://github.com/distribution/distribution/pull/3934))
+  * [`2338ee4f`](https://github.com/distribution/distribution/commit/2338ee4f256b3db91e549a3cf8ab2d6141538055) Add option to enable caller information in logger
+* Fix Content type octet stream typos ([#3939](https://github.com/distribution/distribution/pull/3939))
+  * [`421a97ff`](https://github.com/distribution/distribution/commit/421a97ffab062f3f11c67424a92b6f2b646c95c8) registry/api/v2: fix ContentType in RouteNameBlobUpload
+  * [`93010cae`](https://github.com/distribution/distribution/commit/93010cae90282f0d0038feda5e5e66bee53c1c37) docs/specs/api: fix Content-Type typo
+* Support ztsd compression as Content-Encoding ([#3900](https://github.com/distribution/distribution/pull/3900))
+  * [`afe5a2a9`](https://github.com/distribution/distribution/commit/afe5a2a9b7d924563a5a9b58edcf00921d07162e) Support ztsd compression as Content-Encoding
+* docs: note restriction on URL format of mirrors ([#3933](https://github.com/distribution/distribution/pull/3933))
+  * [`9d1f71c8`](https://github.com/distribution/distribution/commit/9d1f71c801eaaac265dc9d14cc5fc8cee4757d9a) docs: note restriction on URL format of mirrors
+* Fix gcs storage driver ([#3929](https://github.com/distribution/distribution/pull/3929))
+  * [`817dd286`](https://github.com/distribution/distribution/commit/817dd286c11a31c73c710d0debd495547f112dbc) vendor: update gcs driver dependencies files
+  * [`69510289`](https://github.com/distribution/distribution/commit/695102895b7aaa2308108b4a41f18bd35159e00e) go.mod: update gcs driver dependencies
+  * [`0207adaa`](https://github.com/distribution/distribution/commit/0207adaa5c90ce6ef803b00191a5240ada5454fe) registry/storage/driver/gcs: fix code to use updated gcs driver
+  * [`d0bc83d8`](https://github.com/distribution/distribution/commit/d0bc83d8e4e95ea891a5a085318053f148fa9b15) registry/storage/driver: receive context on Cancel methods
+* registry/storage/driver: test call to Stat(ctx, "/") ([#3932](https://github.com/distribution/distribution/pull/3932))
+  * [`0d20e7ae`](https://github.com/distribution/distribution/commit/0d20e7ae9ea7050f59bf526aa718bf4422c00be9) registry/storage/driver/testsuites: use 4MB for Azure append test
+  * [`0c33bb10`](https://github.com/distribution/distribution/commit/0c33bb1092195f50aa652bdb6c7d31129b93a77a) registry/storage/driver/azure: consider CannotVerifyCopySource as 404
+  * [`d2e16fc7`](https://github.com/distribution/distribution/commit/d2e16fc74add3e1514444c3f140dc3df4797f647) registry/storage/driver/azure: fix driver parameters on tests
+  * [`90ece48d`](https://github.com/distribution/distribution/commit/90ece48d7750663d962adc8d12e80f60420ca7fc) registry/storage/driver: add test call to Stat on "/"
+* bump azure sdk ([#3916](https://github.com/distribution/distribution/pull/3916))
+  * [`7caf058a`](https://github.com/distribution/distribution/commit/7caf058a650f393167cc040bbf1f2408e76d54cb) bump azure sdk
+* Fix panic in the s3 backend walk logic ([#3930](https://github.com/distribution/distribution/pull/3930))
+  * [`035a8ec5`](https://github.com/distribution/distribution/commit/035a8ec52ad750ab0987f8b431b9e6b2053667ea) Fix panic in the s3 backend walk logic
+* Remove blobstore from manifest builder ([#3896](https://github.com/distribution/distribution/pull/3896))
+  * [`f3eb91cf`](https://github.com/distribution/distribution/commit/f3eb91cf8559bcbf8d150f9cbd4ebb8379445a81) Update testutil/manifests.go
+  * [`61e576f3`](https://github.com/distribution/distribution/commit/61e576f3d06922791ccbcdc1b9adef762575d783) Remove blobstore from manifest builder
+* `valye` typo again and `ignore` section table layout is broken ([#3917](https://github.com/distribution/distribution/pull/3917))
+  * [`6a429612`](https://github.com/distribution/distribution/commit/6a4296128ae61ce12e90946e5d5a0b335b946dcf) `vallye` typo again and `ignore` section table layout is broken
+* Dockerfile: fix filenames of artifacts ([#3910](https://github.com/distribution/distribution/pull/3910))
+  * [`435c7b9a`](https://github.com/distribution/distribution/commit/435c7b9a7b7ab6c7e44325d6460fb00270ac77cf) Dockerfile: fix filenames of artifacts
+* Github Security Advisory [GHSA-hqxw-f8mx-cpmw](https://github.com/distribution/distribution/security/advisories/GHSA-hqxw-f8mx-cpmw)
+  * [`4c1561e9`](https://github.com/distribution/distribution/commit/4c1561e9fb43af39df7dcf32f9878aa614e1967b) Fix runaway allocation on /v2/_catalog
+* Update configuration.md ([#3898](https://github.com/distribution/distribution/pull/3898))
+  * [`5d301a9b`](https://github.com/distribution/distribution/commit/5d301a9b3b4301585977320a36b8fccf81fcd538) Update configuration.md
+* update to go1.19.9 ([#3905](https://github.com/distribution/distribution/pull/3905))
+  * [`322eb4ee`](https://github.com/distribution/distribution/commit/322eb4eecf39acc1c8bb85117f8e57edc824f41f) update to go1.19.9
+* update golangci-lint to v1.52, fix linting issues ([#3906](https://github.com/distribution/distribution/pull/3906))
+  * [`dec03ea3`](https://github.com/distribution/distribution/commit/dec03ea3d85d66f7681648c502260ea3cf370143) update golangci-lint to v1.52
+  * [`ebe9d674`](https://github.com/distribution/distribution/commit/ebe9d67446a676d4b06f60a9c86e3ede66cc95fd) ignore SA1019: ac.(*accessController).rootCerts.Subjects has been deprecated
+  * [`84a85a40`](https://github.com/distribution/distribution/commit/84a85a40484b10a2540c0b68bc8fedda77ac5e2a) Ignore SA1019: SplitHostname is deprecated.
+  * [`999527f9`](https://github.com/distribution/distribution/commit/999527f9780a9ff7c0bfb4a620f247cc375e49fb) Ignore SA1019: "schema1 is deprecated" linting errors
+  * [`3c144f22`](https://github.com/distribution/distribution/commit/3c144f2264ff839d840f38930bfd35279578f1cd) registry/auth/token: fix the surrounding loop is unconditionally terminate
+  * [`4052d269`](https://github.com/distribution/distribution/commit/4052d269f51d12477ca980d1d3cb389a727d80b4) reference, registry: fix loop variable captured by func literal (govet)
+* Dockerfile: update xx to v1.2.1 ([#3904](https://github.com/distribution/distribution/pull/3904))
+  * [`8c4d2b9d`](https://github.com/distribution/distribution/commit/8c4d2b9d658a335c086e152d159a1b0608962bef) Dockerfile: update xx to v1.2.1
+* assorted test updates ([#3885](https://github.com/distribution/distribution/pull/3885))
+  * [`f03d966e`](https://github.com/distribution/distribution/commit/f03d966ef7a9c2620af5a42b0c11e3bdafa2d421) cloudfront: use consistent names for test-tables, t.Parallel()
+  * [`5301ae14`](https://github.com/distribution/distribution/commit/5301ae14bf344c60909825568808380e21c92adb) cloudfront: rename vars that collided with type
+  * [`85028a80`](https://github.com/distribution/distribution/commit/85028a801b54cb8b432130e13605aa962bea53db) registry/handlers: use consistent names for test-tables
+  * [`f4acd988`](https://github.com/distribution/distribution/commit/f4acd98865ec9efd23581ddd3f365ca8cd7d8411) registry/api/v2: checkTestRouter(): use sub-tests, t.Parallel()
+  * [`2444c328`](https://github.com/distribution/distribution/commit/2444c3282de621dc7c2f5d58667565dc032862ff) registry/api/v2: use consistent names for test-tables
+  * [`9266220c`](https://github.com/distribution/distribution/commit/9266220c2a3c8dd4202c542472bde57594efef41) registry/auth/token: TestAudienceList_Unmarshal: t.Parallel()
+  * [`5e67a40e`](https://github.com/distribution/distribution/commit/5e67a40e0865c881f1d4878b429a5d88724630bf) registry/auth/token: use consistent names for test-tables
+  * [`f884a079`](https://github.com/distribution/distribution/commit/f884a079dff8222766b5b373140ad2255bbdf2b8) registry/api/errorcode: TestErrorCodes: use sub-tests
+  * [`57f9f31a`](https://github.com/distribution/distribution/commit/57f9f31af92f556c3a5b7e4e435c3a06a8fa077c) notifications: don't use un-keyed structs
+  * [`e9ac1728`](https://github.com/distribution/distribution/commit/e9ac1728e6ebd6ba90bf3b31bdff7422d178f4de) notifications: use consistent names for test tables
+  * [`f4be328b`](https://github.com/distribution/distribution/commit/f4be328bff4cc94435d70ea69e6c17ac2f05c20d) context: TestWithTrace(): inline checkContextForValues, use sub-tests
+  * [`2829f7b7`](https://github.com/distribution/distribution/commit/2829f7b7d5417580d7036521c4c55c598d7bd564) context: use consistent names for test-tables
+  * [`f238f7dc`](https://github.com/distribution/distribution/commit/f238f7dcaa9133ce208b44737fed5e0b985cc310) reference: TestMatch(): use sub-tests
+  * [`2819bca9`](https://github.com/distribution/distribution/commit/2819bca991a22e384e7b4e4b127025cebec87cfb) reference: TestNormalizedSplitHostname(): use sub-tests
+  * [`fa1d14c5`](https://github.com/distribution/distribution/commit/fa1d14c5132c044140da59cfcbdb326e5c898cb4) reference: TestParseAnyReference(): use sub-tests
+  * [`fcbddfc6`](https://github.com/distribution/distribution/commit/fcbddfc6ae2a4ea45bd180b2085bc591aeb0cc37) reference: use consistent names for test-tables
+* Fix the issue that the debug server with port 5001 run twice ([#3895](https://github.com/distribution/distribution/pull/3895))
+  * [`99a8ad00`](https://github.com/distribution/distribution/commit/99a8ad00ea69094f4e0a41173df59e908ef6eae7) fix: rename log to logrus
+  * [`f0fdaff0`](https://github.com/distribution/distribution/commit/f0fdaff0a517627a9d4d159a155efc871172a793) Fix the issue that the debug server with port 5001 run twice
+* Remove registry storage testdriver ([#2766](https://github.com/distribution/distribution/pull/2766))
+  * [`9fb201e2`](https://github.com/distribution/distribution/commit/9fb201e23d393ca86cc6451aef1c5c16d9fd07eb) Remove registry storage testdriver
+* Fuzzing: Move over two fuzzers from cncf-fuzzing ([#3795](https://github.com/distribution/distribution/pull/3795))
+  * [`e2a43ec8`](https://github.com/distribution/distribution/commit/e2a43ec8d3b05b8e654aab24dc0213dd222219ce) Fuzzing: Move over two fuzzers from cncf-fuzzing
+* reference: rewrite test to use sub-tests, add benchmark ([#3883](https://github.com/distribution/distribution/pull/3883))
+  * [`49e2de28`](https://github.com/distribution/distribution/commit/49e2de28306d0a29571011d697377fbff81c1935) reference: add BenchmarkParse
+  * [`b50c049f`](https://github.com/distribution/distribution/commit/b50c049fc6346de7612504b6cc5180fbd545cef7) reference: TestParseRepositoryInfo: use subtests
+  * [`af36dd69`](https://github.com/distribution/distribution/commit/af36dd698f9d66b258c1174900480ce621d9d07a) reference: TestParseDockerRef: capture test in loop
+* registry/errors: Parse http forbidden as denied ([#3881](https://github.com/distribution/distribution/pull/3881))
+  * [`5f1df021`](https://github.com/distribution/distribution/commit/5f1df02149bf03f93cd7747ad740a38891fd4b20) registry/errors: Parse http forbidden as denied
+* remove dot-imports for gopkg.in/check.v1 ([#3882](https://github.com/distribution/distribution/pull/3882))
+  * [`3fa6d5a3`](https://github.com/distribution/distribution/commit/3fa6d5a33b46b86975929a6eda96d097b1bc470d) remove dot-imports for gopkg.in/check.v1
+* Accept list of strings in audience claim in token auth ([#3742](https://github.com/distribution/distribution/pull/3742))
+  * [`d6ea77ae`](https://github.com/distribution/distribution/commit/d6ea77ae6517bd7443e9d1c88c8ac05d56603197) refactor: rename WeakStringList to AudienceList
+  * [`3472f7a8`](https://github.com/distribution/distribution/commit/3472f7a8e3b9a645240c5edc9067ef3e5d50a0e1) feat: accept lists in the token audience claim
+  * [`97fa1183`](https://github.com/distribution/distribution/commit/97fa1183bf5de817a87dea61b629fac95ee22cb4) feat: add WeakStringList type to support lists in aud claim
+* Update Azure SDK and support additional authentication schemes ([#3839](https://github.com/distribution/distribution/pull/3839))
+  * [`ba4a6bbe`](https://github.com/distribution/distribution/commit/ba4a6bbe02d226b08c6561cd4adf2060b5bbd09c) Update Azure SDK and support additional authentication schemes
+* Enable pushing empty blobs ([#3763](https://github.com/distribution/distribution/pull/3763))
+  * [`5fa926a6`](https://github.com/distribution/distribution/commit/5fa926a609599161807e30a51c526995b517f695) Enable pushing empty blobs
+* Fix S3 multipart upload pagination loop condition ([#3847](https://github.com/distribution/distribution/pull/3847))
+  * [`2074688b`](https://github.com/distribution/distribution/commit/2074688be947274084eae87e59ea7d5108130889) Fix S3 multipart upload pagination loop condition
+* build(deps): bump golang.org/x/net from 0.4.0 to 0.7.0 ([#3845](https://github.com/distribution/distribution/pull/3845))
+  * [`9594fbcf`](https://github.com/distribution/distribution/commit/9594fbcfebab2ad8ffa621647fbe3fcbb8c7c114) build(deps): bump golang.org/x/net from 0.4.0 to 0.7.0
+* Log username on successful requests ([#3736](https://github.com/distribution/distribution/pull/3736))
+  * [`a811c1bb`](https://github.com/distribution/distribution/commit/a811c1bb574923da5d392562bdaf84e429d6b902) Log username on successful requests
+* Update fossa-contrib/fossa-action action to v2 ([#3838](https://github.com/distribution/distribution/pull/3838))
+  * [`165fd5f9`](https://github.com/distribution/distribution/commit/165fd5f9ac9ab8bc405e9160e2029e329889e9c6) Update fossa-contrib/fossa-action action to v2
+* Support AWS_CA_BUNDLE when talking to the S3 API ([#3841](https://github.com/distribution/distribution/pull/3841))
+  * [`3117e2eb`](https://github.com/distribution/distribution/commit/3117e2eb2f5598acd556d104fd8733453bd4b433) Use default http.Transport for AWS S3 session
+* add double newlines in ADOPTERS.md ([#3823](https://github.com/distribution/distribution/pull/3823))
+  * [`2179a5f6`](https://github.com/distribution/distribution/commit/2179a5f66c486f02b925a4852fe2f702d5b918b3) add double newlines in ADOPTERS.md
+* Fix separator regex to disallow empty strings ([#3818](https://github.com/distribution/distribution/pull/3818))
+  * [`d1c18681`](https://github.com/distribution/distribution/commit/d1c186812e10d97752d42dc29bf275414e7536b4) Fix separator regex
+* manifest/schema1: mark docker manifest v2, schema 1 deprecated ([#3804](https://github.com/distribution/distribution/pull/3804))
+  * [`ff2bce27`](https://github.com/distribution/distribution/commit/ff2bce27319a0a0bca924820c353fae3b9046e91) manifest/schema1: mark docker manifest v2, schema 1 deprecated
+* vendor: golang.org/x/net v0.4.0 ([#3816](https://github.com/distribution/distribution/pull/3816))
+  * [`345be954`](https://github.com/distribution/distribution/commit/345be95498ee8b68630c5bae689386a98aecc131) vendor: golang.org/x/net v0.4.0
+* remove script directory and fuzz left-overs ([#3814](https://github.com/distribution/distribution/pull/3814))
+  * [`59f13577`](https://github.com/distribution/distribution/commit/59f13577751738d056fd017cc2590cbf3a48ecb9) remove script directory and fuzz left-overs
+* Descriptor: align field order with OCI image specification ([#3810](https://github.com/distribution/distribution/pull/3810))
+  * [`19233195`](https://github.com/distribution/distribution/commit/19233195b752c67a5fbf4a32a50cea96b298c210) Align code to match order of fields
+  * [`86cd830f`](https://github.com/distribution/distribution/commit/86cd830fb39c94ece91378eac42bfe6160ddb56a) Descriptor: align field order with OCI image specification
+* minor fixes and enhancements ([#3807](https://github.com/distribution/distribution/pull/3807))
+  * [`0b4311d5`](https://github.com/distribution/distribution/commit/0b4311d5cedfe776451f97bfa9185214e10e52aa) manifest: improve test output and use const
+  * [`f2db7faa`](https://github.com/distribution/distribution/commit/f2db7faa2fc55eba62db0cb942174f2050adf066) registry/storage: rename variables that collided with imports
+  * [`030489ca`](https://github.com/distribution/distribution/commit/030489ca66752b36d4b08f0d40b17b3f5fe62d14) testutil: rename variables that collided with imports
+  * [`0e3efe74`](https://github.com/distribution/distribution/commit/0e3efe749bd40d31e7a3e370833075ce2352044c) manifest: rename variables that collided with imports
+* Fuzzing: Rewrite existing fuzzers to native go fuzzers ([#3794](https://github.com/distribution/distribution/pull/3794))
+  * [`9337b8df`](https://github.com/distribution/distribution/commit/9337b8df6644390f427162143ee8c83ad3db7c96) Fuzzing: Rewrite existing fuzzers to native go fuzzers
+* ci: update github actions ([#3805](https://github.com/distribution/distribution/pull/3805))
+  * [`b91c9a22`](https://github.com/distribution/distribution/commit/b91c9a22f490bf4296a9fac1dcf9d0d257043574) ci: add concurrency check
+  * [`2400718d`](https://github.com/distribution/distribution/commit/2400718d816d17e9eb908a6d4580311bbe733e90) ci: update github actions
+* reference: clean up regular expressions ([#3789](https://github.com/distribution/distribution/pull/3789))
+  * [`02e88c0f`](https://github.com/distribution/distribution/commit/02e88c0f156bf7aa0e0a7b2508b1d2f3b1122b22) reference: move exported regexes to separate block
+  * [`a4cec8ca`](https://github.com/distribution/distribution/commit/a4cec8ca82ae277aaa412f4e55bbc013f6d0d8e4) reference: introduce const for "localhost"
+  * [`bbd41f40`](https://github.com/distribution/distribution/commit/bbd41f40bba09ef34f532089aae8578f66130518) reference: introduce remoteName variable
+  * [`71a06663`](https://github.com/distribution/distribution/commit/71a0666398d948f90b941f83899164a850aeedc1) reference: optional repeated == any number of times
+  * [`919bd8ab`](https://github.com/distribution/distribution/commit/919bd8ab094dd05c78de6d21da8e73fd9caef425) reference: add const for (optional) port, and rename "domain" variable
+  * [`f0c7c97e`](https://github.com/distribution/distribution/commit/f0c7c97e73f822dbb80719a82890555ce0a2a6aa) reference: remove remaining uses of "expression()"
+  * [`04d6592d`](https://github.com/distribution/distribution/commit/04d6592df1d2a8ceb98bfb8423b11294eb13855c) reference: remove "literal()" utility
+  * [`c786a2bd`](https://github.com/distribution/distribution/commit/c786a2bd3ec3b186f94f913bdd96db282141afc3) reference: inline "group()"
+  * [`1d4917d4`](https://github.com/distribution/distribution/commit/1d4917d4fb8f4445232e05d58ae38e653b5509f5) reference: expression(): use strings.Join()
+  * [`a7e7ff93`](https://github.com/distribution/distribution/commit/a7e7ff933cd043e67344ca4f1893d97ec39131ee) reference: align docs and variables with grammar
+  * [`32a4d8e3`](https://github.com/distribution/distribution/commit/32a4d8e39f41b225f1dbc59e0890ae29609ad4d8) reference: fix docs for NameRegexp
+  * [`226b21be`](https://github.com/distribution/distribution/commit/226b21beb6ee7ca666d6118c6a28b01b292c695a) reference: make some regexp vars a const, remove intermediate vars
+  * [`10eace9a`](https://github.com/distribution/distribution/commit/10eace9a5353989cb813d6a44ca75a2b888f0a56) reference: document consts for normalizing and legacy domain
+  * [`53757ea3`](https://github.com/distribution/distribution/commit/53757ea33788ec46df1ab8592d96afed63518c7b) reference: ParseDockerRef: slight refactor, and update docs
+  * [`2bf5e187`](https://github.com/distribution/distribution/commit/2bf5e1879e9c6c702b8d509b2636a91f71465ee0) reference: remove left-over occurrences of "short-identifier"
+  * [`8163e20c`](https://github.com/distribution/distribution/commit/8163e20c6fcbea2d5e3d621c3bbba8a80f32cf8b) reference: splitDockerDomain: remove incorrect "TODO"
+* reference: rewrite various tests to use subtests ([#3786](https://github.com/distribution/distribution/pull/3786))
+  * [`b6a040fa`](https://github.com/distribution/distribution/commit/b6a040faf4603f179f4210d2a7f12a323c9fefc0) reference: run tests with t.Parallel()
+  * [`5703bcf1`](https://github.com/distribution/distribution/commit/5703bcf17d28f89f698a4778e87b3e05cbb3682f) reference: use subtests for regex tests
+  * [`f481f877`](https://github.com/distribution/distribution/commit/f481f877f136f7f85f9e730178baa51d953f2553) reference: use subtests for reference tests
+* simplify mocks ([#3787](https://github.com/distribution/distribution/pull/3787))
+  * [`2cd52d5c`](https://github.com/distribution/distribution/commit/2cd52d5c0c2952e7cce05683ae48ab3d573434fc) simplify mocks
+* deprecate ReadSeekCloser in favor of io.ReadSeekCloser ([#3788](https://github.com/distribution/distribution/pull/3788))
+  * [`1d8cd5e4`](https://github.com/distribution/distribution/commit/1d8cd5e443cad5e6d1fdee8bfdfd94b840030eee) registry/client: use struct literals
+  * [`d71ad5b3`](https://github.com/distribution/distribution/commit/d71ad5b3a6be14e002d130db9b9703732eee42e8) transport.NewHTTPReadSeeker: return concrete type, deprecate ReadSeekCloser
+  * [`019ead86`](https://github.com/distribution/distribution/commit/019ead86f5603e5b1b3a7afd4bb7cbcdab2613e9) deprecate ReadSeekCloser in favor of io.ReadSeekCloser
+* Realloc slice exponentially in mfs ([#3686](https://github.com/distribution/distribution/pull/3686))
+  * [`35cae109`](https://github.com/distribution/distribution/commit/35cae1099e773ad1d34f18ce33f0fd58f5312545) Realloc slice exponentially in mfs
+* replace strings.Split(N) for strings.Cut() or alternatives ([#3769](https://github.com/distribution/distribution/pull/3769))
+  * [`842d4c04`](https://github.com/distribution/distribution/commit/842d4c04f50fbad367ef3d2ebcffa66a982f973d) cloudfront: use strings.Equalfold()
+  * [`3b391d32`](https://github.com/distribution/distribution/commit/3b391d32908f3523b525ac9e5785a24a9f488919) replace strings.Split(N) for strings.Cut() or alternatives
+  * [`552b1526`](https://github.com/distribution/distribution/commit/552b1526c6821a84daab48cbc7f5456ae215d6c4) reference: check for prefix instead of splitting, and use consts
+* go.mod: github.com/spf13/cobra v1.6.1 ([#3764](https://github.com/distribution/distribution/pull/3764))
+  * [`b1285c33`](https://github.com/distribution/distribution/commit/b1285c33a83530010054ba422f013697c1818e92) go.mod: github.com/spf13/cobra v1.6.1
+* Remove uses of deprecated go-digest.NewDigestFromHex, go-digest.Digest.Hex ([#3781](https://github.com/distribution/distribution/pull/3781))
+  * [`bf725364`](https://github.com/distribution/distribution/commit/bf72536440f960a43838f26b0f18914898939159) Remove uses of deprecated go-digest.NewDigestFromHex, go-digest.Digest.Hex
+* digestset: deprecate package in favor of go-digest/digestset ([#3775](https://github.com/distribution/distribution/pull/3775))
+  * [`7b651a96`](https://github.com/distribution/distribution/commit/7b651a969250423bbad532a4f73f9d90d634cb93) digestset: deprecate package in favor of go-digest/digestset
+* Update the BUILDING.md to a world with modules ([#3679](https://github.com/distribution/distribution/pull/3679))
+  * [`30f5f41d`](https://github.com/distribution/distribution/commit/30f5f41d8cc1460dce4500b0b0ee7255139ad0f2) Use GitHub https url
+  * [`57ea90fe`](https://github.com/distribution/distribution/commit/57ea90fee7b8e682403238e3607143de306637e1) Update the BUILDING.md to a world with modules
+* reference: implement Sort() ([#3777](https://github.com/distribution/distribution/pull/3777))
+  * [`1052518d`](https://github.com/distribution/distribution/commit/1052518d9f962372694e004dba46d2036fb23101) reference: implement Sort()
+* reference: replace deprecated function SplitHostname ([#3776](https://github.com/distribution/distribution/pull/3776))
+  * [`3c71f493`](https://github.com/distribution/distribution/commit/3c71f4933db1c49201765df66faf5dc6dc9ba884) referene: fix formatting of "deprecated" comment.
+  * [`79d19015`](https://github.com/distribution/distribution/commit/79d19015492357887313f21c64d6bfa2202549e4) replace deprecated function
+* registry: configureLogging() simplify logic a bit ([#3772](https://github.com/distribution/distribution/pull/3772))
+  * [`b73c0380`](https://github.com/distribution/distribution/commit/b73c0380003a12d0c6c7e422152c806d6eb6d07d) registry: configureLogging() simplify logic a bit
+  * [`f1dff3e4`](https://github.com/distribution/distribution/commit/f1dff3e43433377ddc6e6283a42ae2d62bcc9116) registry: use consts for some defaults
+* reference: remove support for deprecated "shortid" refs ([#3774](https://github.com/distribution/distribution/pull/3774))
+  * [`6d4f62d7`](https://github.com/distribution/distribution/commit/6d4f62d7fdfa25bd4bb42a18995c50aeededc0d6) reference: remove support for deprecated "shortid" refs
+* replace deprecated io/ioutil ([#3767](https://github.com/distribution/distribution/pull/3767))
+  * [`f8b3af78`](https://github.com/distribution/distribution/commit/f8b3af78fc59c56edf318bdb763129ab45b07b54) replace deprecated io/ioutil
+* Fix API doc parameter placeholder: last ([#3681](https://github.com/distribution/distribution/pull/3681))
+  * [`9e74396f`](https://github.com/distribution/distribution/commit/9e74396f316bcd9de6b761907292f6fedb556c1a) Fix API doc parameter placeholder: last
+* Raise a specific error for env var parsing issues ([#3680](https://github.com/distribution/distribution/pull/3680))
+  * [`d5b2f94c`](https://github.com/distribution/distribution/commit/d5b2f94c7cde784db5177edc55960c2a948df61b) Say when a config error is caused by an env var
+* Delete S3 keys incrementally in batches ([#3635](https://github.com/distribution/distribution/pull/3635))
+  * [`ebc4234f`](https://github.com/distribution/distribution/commit/ebc4234fd573e21ee49b0a7b14e5e76818a6a7b0) Delete S3 keys incrementally in batches
+* format code with gofumpt ([#3766](https://github.com/distribution/distribution/pull/3766))
+  * [`e0281dc6`](https://github.com/distribution/distribution/commit/e0281dc609a025383e9bd6505dc69f07e7bae4d9) format code with gofumpt
+* Update doc to reflect that logs go to stderr ([#3770](https://github.com/distribution/distribution/pull/3770))
+  * [`6dbb55ad`](https://github.com/distribution/distribution/commit/6dbb55ada56acc5e8a0f1a4fdb00b63550670e72) Update doc to reflect that logs go to stderr
+* use http consts for request methods ([#3768](https://github.com/distribution/distribution/pull/3768))
+  * [`f9ccd2c6`](https://github.com/distribution/distribution/commit/f9ccd2c6ea3aee0cf86af859597c0f8c32a892f3) use http consts for request methods
+* Revert "registry/client: set Accept: identity header when getting layers ([#3754](https://github.com/distribution/distribution/pull/3754))
+  * [`9c04d0b3`](https://github.com/distribution/distribution/commit/9c04d0b30af71e66c2a181879a00405c8de9f451) Revert "registry/client: set Accept: identity header when getting layers"
+* fit get status issue ([#3755](https://github.com/distribution/distribution/pull/3755))
+  * [`bad5dcb6`](https://github.com/distribution/distribution/commit/bad5dcb60210757eb6e9f51cee78805236fbae1c) fit get status issue
+* vendor: golang.org/x/net v0.0.0-20220906165146-f3363e06e74c ([#3727](https://github.com/distribution/distribution/pull/3727))
+  * [`f9dee9dc`](https://github.com/distribution/distribution/commit/f9dee9dc9036d81d03d94ee5716cd0b8f629827b) vendor: golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
+* Remove workaround from 2.1.1 for faulty 2.1.0 manifest links ([#3365](https://github.com/distribution/distribution/pull/3365))
+  * [`b2b3f860`](https://github.com/distribution/distribution/commit/b2b3f86039b3936710632d50157fa21db2d89836) Remove workaround from 2.1.1 for faulty 2.1.0 manifest links
+* Add Go 1.19 to GHA ([#3748](https://github.com/distribution/distribution/pull/3748))
+  * [`8cc5b4f5`](https://github.com/distribution/distribution/commit/8cc5b4f5aa4a42f59f1a3c3bc7b8f29086a3b20e) Add Go 1.19 to GHA
+* registry/storage/cache/memory: Use LRU cache to bound cache size ([#3689](https://github.com/distribution/distribution/pull/3689))
+  * [`e36cb0a5`](https://github.com/distribution/distribution/commit/e36cb0a5d8cf7b80bef1322bcd486b8017cb2ef8) registry/storage/cache/memory: Use LRU cache to bound cache size
+* fix all json syntax error in error api spec ([#3724](https://github.com/distribution/distribution/pull/3724))
+  * [`e24be4e8`](https://github.com/distribution/distribution/commit/e24be4e8342ab6848c85e688f3523f5f0593ca4c) fix all json syntax error
+* Review contributing for Docker references ([#3682](https://github.com/distribution/distribution/pull/3682))
+  * [`c895369b`](https://github.com/distribution/distribution/commit/c895369b7770bb2abbd9692e69b2ebdb3a69cd22) Review contributing for Docker references
+* Add build tags to BUILDING.md ([#3687](https://github.com/distribution/distribution/pull/3687))
+  * [`87d9edf7`](https://github.com/distribution/distribution/commit/87d9edf7709ef6e928ff19bf15ca7f1c8ba97f89) Add build tags to BUILDING.md
+* configuration: use "fake" values for tests ([#3706](https://github.com/distribution/distribution/pull/3706))
+  * [`567158c3`](https://github.com/distribution/distribution/commit/567158c36508fef5588dc3e58130efcedaa24fe2) configuration: use "fake" values for tests
+* Use http.NewRequestWithContext for outgoing HTTP requests ([#3711](https://github.com/distribution/distribution/pull/3711))
+  * [`fbdfd1ac`](https://github.com/distribution/distribution/commit/fbdfd1ac3580f1aafdbd17c09ebd02c86ccfc4a1) Use http.NewRequestWithContext for outgoing HTTP requests
+* Fix Grammar Mistake ([#3688](https://github.com/distribution/distribution/pull/3688))
+  * [`3801e37d`](https://github.com/distribution/distribution/commit/3801e37d168bb79c944f1590804b87a6796dec41) Fix grammar mistake
+* Do not recreate mux router for each incoming request ([#3683](https://github.com/distribution/distribution/pull/3683))
+  * [`853e2e92`](https://github.com/distribution/distribution/commit/853e2e92d8fba72d2a32d655c560b27253028dc3) Do not recreate mux router for each incoming request
+* Ipv6 registries ([#3489](https://github.com/distribution/distribution/pull/3489))
+  * [`53a6f7d7`](https://github.com/distribution/distribution/commit/53a6f7d7aa2d0e423d85e3bf263521778c4a414d) registry: support ipv6 addresses
+* ci: cleanup ci workflow ([#3644](https://github.com/distribution/distribution/pull/3644))
+  * [`0e17e540`](https://github.com/distribution/distribution/commit/0e17e5409133bf70576844a1031e579ff3634d82) dockerfiles: formatting
+  * [`b066451b`](https://github.com/distribution/distribution/commit/b066451b4029c4b063c06e65390a92e56a668a43) dockerfiles: set ALPINE_VERSION
+  * [`7e546784`](https://github.com/distribution/distribution/commit/7e546784a409f88aead01cc718583e7e47a241e0) ci: move test step to build workflow and remove ci workflow
+  * [`1a905ab9`](https://github.com/distribution/distribution/commit/1a905ab966549bf9ce80494a36728c497dcaea9e) ci: git validation target
+  * [`8b2c54bf`](https://github.com/distribution/distribution/commit/8b2c54bf57ea86892e77cd56d9646663dd2b0840) ci: remove dco check (dco bot already does this)
+* Update to xx 1.1.1 ([#3693](https://github.com/distribution/distribution/pull/3693))
+  * [`52a88c59`](https://github.com/distribution/distribution/commit/52a88c596b5e147a6607650b9c032aa8b1067b42) Update to xx 1.1.1
+* Change GET in example request to POST ([#3692](https://github.com/distribution/distribution/pull/3692))
+  * [`c3074d09`](https://github.com/distribution/distribution/commit/c3074d095e10500b444cc1724d1406be6cd9938b) Change GET in example request to POST
+* Fix comment for manifest list ([#3669](https://github.com/distribution/distribution/pull/3669))
+  * [`bbeffe6a`](https://github.com/distribution/distribution/commit/bbeffe6a124ef2bb60c6eec587ab112815d3487f) Fix comment for manifest list
+* Explain important caveat in htpasswd tutorial ([#3630](https://github.com/distribution/distribution/pull/3630))
+  * [`d64056af`](https://github.com/distribution/distribution/commit/d64056afdcea60b9b66966241e779276b536275a) Explain important caveat in htpasswd tutorial
+* fix json syntax error in error api spec ([#3658](https://github.com/distribution/distribution/pull/3658))
+  * [`8628eab4`](https://github.com/distribution/distribution/commit/8628eab487b1cc74f9e95255fbb572c0f74d3e8c) fix json syntax error in error api spec
+* Update maintainers mailing list ([#3655](https://github.com/distribution/distribution/pull/3655))
+  * [`ba29eb8a`](https://github.com/distribution/distribution/commit/ba29eb8a41e4dee48ffa4d6a461945bc72d399a5) Update maintainers mailing list
+* go.mod: remove outdated comment ([#3651](https://github.com/distribution/distribution/pull/3651))
+  * [`3bd75427`](https://github.com/distribution/distribution/commit/3bd75427a87341d88a57f1b2b121344843b77614) go.mod: remove outdated comment
+* Fix CVE-2022-28391 by bumping alpine from 3.15 to 3.16 ([#3649](https://github.com/distribution/distribution/pull/3649))
+  * [`9f2bc25b`](https://github.com/distribution/distribution/commit/9f2bc25b7accaa578ea5431b750f8c19a42df1b5) Fix CVE-2022-28391 by bumping alpine from 3.15 to 3.16
+* vendor: github.com/prometheus/client_golang v1.12.1 ([#3642](https://github.com/distribution/distribution/pull/3642))
+  * [`ec47096e`](https://github.com/distribution/distribution/commit/ec47096efc3b2803b00ff053f9e703e632875b2d) vendor: github.com/prometheus/client_golang v1.12.1
+* update to go 1.18 (continue testing against 1.17) ([#3643](https://github.com/distribution/distribution/pull/3643))
+  * [`6e8dd268`](https://github.com/distribution/distribution/commit/6e8dd268a80fdfc7a1c2368805921bb247735cb6) update to go 1.18 (continue testing against 1.17)
+  * [`18b4da91`](https://github.com/distribution/distribution/commit/18b4da91a4146277be27074f021e77439df102db) Update golang-ci-lint to v1.45.x
+* lint target and workflow job ([#3640](https://github.com/distribution/distribution/pull/3640))
+  * [`7548c315`](https://github.com/distribution/distribution/commit/7548c315f813916116f4f0af58e5da66f3f4d66e) cleanup old check behavior
+  * [`26a586cf`](https://github.com/distribution/distribution/commit/26a586cf39831db7afab1ad97cc8556734919ffb) lint target and workflow job
+* Dockerfile: switch to xx ([#3641](https://github.com/distribution/distribution/pull/3641))
+  * [`87f93ede`](https://github.com/distribution/distribution/commit/87f93ede9e5de6e86a2d2aefb2d5d8fe7ce98274) Dockerfile: switch to xx
+* validate and update vendor targets ([#3634](https://github.com/distribution/distribution/pull/3634))
+  * [`de240721`](https://github.com/distribution/distribution/commit/de240721ff63df9006e6aad5afba906b17206d97) cleanup old vendor validation behavior
+  * [`c0526595`](https://github.com/distribution/distribution/commit/c0526595434104717c8a63e01143ead90cb5842b) mod-outdated target to check for outdated dependencies
+  * [`ffa3019c`](https://github.com/distribution/distribution/commit/ffa3019c1fdaa3b117a922a74a214ef7c78b319e) validate and update vendor target
+* Support all S3 instant retrieval storage classes ([#3622](https://github.com/distribution/distribution/pull/3622))
+  * [`966fae54`](https://github.com/distribution/distribution/commit/966fae54639c0268949ee9a329b6951b92b4921f) Add tests for all supported storage classes
+  * [`fb937dea`](https://github.com/distribution/distribution/commit/fb937deabf5845996d06a5d7edd7c1b5146346c8) Support all S3 instant retrieval storage classes
+* docs/spec: provide valid manifest examples ([#2291](https://github.com/distribution/distribution/pull/2291))
+  * [`119a48eb`](https://github.com/distribution/distribution/commit/119a48eb79ba8c56d8c7f5c5ec93b7fdb58c953f) docs/spec: provide a valid manifest-v2-s1 example
+  * [`3244e471`](https://github.com/distribution/distribution/commit/3244e471de15a444c5d627cac39c44eb1de7ce4b) docs/spec: provide a valid manifest-list-v2-s2 example
+* (docs) Fix rendering of markdown links in OAuth docs HTML ([#3498](https://github.com/distribution/distribution/pull/3498))
+  * [`dea56fae`](https://github.com/distribution/distribution/commit/dea56fae966ab6c200239c23e7fbfe539d9ff3e0) (docs) Fix rendering of markdown links in OAuth docs HTML
+* Update s3 ListObjects to V2 API ([#3624](https://github.com/distribution/distribution/pull/3624))
+  * [`48f3d9ad`](https://github.com/distribution/distribution/commit/48f3d9ad29474d200af8fe8ee9e7965ebf72f903) Fix typo
+  * [`8eab5d1b`](https://github.com/distribution/distribution/commit/8eab5d1bd6c69e895d762c30a0d34031ccc872ee) Update s3 ListObjects to V2 API
+* Add forcepathstyle parameter for s3 ([#3632](https://github.com/distribution/distribution/pull/3632))
+  * [`15de9e21`](https://github.com/distribution/distribution/commit/15de9e21bad774b24e48a46d9238a5714e7ceb6c) Add forcepathstyle parameter for s3
+* Add new parameter accelerate to S3 storage driver. ([#3181](https://github.com/distribution/distribution/pull/3181))
+  * [`80952c9e`](https://github.com/distribution/distribution/commit/80952c9e2b75e1bc80fa138f9354d000d6a56b59) Rename s3accelerate parameter to accelerate
+  * [`ea27621d`](https://github.com/distribution/distribution/commit/ea27621d4a2d9c0d0122d23004ef317077783298) Fix review
+  * [`51c0c814`](https://github.com/distribution/distribution/commit/51c0c8148ab75fae72f60957b3b9f246e421b6f5) Add new parameter s3accelerate to S3 storage driver.
+* Remove duplicate code of conduct ([#3112](https://github.com/distribution/distribution/pull/3112))
+  * [`8ad73297`](https://github.com/distribution/distribution/commit/8ad732972ea8842eeb8d98bed01db4a4c7cf6ad0) Remove duplicate code of conduct
+* Fix panic in inmemory driver ([#3615](https://github.com/distribution/distribution/pull/3615))
+  * [`1a75c719`](https://github.com/distribution/distribution/commit/1a75c71907c6b67914174c8a9fded34c7b1d96d3) Fix panic in inmemory driver
+* Incorrect variable in test output ([#3613](https://github.com/distribution/distribution/pull/3613))
+  * [`25bd1f70`](https://github.com/distribution/distribution/commit/25bd1f704d8c4bc30d2f7d631e76571e67743169) Incorrect variable in test output
+* go.mod: github.com/aws/aws-sdk-go v1.43.16 ([#3606](https://github.com/distribution/distribution/pull/3606))
+  * [`decc64eb`](https://github.com/distribution/distribution/commit/decc64eb5c5e846c9cfae657afe38b1d5df806ad) go.mod: github.com/aws/aws-sdk-go v1.43.16
+* fix: paginate through s3 multipart uploads ([#3519](https://github.com/distribution/distribution/pull/3519))
+  * [`7736319f`](https://github.com/distribution/distribution/commit/7736319f2ed49768b9d9eb832465a1317dd0b106) fix: paginate through s3 multipart uploads
+* Restore documentation that was moved to docker docs repository (take 2) ([#3397](https://github.com/distribution/distribution/pull/3397))
+  * [`3b83bce7`](https://github.com/distribution/distribution/commit/3b83bce74dfe1854698866a14a3bb7f472ccac70) docs: update some URLs and remove some of the Docker branding
+  * [`ae248991`](https://github.com/distribution/distribution/commit/ae24899119ea77ada158922497b6b88c981a538c) Remove code related to building docs with Hugo
+  * [`ff0c463f`](https://github.com/distribution/distribution/commit/ff0c463f2b4fd8f993055f3e1ce7306731361088) Remove docs.docker.com "include" directives
+  * [`ef8966aa`](https://github.com/distribution/distribution/commit/ef8966aacd1dc54aa770acc17e27ab8cf01512d9) Merge remote-tracking branch 'distribution_docs/migrate_distribution_docs' into restore_docs3
+  * [`846be378`](https://github.com/distribution/distribution/commit/846be37893d6b3aad2917beb9169fa8663684b7d) Update note on Docker official images
+  * [`f2f9b296`](https://github.com/distribution/distribution/commit/f2f9b29658397578c23d4b2aadc9e806214d3455) Update insecure.md
+  * [`f6a54b0d`](https://github.com/distribution/distribution/commit/f6a54b0d29f88631d16c541ce2c80ded15eb3aa8) Update most links to use https by default
+  * [`7b77a24b`](https://github.com/distribution/distribution/commit/7b77a24bb22b667af4a99b8f4ea7224cf4b06ace) Revert "Remove info on service accounts"
+  * [`715959c1`](https://github.com/distribution/distribution/commit/715959c1713b91b9df5adeb08aa9aab8e3ba3a22) Remove info on service accounts
+  * [`1003ce30`](https://github.com/distribution/distribution/commit/1003ce30f1d980bb8bf710e55dc19c22b4071e10) Update deploying.md
+  * [`072bad48`](https://github.com/distribution/distribution/commit/072bad48b1787e02f34b1aaa15e0876710d65644) Add missing code-hints, and minor markdown edits
+  * [`9b971331`](https://github.com/distribution/distribution/commit/9b971331af8f6c2a3f7922d7fd2f44e44159bf46) Desktop: move "docker-for-windows" to "desktop/windows"
+  * [`31c9a9d7`](https://github.com/distribution/distribution/commit/31c9a9d737175454b0f1c7a2fd9d28cedc4c45af) Desktop: move "docker-for-mac" to "desktop/mac"
+  * [`576f4fc0`](https://github.com/distribution/distribution/commit/576f4fc07466dad0ce9fb8318b9f52a55b18ae5c) fix broken link for setting up local registry with auth
+  * [`ee8c75cb`](https://github.com/distribution/distribution/commit/ee8c75cbd152527c3c88f1a6f92de040a1560dfd) registry: use "console" for shell examples
+  * [`1fa75f31`](https://github.com/distribution/distribution/commit/1fa75f3129b235840c290d5210e47b134e8f8f2d) Indent webhook notifications Authorization header
+  * [`4ff7f21b`](https://github.com/distribution/distribution/commit/4ff7f21b2d98a2a8d95b0589e68abdc3fba9bc38) Update pull limits for service accounts
+  * [`3d717101`](https://github.com/distribution/distribution/commit/3d7171013327803a15dc4a463391b17155644582) Updated service account links (#12953)
+  * [`1777a5ba`](https://github.com/distribution/distribution/commit/1777a5ba63d1145f1d55fd69ba55baadf00cf7df) Updating registry help (#12948)
+  * [`e7dc768a`](https://github.com/distribution/distribution/commit/e7dc768ae54ded551b7ae2eda38d2e551a4d5dfc) Self-signed certificate with Kubernetes fix
+  * [`e2872d1d`](https://github.com/distribution/distribution/commit/e2872d1d2a61084cec196bc29fcb2cd66551c693) Migrate IPvlan docs from CLI to docs repository
+  * [`13022287`](https://github.com/distribution/distribution/commit/1302228707d71d1d7674e582aee04c2292d283ec) init
+  * [`0a7648ed`](https://github.com/distribution/distribution/commit/0a7648edb5f2963392a01e297c28a0a6c6fa4e25) Fixes docker/distribution-library-image/issues/107
+  * [`a49afdbd`](https://github.com/distribution/distribution/commit/a49afdbd98c59ccad56b99412bb28b7a4db64b21) Adding in points to clarify usage of official images (#12713)
+  * [`b2ac3a28`](https://github.com/distribution/distribution/commit/b2ac3a28846a1bc7caaa6f165725deb1088d1d30) TASK: Add codeblocks to code examples
+  * [`977c98e0`](https://github.com/distribution/distribution/commit/977c98e06f71a58967331d0dd065c373dcacb1cc) Fix broken links
+  * [`78242c79`](https://github.com/distribution/distribution/commit/78242c79ea72f69007ac75f6110c740230758009) Update insecure.md for Docker Desktop (#11964)
+  * [`430bf259`](https://github.com/distribution/distribution/commit/430bf25958663fcefa897a361f684a6c05934caa) update http://dockr.ly links to use TLS
+  * [`82f04d03`](https://github.com/distribution/distribution/commit/82f04d03355b290179cc737b33c04577517b09f6) Remove references to obsolete engine versions
+  * [`2059160c`](https://github.com/distribution/distribution/commit/2059160c94535f23a9d9006720302dc96172335e) Remove Docker Toolbox docs
+  * [`e02cd812`](https://github.com/distribution/distribution/commit/e02cd8124dec4dbd793e56b9cec5d1a7f891d147) Use https:// for links and examples
+  * [`3ec5e7e0`](https://github.com/distribution/distribution/commit/3ec5e7e073f2c997cd359439c32b05e78630fd15) Add rel="noopener" to external links
+  * [`eaeb3160`](https://github.com/distribution/distribution/commit/eaeb31604e6e44c5a377e406f6b589ac9580c755) Add azure config container example (#11152)
+  * [`dc7801c5`](https://github.com/distribution/distribution/commit/dc7801c55b5aaf75a6b40eb01bb156b994c80214) Add note on Docker Hub
+  * [`989101c8`](https://github.com/distribution/distribution/commit/989101c8c8626f88b092eb329b1ee49b1f5bb0e4) Remove some references to enterprise products
+  * [`40f4476d`](https://github.com/distribution/distribution/commit/40f4476dab791d1a9e4c4f464973d47df43d5f0c) Remove not really implemented s3accelerate option (#10993)
+  * [`b338d2f6`](https://github.com/distribution/distribution/commit/b338d2f6ac647dbac3d9d83b5e85da784832f227) Get Docker: fix broken links and wrap markdown to 80 char (#10691)
+  * [`aee0eeb3`](https://github.com/distribution/distribution/commit/aee0eeb354dcd108581fa76ddc97f90c8cbf1926) registry: use relative markdown links
+  * [`267e231d`](https://github.com/distribution/distribution/commit/267e231de0a40da3b90bcabbb090938eb4e34bd7) Fix various links that were generating URLs with `.md` (#10548)
+  * [`cb2a09fa`](https://github.com/distribution/distribution/commit/cb2a09fac2423535a12e115de9dfb835e81dc69e) Update tables from html to markdown format (#10360)
+  * [`5e3911c2`](https://github.com/distribution/distribution/commit/5e3911c2e64bbd8828ba5d74d93e92b28fef193d) update registry s3 storage driver docs to add skipverify flag
+  * [`fdb1abd3`](https://github.com/distribution/distribution/commit/fdb1abd387eec05220a79db647859d788eddd8e2) Added Nginx Recipe Redirect
+  * [`f580993c`](https://github.com/distribution/distribution/commit/f580993c805af53d0a34c7920e3dbc9e40a7691f) fix typo
+  * [`dfcc7bcc`](https://github.com/distribution/distribution/commit/dfcc7bcccac915572b45ed0fff49c73536171024) [sec] nginx/compose: Drop aforementioned loophole
+  * [`d6167089`](https://github.com/distribution/distribution/commit/d61670894ad9500c9098af832fcd21f944df377f) removing section for Chinese mirror
+  * [`414cebd4`](https://github.com/distribution/distribution/commit/414cebd40e46c26ed57d5368dd069f2c0a48d47d) Update link to DTR
+  * [`3be1cdec`](https://github.com/distribution/distribution/commit/3be1cdec0e7941c962dae54d268b0a853522c66f) Update help.md
+  * [`297ba124`](https://github.com/distribution/distribution/commit/297ba124e6b97f89d1eeb8211a72d559ebdc9b69) Use consistent formatting for notes
+  * [`560471b5`](https://github.com/distribution/distribution/commit/560471b55574be4817a43285161a18798d1de0af) Update deploying.md
+  * [`43b914b6`](https://github.com/distribution/distribution/commit/43b914b687eaddc1cc8157520b1d292e8d003cb1) Update nginx.md
+  * [`f89f0867`](https://github.com/distribution/distribution/commit/f89f0867e2ec64ad002b11db7b5617b48362f1ce) Update nginx.md
+  * [`8112d01b`](https://github.com/distribution/distribution/commit/8112d01b9be3b42f78d031787042ba5789dff89a) nginx.md: Add note about potential security isues
+  * [`b98fb58a`](https://github.com/distribution/distribution/commit/b98fb58a09f1a4548f29c4720a2101b39dc6d218) Document registry s3 transfer acceleration option.
+  * [`582d8e62`](https://github.com/distribution/distribution/commit/582d8e62dc178035aebf06a4c7dbb857bc7919f3) Revert "Fix error (small change, only 1 line)"
+  * [`06205627`](https://github.com/distribution/distribution/commit/06205627504286cb5efa8b35f86100a5b7877806) Fix error
+  * [`af3ab222`](https://github.com/distribution/distribution/commit/af3ab2227864a5f0982ca7b4c11012bfcfdd3b2c) Merge branch 'master' into name-change-for-Docker-Desktop
+  * [`f9d531c4`](https://github.com/distribution/distribution/commit/f9d531c4b7c505912c86c11eba8334c5ff6d0b9c) 404 registry API
+  * [`c594eb1f`](https://github.com/distribution/distribution/commit/c594eb1ff04b154e15c69bfb1623b7a03c078214) Mention that rootdirectory prefix has to be pre-existcreated
+  * [`c7386154`](https://github.com/distribution/distribution/commit/c73861540e74e8217442069869968dda9d8d47f9) Update insecure.md
+  * [`401a2b75`](https://github.com/distribution/distribution/commit/401a2b75e85a7d856df229f990446da266bda512) Merge branch 'JoeWrightss-patch-1'
+  * [`01ceef9f`](https://github.com/distribution/distribution/commit/01ceef9f0ae6031f1243b5980ac275cd7fa7bccb) Restoring open source registry garbage collection page
+  * [`62894d68`](https://github.com/distribution/distribution/commit/62894d68b6f49d2711c75df121e40b75f1ca0337) Merge public:master into private
+  * [`e92760a3`](https://github.com/distribution/distribution/commit/e92760a3a052931d6086237cbb8047f5a0dfdbad) Spelling revision
+* Export ServeJSON for serving error codes ([#705](https://github.com/distribution/distribution/pull/705))
+  * [`2fda032d`](https://github.com/distribution/distribution/commit/2fda032d489219100e72aa08d47d6306f9430893) Delete tag-pruning.md
+  * [`50dacc55`](https://github.com/distribution/distribution/commit/50dacc554b901a3fd2167e11be6429e815d8c709) Initial draft of product manual for tag-pruning
+  * [`b0bb8437`](https://github.com/distribution/distribution/commit/b0bb8437cf2bbe99c558710652459241975280f8) Delete garbage-collection.md
+  * [`71d02b10`](https://github.com/distribution/distribution/commit/71d02b105c93c4c4ec7219a5b481c35b7cf0d837) Add online garbage collection feature and known limitation as described on DTR Workshop doc
+  * [`f04f6208`](https://github.com/distribution/distribution/commit/f04f6208b9563111cfe4426fcdf9385f800dfac2) Revert "Revert "Merge branch 'master' of github.com:docker/docs-private into test-branch-2""
+  * [`88038ffd`](https://github.com/distribution/distribution/commit/88038ffd3a7e7063606f4f72b780b9af62823079) Revert "Merge branch 'master' of github.com:docker/docs-private into test-branch-2"
+  * [`b9c4182e`](https://github.com/distribution/distribution/commit/b9c4182eb6ce6a8a2489faffc785f1c4ea87d1ad) Revert "Revert "Merge branch 'master' of github.com:docker/docs-private into test-branch-2""
+  * [`2df45044`](https://github.com/distribution/distribution/commit/2df45044a66e2cb4a4e542d735636c6fd2db6920) Revert "Merge branch 'master' of github.com:docker/docs-private into test-branch-2"
+  * [`7eac5fad`](https://github.com/distribution/distribution/commit/7eac5fad26eece406bb0bcfb66d589a90ed853ac) Revert absolute path change
+  * [`bfd7156f`](https://github.com/distribution/distribution/commit/bfd7156f338a97eaddfabc6e7a5fb440138d7893) Grammatical and spelling updates
+  * [`955f7ef6`](https://github.com/distribution/distribution/commit/955f7ef68b419f22159e6d700a7ccccd9b400838) fix: configuration reference link
+  * [`ff786644`](https://github.com/distribution/distribution/commit/ff7866442a2010ee70d0e0bc413807337770c653) Update deploying.md
+  * [`f497e79c`](https://github.com/distribution/distribution/commit/f497e79c7eb3bb6d9803b24393e851fcd3aad238) Update part2.md (#6475)
+  * [`1b6e19d6`](https://github.com/distribution/distribution/commit/1b6e19d694f0776b89aa32088422c0919a3d0ff4) Update link to Docker Trusted Registry (#6479)
+  * [`9042088f`](https://github.com/distribution/distribution/commit/9042088fad2e83934452c76f9e9c599364a1f70c) Fix "Run the registry as a service" link (#6289)
+  * [`f0fe5c38`](https://github.com/distribution/distribution/commit/f0fe5c3875c2bce48de6d78f4869d3bdbd156474) registry/filesystem: mention umask (#6276)
+  * [`e80e5f2e`](https://github.com/distribution/distribution/commit/e80e5f2eb86c5e514a0a9a217578d5445a9fa300) Update swift.md (#6054)
+  * [`4a9ec817`](https://github.com/distribution/distribution/commit/4a9ec8171ddcd35f25e596be77b14c2b69e16304) Update azure.md (#6053)
+  * [`198ebadc`](https://github.com/distribution/distribution/commit/198ebadc6de2c124d5359a779ac4ea469f40abd3) Fix links not rendering properly (#6049)
+  * [`35cca3f0`](https://github.com/distribution/distribution/commit/35cca3f0f4136bcee67b8510eb4e4bc9cf01e1a6) Update compatibility.md (#6043)
+  * [`db6444ac`](https://github.com/distribution/distribution/commit/db6444ace50560acb4a04da463825b01e085fba6) Update mirror.md
+  * [`947af10c`](https://github.com/distribution/distribution/commit/947af10cc08a7af12de9f7e54965896d530231ae) Update insecure.md
+  * [`1edd9dcc`](https://github.com/distribution/distribution/commit/1edd9dcccc3a28bc48a62421667b908549bcccb3) Update notifications.md
+  * [`a92ed35a`](https://github.com/distribution/distribution/commit/a92ed35ab2ef57816fa977704c850d20e4fc170c) Fix port requirement for SSL of docker registry (#5973)
+  * [`09d8e4bd`](https://github.com/distribution/distribution/commit/09d8e4bd9316d1b3dff31e59956a4b1c861fbb2f) Favor docker <object> <verb> format of commands (#5914)
+  * [`f1fb0683`](https://github.com/distribution/distribution/commit/f1fb06838a345aa535ccd268b9cc1f64c7e1221e) Various copyedits to reduce future tense, wordiness, and use of 'please' (#5788)
+  * [`b5bbca9e`](https://github.com/distribution/distribution/commit/b5bbca9ed4c2b669d3a39a065ff3d9071fc4b303) Improve Cloudfront notes regarding private buckets (#5225)
+  * [`a6edcada`](https://github.com/distribution/distribution/commit/a6edcadac929d3c204b2bfddbfcf164a851486ca) Correct parameter names for --publish long syntax (#5457)
+  * [`a8dac1ad`](https://github.com/distribution/distribution/commit/a8dac1ad4ef7726168500b1a4cf82d168e9a74fe) Navigation under "Reference" and "Manuals," Registry warning, "Latest" UCP/DTR (#5469)
+  * [`82530e5a`](https://github.com/distribution/distribution/commit/82530e5a584dba69e114fdb19ceeb0e66fbb505a) Add alt text to images which are missing it (#5047)
+  * [`93600752`](https://github.com/distribution/distribution/commit/936007524ab8f46a2ed0872232517a419589bcd8) Update docs for new publish syntax (#5323)
+  * [`3d5f8b03`](https://github.com/distribution/distribution/commit/3d5f8b0380e8cdcc0b068e0b5cff4c6e247bdad2) Add link to forums in registry docs (#5308)
+  * [`d549a5cc`](https://github.com/distribution/distribution/commit/d549a5cc37ff320528ab3a8cf5c5d77c186ed2c5) Prefer daemon.json over command-line flag
+  * [`e25f858b`](https://github.com/distribution/distribution/commit/e25f858bb60dbef6959ae5c6494fe9754b5d7382) Remove deprecated '-d' option to start daemon
+  * [`b5975461`](https://github.com/distribution/distribution/commit/b5975461f0e4318e45032674ea6d863b32b3c642) Update deploying.md
+  * [`e95522ec`](https://github.com/distribution/distribution/commit/e95522ec4519f152abb852f6885ff9d70a0c8c6e) Update notifications.md (#5045)
+  * [`e61eb68b`](https://github.com/distribution/distribution/commit/e61eb68b3b8c9183523f94b11aac66a6c2785d0c) Deploying Registry: Fixed ports on HTTPS (#4965)
+  * [`c8d82bbd`](https://github.com/distribution/distribution/commit/c8d82bbd38f2562dc4f6d394b2e084e69d01d853) Docker service registry not running correctly (Replicas 0/1) (#4641)
+  * [`1f640d19`](https://github.com/distribution/distribution/commit/1f640d19dd20141e9ad0fe15b3b5f2f67a185861) contraint instead of label to create Registry on node1 (#4644)
+  * [`8b93c509`](https://github.com/distribution/distribution/commit/8b93c509824c3bfa04339a52cb30ba7460700da8) Update b.o. Error while creating Registry Service (#4465)
+  * [`675ffdbd`](https://github.com/distribution/distribution/commit/675ffdbdaf0d3a57a57a754595ee1e03410f8335) Fix Typo (#4575)
+  * [`fd9fc031`](https://github.com/distribution/distribution/commit/fd9fc031a2f46bb061c8c6b652e53d5dad04036a) Use nginx image which supports bcrypt (#4489)
+  * [`f01d83d6`](https://github.com/distribution/distribution/commit/f01d83d61e6b912261b86dab403da44f1895168b) Update mirror.md (#4506)
+  * [`5096a16d`](https://github.com/distribution/distribution/commit/5096a16d32ce43b9d45878ae4ecc5184164be7af) Update garbage-collection.md (#4317)
+  * [`e4f126c1`](https://github.com/distribution/distribution/commit/e4f126c10e670e7405b10a7982cae6fad400bbbf) nginx does not support bcrypt when using auth_basic (#4332)
+  * [`90a402d9`](https://github.com/distribution/distribution/commit/90a402d946a9eba25935b7abba007c157b9223da) fix registry template plist location for launchctl (#4333)
+  * [`aa6e6971`](https://github.com/distribution/distribution/commit/aa6e69711a1617e207cc659a2b1fc689f99991ce) Update compatibility.md (#4321)
+  * [`c1950e12`](https://github.com/distribution/distribution/commit/c1950e123d32682fdd115cf04326c49125c9629b) Update index.md (#4323)
+  * [`aa2955a7`](https://github.com/distribution/distribution/commit/aa2955a748e4c2f889f53c3ac8b2b57e29ae86a0) Update index.md (#4322)
+  * [`3ae7d9ca`](https://github.com/distribution/distribution/commit/3ae7d9ca651a30e46ab8ccac47b602db917f4f03) Update insecure.md (#4318)
+  * [`e98a162c`](https://github.com/distribution/distribution/commit/e98a162c62149ed7112f50831919a8d638655678) Update osx-setup-guide.md (#4316)
+  * [`d18e3a63`](https://github.com/distribution/distribution/commit/d18e3a63bead8334ef70ef0df40461868a3f9127) Update filesystem.md (#4324)
+  * [`a2500623`](https://github.com/distribution/distribution/commit/a25006234fecb87c1e6b82b5ce83e7ea26619378) Add China registry mirror section (#84)
+  * [`a9549228`](https://github.com/distribution/distribution/commit/a95492280b354b8963b7d4556c4b5c2d3bc0df82) Fix borked link (#4097)
+  * [`a1088938`](https://github.com/distribution/distribution/commit/a1088938b01045c8c3b37e86a048d7eda27a10d3) Remove sentence about super old Docker (#4099)
+  * [`2aa6e2ae`](https://github.com/distribution/distribution/commit/2aa6e2ae80dd9d3b284e3141a5799b6adbd11104) Documentation typo fix (#4087)
+  * [`c2bbc7ea`](https://github.com/distribution/distribution/commit/c2bbc7eab7b5552070434e663360dd592795d8d1) fix default secrets path in container (#4011)
+  * [`3c1aeebc`](https://github.com/distribution/distribution/commit/3c1aeebc2a8131963437f8b4b3ba45d1fac46413) Fix links to subtopics in index.md files by include full path (#4054)
+  * [`23c116b7`](https://github.com/distribution/distribution/commit/23c116b75fd9b7dc85664abe88d5d30a1d883ae5) Fix link to requirements (#3970)
+  * [`a59d321e`](https://github.com/distribution/distribution/commit/a59d321e8de603edc342d517e0a0d51f1cd92911) Fix link to requirements in Nginx recipe (#3969)
+  * [`c6f6c44e`](https://github.com/distribution/distribution/commit/c6f6c44e56cc1cd350870e4ed98136cd8e0d0ef6) Remove v2-registry-auth image (#3965)
+  * [`cb3f2ace`](https://github.com/distribution/distribution/commit/cb3f2ace6dd63705f30e00ee5078c432161d92d7) Update mirror.md
+  * [`cf36ad3c`](https://github.com/distribution/distribution/commit/cf36ad3cb2e34d632efda68a496f44462300848f) Improve tip on log messages (#3888)
+  * [`82998e10`](https://github.com/distribution/distribution/commit/82998e1077398d75a4395ac065838ac16862322d) Add tip about error message in registry cache (#3874)
+  * [`b19b19cc`](https://github.com/distribution/distribution/commit/b19b19cc7082b2ff7a663de8f0c950ff3ec8fef7) Fixed spelling of 'exammple' (#3769)
+  * [`31619aed`](https://github.com/distribution/distribution/commit/31619aedd393a34aff9b16d0769c9c7d92b31123) Reorganize registry deployment guide (#3485)
+  * [`8ac75794`](https://github.com/distribution/distribution/commit/8ac75794dd4b523c98bcd87488af84ab37098c73) Point to newer registry topic (#3719)
+  * [`55aec8a4`](https://github.com/distribution/distribution/commit/55aec8a4f7ef4148fb9a6736f146aba7edfd8857) htpasswd passwords should use bcrypt hashing (#3401)
+  * [`c60e7107`](https://github.com/distribution/distribution/commit/c60e7107fa97cf826781068ad8b8f36e3ad9c7e7) Add use case for China registry mirror (#3682)
+  * [`6508f123`](https://github.com/distribution/distribution/commit/6508f123f8f504785b65fb82e4b681d31eb548c1) Reword sentence
+  * [`bbbafb0e`](https://github.com/distribution/distribution/commit/bbbafb0e72fe828e0f56179edc85d2de2f60e689) Update notifications.md (#3399)
+  * [`efa76b98`](https://github.com/distribution/distribution/commit/efa76b98d077c8bf35adca580978a201dc0da313) Update oss.md (#3448)
+  * [`4da4fc02`](https://github.com/distribution/distribution/commit/4da4fc02c0ca05f11c90c08e41083282c94d083c) Update compatibility.md (#3445)
+  * [`528d2279`](https://github.com/distribution/distribution/commit/528d227917743d692a51f67f0e3ddafb93080d3e) Update insecure.md (#3444)
+  * [`78d25013`](https://github.com/distribution/distribution/commit/78d250137b01f951efe4cf07300876b13b2db8db) Update garbage-collection.md (#3443)
+  * [`a6fc3fa7`](https://github.com/distribution/distribution/commit/a6fc3fa7fab71cd0d1a2bfac1deade510cc7e331) Update osx-setup-guide.md (#3442)
+  * [`2c19d1ca`](https://github.com/distribution/distribution/commit/2c19d1ca88a7e88e6c1239039fc6d8910c4eaa72) Update apache.md (#3441)
+  * [`b9220191`](https://github.com/distribution/distribution/commit/b9220191fccdfca9903cae5b31f104613f35c7f3) Fix typo in markdown (#3371)
+  * [`864905cf`](https://github.com/distribution/distribution/commit/864905cfac74a3efddc4fe69ec554b81a62d85b6) "as mall as possible"=>"as small as possible" (#3372)
+  * [`a5b2b63b`](https://github.com/distribution/distribution/commit/a5b2b63bcb3c29ce82967c9a624e66a24d67dc95) Update deploying.md (#3373)
+  * [`aed6cb22`](https://github.com/distribution/distribution/commit/aed6cb22b506583b669a63873e79d57d569992f4) Reverted (#3393)
+  * [`1b6da36a`](https://github.com/distribution/distribution/commit/1b6da36acda4a49199738f77175ea3f3332fd7a9) Add section on China registry mirror (#3379)
+  * [`7c5b1e60`](https://github.com/distribution/distribution/commit/7c5b1e60c241a4740351dbc155a28e47f42db556) Remove registry/architecture.md from docs repo (#3365)
+  * [`9161e93e`](https://github.com/distribution/distribution/commit/9161e93e927442d1682bb64a9c881c55212f5fbb) Update introduction.md (#3353)
+  * [`4f582ad9`](https://github.com/distribution/distribution/commit/4f582ad996ab7c97063732e24930133a66b70645) Add instructions to remove also proxy_set_header Host (#3156) (#3342)
+  * [`ed56794d`](https://github.com/distribution/distribution/commit/ed56794d56863a03284e49e94ad51c671d1a686f) Use daemon.json everywhere possible (#3252)
+  * [`eb2763d8`](https://github.com/distribution/distribution/commit/eb2763d826767fadf4783e5b56d18234a7bf49ca) Update index.md (#3102)
+  * [`f1899170`](https://github.com/distribution/distribution/commit/f1899170e94aa2b958f98aa185d6edce2b96ad71) Self-signed certificates setup on Windows (Part 1) (#2909)
+  * [`b5889701`](https://github.com/distribution/distribution/commit/b588970105270e1de92b2f6e272904be9f155b74) add warning class and a linebreake to the warning blogquote (#2937)
+  * [`7cf8dc7c`](https://github.com/distribution/distribution/commit/7cf8dc7c5126e610bc2ad37eec930ea63e2c6a14) Spelling mistakes (#2970)
+  * [`547233ee`](https://github.com/distribution/distribution/commit/547233ee69ffd214b836462d03d3464a394d3934) replaced docker/docker with moby/moby (#2879)
+  * [`b2635632`](https://github.com/distribution/distribution/commit/b2635632a20ff910691d7610ec927b7e223bf0fc) Updated the registry documentation to include an example for the config.yml file
+  * [`39a8fcd8`](https://github.com/distribution/distribution/commit/39a8fcd85e788338f6f6c7751a5c5be2c99cddcd) Fix table formatting and endpoint template examples (#2726)
+  * [`5cf92032`](https://github.com/distribution/distribution/commit/5cf920322316c5fd8bef30a346f6d4df3e72fc57) Updating table to remove extra closing table row (#2725)
+  * [`fde52284`](https://github.com/distribution/distribution/commit/fde52284cc56533dc64e5a8eb7523fbd620960dc) Fix some links (#2584)
+  * [`00d1f820`](https://github.com/distribution/distribution/commit/00d1f82041680f37aa42b9919a03532cb4adbdb6) Fix spelling errors (#2409)
+  * [`eb77e2f7`](https://github.com/distribution/distribution/commit/eb77e2f74a8f73dc255f001dd720ea09341f6be3) Docker 17.03 release (#2050)
+  * [`6f785666`](https://github.com/distribution/distribution/commit/6f7856665ae162ffd5b8140f35d4b0eaf8769803) Add info about fetching credentials from IAM role
+  * [`d12fce88`](https://github.com/distribution/distribution/commit/d12fce88537ee1ab36475f2ae6ec6a12b3727387) Change erroneous push to pull (#1555)
+  * [`ee6aa7d3`](https://github.com/distribution/distribution/commit/ee6aa7d3aa699d04b937d3d6da9aca2ee7a5dc98) Update links to DTR
+* Clearer documentation around environment variable overrides ([#1110](https://github.com/distribution/distribution/pull/1110))
+  * [`042cf0f5`](https://github.com/distribution/distribution/commit/042cf0f527a3536cc3a580d93d1986abdf90f4f9) Updates broken links for #1068
+  * [`8edea601`](https://github.com/distribution/distribution/commit/8edea6017951841dd5787375a6a1ce45bfa9f338) Correct wrong default value
+  * [`943860f0`](https://github.com/distribution/distribution/commit/943860f0b72fdb5590d2bfe440f7b85f2332a578) Update gcs.md
+  * [`09fdbf47`](https://github.com/distribution/distribution/commit/09fdbf4750e276df3aa2cf2f3255239dbe86fa7c) Lossless Image optimization (#959)
+  * [`5a2e1bf6`](https://github.com/distribution/distribution/commit/5a2e1bf613526d32dfc628f9b2764b1efabb50f7) improve formatting on insecure registry openssl command (#873)
+  * [`5e614987`](https://github.com/distribution/distribution/commit/5e6149879285f0e66ca7ece62b7678be25263b1c) Do not add second Api-Version header
+  * [`81498934`](https://github.com/distribution/distribution/commit/8149893423cda8d425c0bdb06a7bf3897b0a6c3d) Disable parameters substitution in heredoc
+  * [`fff17e07`](https://github.com/distribution/distribution/commit/fff17e075badc814af576f5e2d2a44661254a751) Merge remote-tracking branch 'upstream/master' into distribution_docs_from_upstream
+  * [`82eb4bc3`](https://github.com/distribution/distribution/commit/82eb4bc3020a25a752a10a344b620e6adc68a040) Pull distribution reference docs from upstream
+  * [`cc72cef9`](https://github.com/distribution/distribution/commit/cc72cef91e9ffcc4b444e95c45d5a008a4f2a69f) Transform html into markdown
+  * [`c7bc40bc`](https://github.com/distribution/distribution/commit/c7bc40bcb892b149cbd5679768251a046cefeb94) registry/azure.md: fix broken syntax/links
+  * [`ea84d17e`](https://github.com/distribution/distribution/commit/ea84d17ea6ea03cb4541ce6c8b70499496c36dd4) Improve section about AWS policy
+  * [`c7dab7f3`](https://github.com/distribution/distribution/commit/c7dab7f374ba4f0903c4c699321c88a23e11e816) fix typo in spec/api.md
+  * [`dc28d9f1`](https://github.com/distribution/distribution/commit/dc28d9f1b781f2d7ba4e9cf01db81e1e6c134c7e) Merge remote-tracking branch 'upstream/master' into vnext-compose-1.9.0-merge
+  * [`cc71beda`](https://github.com/distribution/distribution/commit/cc71bedafbcd60d14fb01e3936ed74508e57a0da) fix type of keywords entry in frontmatter (in /registry/) (#517)
+  * [`bc1e1621`](https://github.com/distribution/distribution/commit/bc1e162172ec0ae9ffda404efab5f63ac8024911) Change instances of alias: to redirect_from:
+  * [`908a1f14`](https://github.com/distribution/distribution/commit/908a1f14f5919cd2abd8d41f89cc635efbf0b8f8) Converges titles to imperative-form, front-matter based, and sentence-case (#438)
+  * [`8c922b0c`](https://github.com/distribution/distribution/commit/8c922b0c8c90bf551e596b4b411ffaf0406b6a30) Revert "Merge pull request #437 from gdevillele/fix_keywords_format"
+  * [`3d147416`](https://github.com/distribution/distribution/commit/3d14741648eca978ea99528159e1390d911bd22c) fix more frontmatter keywords values (#439)
+* Allow configuration of chunksize parameter ([#418](https://github.com/distribution/distribution/pull/418))
+  * [`2ecf05a7`](https://github.com/distribution/distribution/commit/2ecf05a74ecae70ae5cde9f0940b4d5655c9bb0d) absolute links to docs.docker.com are now relative links
+  * [`81b038a8`](https://github.com/distribution/distribution/commit/81b038a875b2ff483fcd0201de20bc820a0bed89) removed menu.md files
+  * [`e63f5950`](https://github.com/distribution/distribution/commit/e63f5950da8738e3409d44863ef7d544ec1a4bdd) Formatting fixes
+  * [`8e8290bd`](https://github.com/distribution/distribution/commit/8e8290bd814e6108a5e470d1348b1ed2cd844e5a) Formatting fix
+  * [`bd9f8c7f`](https://github.com/distribution/distribution/commit/bd9f8c7f6ef970c346244c6eec4cd72bdf6745ea) Update mirror.md
+* doc/spec: patch #222 to api.md.tmpl ([#240](https://github.com/distribution/distribution/pull/240))
+  * [`70c7657c`](https://github.com/distribution/distribution/commit/70c7657c69e38dce3fd73913e3df2cfd33f180d1) Update branding for macOS
+  * [`b206e8b2`](https://github.com/distribution/distribution/commit/b206e8b2a45938a42f4a6d74ea38f93908e94d92) Add note about configuring a registry cache with delete enabled
+  * [`50bd0cce`](https://github.com/distribution/distribution/commit/50bd0cce0748ca0503617fa1f9ec82f67ef8db85) Delete api.md.tmpl
+  * [`677eaaa3`](https://github.com/distribution/distribution/commit/677eaaa3cc21da3a3d1054217f6e99acc109f2ce) Change 'draft: true' to 'published: false' for Jekyll
+  * [`9204a649`](https://github.com/distribution/distribution/commit/9204a649259f6b2a229c5ef80b61b71be5c1f25b) Rendering fixes, part 2
+* Move manifest to discrete package  ([#21](https://github.com/distribution/distribution/pull/21))
+  * [`2d32aa43`](https://github.com/distribution/distribution/commit/2d32aa43eb491edcd3929da2f87621d5d4327bcb) Fixed typos
+  * [`856dacad`](https://github.com/distribution/distribution/commit/856dacadfc85cabfce96e2322c01e7800a81855e) Content rendering fixes
+  * [`b3b099f0`](https://github.com/distribution/distribution/commit/b3b099f079e55060996734fbc0d1bb9b5b97da3a) Removing merge detritus
+  * [`9e3c43c6`](https://github.com/distribution/distribution/commit/9e3c43c60c7e52b1fb6c5b82b349bf8607666be9) Removing empty front-matter
+  * [`0fb207c8`](https://github.com/distribution/distribution/commit/0fb207c822129834b1e171208cf2d49bdd518e13) Convert TOML to YAML, tweaks to work with Jekyll
+  * [`1f6cc853`](https://github.com/distribution/distribution/commit/1f6cc853d31cae74942700755a91862a9eeabf40) Initial import of https://github.com/docker/docker
+  * [`8d287d43`](https://github.com/distribution/distribution/commit/8d287d4332e68b6f9a60897053a37996e961ff79) Improve flag help consistency, and update docs
+  * [`93f029e8`](https://github.com/distribution/distribution/commit/93f029e87c97935a14e85df41c1a1819a5e17a03) Allow v1 search to use v2 auth with identity token
+  * [`a58c7430`](https://github.com/distribution/distribution/commit/a58c74303c6a527dedccb5720822ece24bee085f) Fix logrus formatting
+  * [`08426ad1`](https://github.com/distribution/distribution/commit/08426ad10debbc46e922334c3890f76950024713) Add `--limit` option to `docker search`
+  * [`d265da73`](https://github.com/distribution/distribution/commit/d265da7356ae8c272d73bb7d1d321935dc7bf9a2) fix typos
+  * [`04476ff5`](https://github.com/distribution/distribution/commit/04476ff5a9e638b793a3701e951e80ab97c5c6f1) Add Unit test to daemon.SearchRegistryForImages…
+  * [`c4778ea1`](https://github.com/distribution/distribution/commit/c4778ea1bea152515d2fbd82bf0085a6ce9af663) Respect ALL_PROXY during registry operations
+  * [`56480ce8`](https://github.com/distribution/distribution/commit/56480ce80ac6d16e44cc99afec83c5f1914c0fb8) Add default `serveraddress` value in remote API `/auth`
+  * [`53a8806b`](https://github.com/distribution/distribution/commit/53a8806b40437074e0bdcd29425c54a87df7e0c0) 1.change validateNoSchema into validateNoScheme 2.change schema into scheme in docs and some annotations.
+  * [`0f4b8d34`](https://github.com/distribution/distribution/commit/0f4b8d34555803b77901fb8a017d015059641c19) Correct login debug log message
+  * [`7f7cb821`](https://github.com/distribution/distribution/commit/7f7cb8214961d95283571cba5e23791654bfcd8a) *: fix response body leaks
+  * [`b4d9ae60`](https://github.com/distribution/distribution/commit/b4d9ae605214569fe535979f5b2e98d377ac71c8) registry: endpoint_v1: fix outdated comment
+  * [`d5160a02`](https://github.com/distribution/distribution/commit/d5160a02110e411447ca154e86875648083cf6ea) daemon: update: check len inside public function
+  * [`cbd95acb`](https://github.com/distribution/distribution/commit/cbd95acbbc556e3da505c95d7b83ffb46742c5ec) Add support for identity token with token handler
+  * [`2f170573`](https://github.com/distribution/distribution/commit/2f170573145d7fb8a24ed8e0df11555aa8336ec0) Remove Windows-specific default registry definitions
+  * [`7caf33d6`](https://github.com/distribution/distribution/commit/7caf33d6c5516f5497401ffe1223b65b377ad20c) Move registry service options to the daemon configuration.
+  * [`3e2da426`](https://github.com/distribution/distribution/commit/3e2da4263eef8573c6e8dcef55b7e999d22c4e80) fix some typos.
+  * [`065ddf01`](https://github.com/distribution/distribution/commit/065ddf0186c44d67a5a1de830b58ce74b0d40993) Login update and endpoint refactor
+  * [`e123ca92`](https://github.com/distribution/distribution/commit/e123ca925e4b027a17a1f39a6387a0c4c62a1ffd) Remove email address field from login
+  * [`9a2cef38`](https://github.com/distribution/distribution/commit/9a2cef38e31bbdeaff74c2e724990df64182c1db) Change APIEndpoint to contain the URL in a parsed format
+  * [`4bb475cd`](https://github.com/distribution/distribution/commit/4bb475cd3ce2690339ee19cebf35d9c28dac83e4) Push/pull errors improvement and cleanup
+  * [`377f5564`](https://github.com/distribution/distribution/commit/377f556464608d99712d9921fcec02bd60060016) Respond with 401 when there is an unauthorized error from the registry.
+  * [`6e85a8d9`](https://github.com/distribution/distribution/commit/6e85a8d94aa1ac0320e9c88ddd69eba39ea0b388) Remove the use of dockerversion from the registry package
+  * [`0e06c1ca`](https://github.com/distribution/distribution/commit/0e06c1cad1e97fc912c74f9bf2a71c02c2179bac) Clarify error message when a .cert file is missing a corresponding key
+  * [`981a573e`](https://github.com/distribution/distribution/commit/981a573eaf22434ebec754ac03e41cbac3f50395) Modify import paths to point to the new engine-api package.
+  * [`693eb14e`](https://github.com/distribution/distribution/commit/693eb14e730b6675455fdc3b01d48b023331663e) Allow v1 protocol fallback when pulling all tags from a repository unknown to v2 registry
+  * [`72432a70`](https://github.com/distribution/distribution/commit/72432a701a7c39cb394c6bc974256137e705ea11) Show the legacy registry flag only in the daemon arguments
+  * [`4f4b3d52`](https://github.com/distribution/distribution/commit/4f4b3d525784b8b7e473ec9aaae59dfc55c12cce) Remove usage of pkg sockets and tlsconfig.
+  * [`71ddfd40`](https://github.com/distribution/distribution/commit/71ddfd40efd02560fb7fe1ed1ae7facd6b82fd5b) When a manifest is not found, allow fallback to v1
+  * [`5717c824`](https://github.com/distribution/distribution/commit/5717c8243d1a92562bf9226b17f11e3ae492f21c) Do not fall back to the V1 protocol when we know we are talking to a V2 registry
+  * [`46683f61`](https://github.com/distribution/distribution/commit/46683f619203bc4d85f6b3087f78b2445e8b4b0a) Update Named reference with validation of conversions
+  * [`9b8f1a08`](https://github.com/distribution/distribution/commit/9b8f1a08957674e3e0c908f6cac01a4c3e56b39d) Add own reference package wrapper
+  * [`14d27ab7`](https://github.com/distribution/distribution/commit/14d27ab761797b45e0fc3242cd6067773a1214c7) Move the TestEncodeAuth test to the correct package.
+  * [`0a56a1cb`](https://github.com/distribution/distribution/commit/0a56a1cbd2821f0be8790b5d4a08ccc1b58fec99) Move registry.SearchResult types to api/types/registry.
+  * [`55fad57a`](https://github.com/distribution/distribution/commit/55fad57ac8e8f16e893466504e9b221ffb942c25) Remove timeout shared function.
+  * [`aead731d`](https://github.com/distribution/distribution/commit/aead731d54f4d777fc7a2a41c65abdf901efdcd3) Move IndexInfo and ServiceConfig types to api/types/registry/registry.go
+  * [`6fc54d04`](https://github.com/distribution/distribution/commit/6fc54d049befbea1afcf578617a6f0dfa0fb48a7) Move AuthConfig to api/types
+  * [`f7bb65ca`](https://github.com/distribution/distribution/commit/f7bb65ca8b8d931f5da77f308091572acd38e7af) Refactor ResolveAuthConfig to remove the builder dependency on cli code.
+  * [`11e8c03c`](https://github.com/distribution/distribution/commit/11e8c03c18ed46ed56e25fec01662e150de2961c) Fix typos found across repository
+  * [`00cca12e`](https://github.com/distribution/distribution/commit/00cca12e77708639d5609e06733da9b9a2c13119) Improved push and pull with upload manager and download manager
+  * [`03778bd1`](https://github.com/distribution/distribution/commit/03778bd1d2c6ecea3b040fedad081f87e4f74317) Add missing bounds in ContinueOnError
+  * [`73a20910`](https://github.com/distribution/distribution/commit/73a209107e3e17f5700b8fa494243027d683745a) Check if CertsDir is not empty
+  * [`b7d246ef`](https://github.com/distribution/distribution/commit/b7d246effb016793ee50984ce1fac0e9bc5ca4ae) rename req to resp
+  * [`6bb27bcf`](https://github.com/distribution/distribution/commit/6bb27bcfda34c21c54bb999824469125ee534e01) move defer statement for readability
+  * [`7efcb749`](https://github.com/distribution/distribution/commit/7efcb7496c64226050319c91b4c554c88dadd6d3) Update daemon and docker core to use new content addressable storage
+  * [`dde006ba`](https://github.com/distribution/distribution/commit/dde006ba6b929e5a57644334ac962a544cce1e78) registry/registry.go: simplify logical expression
+  * [`18207042`](https://github.com/distribution/distribution/commit/1820704288cadc715ca98518dd9f43cdee3e05ff) Fix for #17168 misleading pull error
+  * [`3eeebe7b`](https://github.com/distribution/distribution/commit/3eeebe7be30a8b9e9e71d05839cd17c37bf2013f) Make NormalizeLocalName to not reach the network to normalize names.
+  * [`9516a01c`](https://github.com/distribution/distribution/commit/9516a01c56885b4b763951c15921303ecaac28f6) dockerversion placeholder for library import
+  * [`94913b8f`](https://github.com/distribution/distribution/commit/94913b8f7ff03570eef62a66afa66fbacccb85bb) Fix go vet warnings
+  * [`afd61ce8`](https://github.com/distribution/distribution/commit/afd61ce8f2341785448155a9607ca3b58b9761c5) Vendor updated version of docker/distribution
+  * [`24de26a8`](https://github.com/distribution/distribution/commit/24de26a805ba4fa1c583d3742cfe19f93751fc5c) Revert "dockerversion placeholder for library-import"
+  * [`c2d5c294`](https://github.com/distribution/distribution/commit/c2d5c29437cd11e1a01cc2c574e02ed9865eb647) dockerversion placeholder for library-import
+  * [`ed69ef01`](https://github.com/distribution/distribution/commit/ed69ef01ee1d5d218fdcc44839942cbd77d0d0db) Update distribution package
+  * [`0b543b47`](https://github.com/distribution/distribution/commit/0b543b4767b242eecd0ba708eacada42b47f4588) change flag name to better follow the other flags that start with disable;
+  * [`82965f6c`](https://github.com/distribution/distribution/commit/82965f6c84f207c53321c5720072785111ab3fb5) Fix docker search problem
+  * [`ebaa771c`](https://github.com/distribution/distribution/commit/ebaa771c3b18683fe56abd85261329176e33cae7) Prevent push and pull to v1 registries by filtering the available endpoints. Add a daemon flag to control this behaviour. Add a warning message when pulling an image from a v1 registry. The default order of pull is slightly altered with this changset.
+  * [`2b658054`](https://github.com/distribution/distribution/commit/2b658054bbccd0f9f78a89ee6deb3fe7826645bd) Make RegistryConfig a typed value in the api.
+  * [`b82b0694`](https://github.com/distribution/distribution/commit/b82b069475859faa1d7059ea95ab47b4c42ca314) Remove unnecessary func parameter, add mirror endpoint test
+  * [`777fd4c7`](https://github.com/distribution/distribution/commit/777fd4c7aabea981a2c27c5fc24d7848d2e23b20) Update Windows TP3 registry endpoints
+  * [`cf901659`](https://github.com/distribution/distribution/commit/cf9016592ef7a0d382ebc794b84a9fe334a4792c) typofix - https://github.com/vlajos/misspell_fixer
+  * [`66761c02`](https://github.com/distribution/distribution/commit/66761c0284e101de1e380dcdfa210a9f94c086a7) Better/more specific error messages on connect
+  * [`a7eb16ad`](https://github.com/distribution/distribution/commit/a7eb16ad1c64cc9a3ea4c93e41353fe15126259a) registry: Do not push to mirrors
+  * [`86a3ea91`](https://github.com/distribution/distribution/commit/86a3ea91b817ef42d22748ee01ddfc9f2b881fe9) Windows: Fix certificate directory for registry
+  * [`cfb0b7aa`](https://github.com/distribution/distribution/commit/cfb0b7aa77b060dbb2abf915fcc64a97690a410d) Fix uses of "int" where "int64" should be used instead
+  * [`6f83ba2b`](https://github.com/distribution/distribution/commit/6f83ba2b29f820966a60bf316f18614a3fa7c5ea) registry: Change default endpoint on windows to a windows-specific one
+  * [`048339e3`](https://github.com/distribution/distribution/commit/048339e3f56b39ef2ae46b8311990fd68131ccf7) registry: allow fallback on unknown errors
+  * [`ba358690`](https://github.com/distribution/distribution/commit/ba358690c11e3f1d868ffd8b9b9775d206a6ce0e) Fix login and search TLS configuration
+  * [`c219afdb`](https://github.com/distribution/distribution/commit/c219afdb4b1fed22aafe604d3861ff8ef50c9ecb) Use notary library for trusted image fetch and signing
+  * [`52136ab0`](https://github.com/distribution/distribution/commit/52136ab008e9586786fa4d81bd964e0c055d6fe5) Improve documentation and golint compliance of registry package
+  * [`a246ab0a`](https://github.com/distribution/distribution/commit/a246ab0a5e65ae553d10c24e54052ae5184305ba) cli: new daemon command and new cli package
+  * [`726f3e07`](https://github.com/distribution/distribution/commit/726f3e07e39561bbe75b0e9696d7130adc17a97b) better i/o timeout error on pull
+  * [`2b7788f2`](https://github.com/distribution/distribution/commit/2b7788f2e8d2cf33aca06438915443c5cf9a3fb6) Remove v1 registry mirror configuration from LookupEndpoints.
+  * [`00edb3bb`](https://github.com/distribution/distribution/commit/00edb3bbcef75b26da81ae727346074b890dfa96) Configure TLS for private registry mirrors.
+  * [`5280103c`](https://github.com/distribution/distribution/commit/5280103cc41ff1e6f1f5da499950d6615ed66590) Remove unused types in registry package
+  * [`4c255a0d`](https://github.com/distribution/distribution/commit/4c255a0d41630ccf67b8e84b65dfc0370adcea37) Remove dead code in registry package
+  * [`138ba392`](https://github.com/distribution/distribution/commit/138ba392603a394afca5350f9639d0b6fdd1e809) golint for cliconfig
+  * [`3552960e`](https://github.com/distribution/distribution/commit/3552960ef83951f70f915c8ff3cc7d8fb6284ad4) fix 8926: rmi dangling is unsafe when pulling
+  * [`7fed379d`](https://github.com/distribution/distribution/commit/7fed379d95cd65796e55acdd768159191eff9109) Update graph to use vendored distribution client for the v2 codepath
+  * [`950cf586`](https://github.com/distribution/distribution/commit/950cf586c8336ad182793f1f3e9828f986c7a9b9) remove pkg/transport and use the one from distribution
+  * [`45bd073e`](https://github.com/distribution/distribution/commit/45bd073e54614561daf1809e0a5e601ca041eecd) Fix issue where Search API endpoint would panic due to empty AuthConfig
+  * [`8e857d11`](https://github.com/distribution/distribution/commit/8e857d114742f633b5277e535011f53d6375e1e5) Add 500 check for registry api call
+  * [`01c8fb36`](https://github.com/distribution/distribution/commit/01c8fb36657a2147835cf45e2f4012f84e9c9e59) Set canonical name correctly
+  * [`c82a9a81`](https://github.com/distribution/distribution/commit/c82a9a817f4e565586b3e3378595e8274f860391) Add the X-Docker-Token header to the /v1/search requests.
+  * [`b425c402`](https://github.com/distribution/distribution/commit/b425c402fb7d38088b8b461087b19b3e70231697) Allow one character repository name components
+  * [`f432bcc9`](https://github.com/distribution/distribution/commit/f432bcc925a97cbf323540a3fa0776072f078d52) Remove RC4 from the list of registry cipher suites
+  * [`79661b8a`](https://github.com/distribution/distribution/commit/79661b8a7e7b075d9b56c2bced927e996f07d8f0) Unconditionally add AuthTransport.
+  * [`ebd56996`](https://github.com/distribution/distribution/commit/ebd569961dbc1f8265c56ef9db6ef3bc84b9bfd3) Remove dead code
+  * [`d4c7ea43`](https://github.com/distribution/distribution/commit/d4c7ea430101b29100854928e88f55d96f95445b) Use distribution's ValidateRepositoryName for remote name validation.
+  * [`c01c508e`](https://github.com/distribution/distribution/commit/c01c508ea1a6500dd18df9c8034e1fff85cd30d0) Make the v2 logic fallback on v1 when v2 requests cannot be authorized.
+  * [`13b279f5`](https://github.com/distribution/distribution/commit/13b279f5b6806f39f2c7bd7f86644a6550214789) Only pulling single repository tag on pull for a specific tag. extending TestGetRemoteTags unit test Splitting out GetRemoteTag from GetRemoteTags. Adding registry.ErrRepoNotFound error
+  * [`5a8f6904`](https://github.com/distribution/distribution/commit/5a8f690426b9e1ea9490064b08aa9511c23075e4) Do not set auth headers if 302
+  * [`5b3e2c7d`](https://github.com/distribution/distribution/commit/5b3e2c7dda7c58a137cbe4c36b809c917af96ce7) Registry: remove unwanted return variable name
+  * [`6640f60c`](https://github.com/distribution/distribution/commit/6640f60cc58587d49a4fcb37466cc5f753102cd3) registry: debugTransport should print with testing.T.Log
+  * [`5418e3be`](https://github.com/distribution/distribution/commit/5418e3be0c799c868cb7440ac7837933a153b399) Upon HTTP 302 redirect do not include "Authorization" header on 'untrusted' registries.
+  * [`0ecc7596`](https://github.com/distribution/distribution/commit/0ecc759684ddc36cac924bc8b03d8bc4204796e4) Properly verify manifests and layer digests on pull
+  * [`767c5283`](https://github.com/distribution/distribution/commit/767c5283a28f68751c3003bc7dec4f43338020af) Fix race condition in registry/session
+  * [`7d11fc6e`](https://github.com/distribution/distribution/commit/7d11fc6e5c53fa476b98440c0913aa028b120489) Remove PortSpecs from Config
+  * [`8fc7d769`](https://github.com/distribution/distribution/commit/8fc7d769ab3a680e2ae3a93691cbc1ecccf831ee) Fix race in httpsRequestModifier.ModifyRequest when writing tlsConfig
+  * [`287cf411`](https://github.com/distribution/distribution/commit/287cf41118c281e99dbc99c3c45accaa0040fa22) Registry v2 mirror support.
+  * [`a1ade52b`](https://github.com/distribution/distribution/commit/a1ade52bb6582bcb255e95d3f03f7926d40d0534) registry: fix auth bug
+  * [`07e5885d`](https://github.com/distribution/distribution/commit/07e5885de1cb52c1b3a47776df0778f05f279eec) Fix wording in comment
+  * [`38f0c6fa`](https://github.com/distribution/distribution/commit/38f0c6fa8a6d5650046ca7ef50e860c2817ba84d) Windows: fix registry filepath and location
+  * [`808c87ce`](https://github.com/distribution/distribution/commit/808c87ce270c78faef15703c3d208c0e5223516c) Add transport package to support CancelRequest
+  * [`9e6affc3`](https://github.com/distribution/distribution/commit/9e6affc364d3f1e2afb06d4ea865ac9d1199aa22) requestdecorator: repurpose the package and rename to useragent
+  * [`89bd4848`](https://github.com/distribution/distribution/commit/89bd48481ce25ec050cd678d04e3fc3180f05b59) registry: Refactor requestfactory to use http.RoundTrippers
+  * [`3c34b3c8`](https://github.com/distribution/distribution/commit/3c34b3c87e3794746918294077683f0d8b1e4533) Increase default connection timeout to 30s
+  * [`351babbf`](https://github.com/distribution/distribution/commit/351babbf07f56082d65bca5a18ad7b39a881c8f1) Fix invalid tag name
+  * [`bb93129d`](https://github.com/distribution/distribution/commit/bb93129df4c9d0ff61859d752a4a11e5d5b400b5) trivial: typo cleanup
+  * [`9a26753d`](https://github.com/distribution/distribution/commit/9a26753d4187562131380e4f714fbd381ae154ad) Small if err cleaning
+  * [`2bd5eb9d`](https://github.com/distribution/distribution/commit/2bd5eb9d7c765a9d36dbab9e0640cfcaafac1f28) What if authConfig or factory is Null?
+  * [`a8b9bec1`](https://github.com/distribution/distribution/commit/a8b9bec1049eb9812faf032491b3b572d1df8d24) Move CLI config processing out from under registry dir
+  * [`34d1494c`](https://github.com/distribution/distribution/commit/34d1494c7fe484a4c796bd1984da38c852fb3ad1) Make .docker dir have 0700 perms not 0600
+  * [`7b8b61bd`](https://github.com/distribution/distribution/commit/7b8b61bda1cef0211db51b44ef293b069d9a9ae8) Add .docker/config.json and support for HTTP Headers
+  * [`47784682`](https://github.com/distribution/distribution/commit/47784682029f587384d6b850ae72b318725197cf) Removes redundant else in registry/session.go
+  * [`742cf000`](https://github.com/distribution/distribution/commit/742cf000d34a141866c38734f839152367446a0f) Refactor else branches
+  * [`ad3d8799`](https://github.com/distribution/distribution/commit/ad3d879929c742b1e762eb2e4e9323676f3bc590) Refactor utils/utils, fixes #11923
+  * [`67e5c940`](https://github.com/distribution/distribution/commit/67e5c940c40c10780d2ed451255a24703f0e4b3f) Use vendored v2 registry api
+  * [`e5408bd9`](https://github.com/distribution/distribution/commit/e5408bd911d3f1363d148eeca5ecf2ef8aea41b4) Remove engine.Table from docker search and fix missing field
+  * [`638ccff5`](https://github.com/distribution/distribution/commit/638ccff56443bbc11ac0656673196d6a4debead7) Remove jobs from registry.Service
+  * [`5fa2d814`](https://github.com/distribution/distribution/commit/5fa2d814f8e985747b80d6cb4e05eb6dee1d3f12) Refactor utils/http.go, fixes #11899
+  * [`b085d555`](https://github.com/distribution/distribution/commit/b085d5556e9e69da5321e45730de43f8bb6665bc) Changed snake case naming to camelCase
+  * [`d5045d05`](https://github.com/distribution/distribution/commit/d5045d054baa6ce9c607b52ea01f44720387acc6) Replace aliased imports of logrus, fixes #11762
+  * [`eff5278d`](https://github.com/distribution/distribution/commit/eff5278d12d264ff8d80eaba85a6d16786252714) Fix for issue 9922: private registry search with auth returns 401
+  * [`9c08a436`](https://github.com/distribution/distribution/commit/9c08a436249db722579cc5db672777142f177e34) Remove engine.Status and replace it with standard go error
+  * [`10128f6e`](https://github.com/distribution/distribution/commit/10128f6e8cde28fec9c3179fec8bd6d7cf8e20de) Add struct tags on v2 remote tags struct
+  * [`0e7650f9`](https://github.com/distribution/distribution/commit/0e7650f958592a1ab291f5c719a272d3cb1156e7) Fix decode tags value error when call get /v2/<name>/tags/list in registry api v2.
+  * [`9f5184c1`](https://github.com/distribution/distribution/commit/9f5184c1116760716f33ba69345567ac33b2ea94) Add check for 404 on get repository data
+  * [`bcccf35b`](https://github.com/distribution/distribution/commit/bcccf35bb2b63035feb988e9d166d806d54d613e) Separate init blob upload
+  * [`11d08c30`](https://github.com/distribution/distribution/commit/11d08c30654eceeeb9f0b189447b7f698819c060) Add verification of image manifest digests
+  * [`4bf67913`](https://github.com/distribution/distribution/commit/4bf6791328cb1d47a69918858b3605ba0df7fdc7) Update auth client configuration to use proper tls config
+  * [`7d4c1d1e`](https://github.com/distribution/distribution/commit/7d4c1d1e979a023db8241785a7dcdfd87a69f8ac) print detailed error info for docker pull
+  * [`dc4e9c6e`](https://github.com/distribution/distribution/commit/dc4e9c6e90f724ee501a6da1270a013ce31b9292) Docker Tag command: Relax the restriction on namespace (username) length from 30 to 255 characters.
+  * [`4b813b38`](https://github.com/distribution/distribution/commit/4b813b38476089abc347dd387e4d576530dd1e23) Add ability to refer to image by name + digest
+  * [`1d6ccc1b`](https://github.com/distribution/distribution/commit/1d6ccc1b723e6417f9ca2ad7053dcac0259be3ad) Quote registry error strings
+  * [`9879aefa`](https://github.com/distribution/distribution/commit/9879aefa816a3c0ce8e18179c0e555e0c9c4fec8) Use request factory for registry ping
+  * [`99401d72`](https://github.com/distribution/distribution/commit/99401d7290fee5aff529eedb8974ee0b68db092e) Allow single name component repository names
+  * [`7a35d98c`](https://github.com/distribution/distribution/commit/7a35d98c5ef35b283b119009ffa2ecb5d5eabe4f) Remove subdirectories MAINTAINERS files
+  * [`9dc3529d`](https://github.com/distribution/distribution/commit/9dc3529dfe057eeef1da4b111692c20fd27f8a9a) Add distribution maintainers to maintainers files
+  * [`d3ad1c3c`](https://github.com/distribution/distribution/commit/d3ad1c3cbb289ca8acb49fa944e0b9c589585ba6) Rename package timeout to timeoutconn.
+  * [`ec7ed3ee`](https://github.com/distribution/distribution/commit/ec7ed3eefde92418ba350a39cfe4e29be0a3ece8) Move TimeoutConn to seperate pkg dir.
+  * [`2867d39c`](https://github.com/distribution/distribution/commit/2867d39cd9259df5be0d25f295de68ab45c88b24) Removing -X flag option and autogenerated code to create Dockerversion.go functionality Addresses #9207
+  * [`92de07ce`](https://github.com/distribution/distribution/commit/92de07cee0818906a5a34671a0e6eefca9ec0b8e) Pretty the help text
+  * [`5589ce8b`](https://github.com/distribution/distribution/commit/5589ce8b8ab11576f7432d758754f65a470dc37c) delete duplicated word in registry/session.go
+  * [`3790b5d6`](https://github.com/distribution/distribution/commit/3790b5d6b457a1d5da9f1de31c2b59bc0074ff05) Fix some go vet errors
+  * [`050337b2`](https://github.com/distribution/distribution/commit/050337b25798d23b2a8296531d5d492bdaeb1774) Handle gorilla/mux route url bug
+  * [`63af81b8`](https://github.com/distribution/distribution/commit/63af81b88366692716e601f770cf2d404543dc9c) Fix token basic auth header issue
+  * [`0818476c`](https://github.com/distribution/distribution/commit/0818476cb1e4487a21ba7d05f53761ec079916d6) Open up v2 http status code checks for put and head checks
+  * [`6a736c20`](https://github.com/distribution/distribution/commit/6a736c20f01735f797f14353b180bc8178bfb752) Split API Version header when checking for v2
+  * [`d96d4aa9`](https://github.com/distribution/distribution/commit/d96d4aa9f030a9d499a5f05a77aeaeb4f7d3b904) Better error messaging and logging for v2 registry requests
+  * [`41703e2b`](https://github.com/distribution/distribution/commit/41703e2bb7fe2adc32835b150d0ad0c7469dd689) Fix write after close on http response
+  * [`1c727112`](https://github.com/distribution/distribution/commit/1c7271129b71cb91ccfed7dfbed5857649194e4e) Resolve ambiguity on registry v2 ping
+  * [`9c24fc93`](https://github.com/distribution/distribution/commit/9c24fc93adf4bdc666575f1ca2bb530d7a10c8ac) Add token cache
+  * [`5bf94a64`](https://github.com/distribution/distribution/commit/5bf94a6438b6619aef7d711b438e8fa0323ca88c) Cleanup v2 session to require endpoint
+  * [`735a1124`](https://github.com/distribution/distribution/commit/735a112415ee94795dd3594ae978d45ef6e5b36a) Fix list tags
+  * [`e5744a3b`](https://github.com/distribution/distribution/commit/e5744a3bad5de7d92d0fdc3e14f7f0f17466987e) Refactor from feedback
+  * [`826bde85`](https://github.com/distribution/distribution/commit/826bde851b3c0962c9075d123e9c3a00d14dc883) Add Tarsum Calculation during v2 Pull operation
+  * [`6f09abd5`](https://github.com/distribution/distribution/commit/6f09abd5c97aa1c8efc491b4fb0eb73c73a53a8f) Correctly check and propagate errors in v2 session
+  * [`22c73285`](https://github.com/distribution/distribution/commit/22c7328529311bfa6c38b67df6156658e2a2f411) Get token on each request
+  * [`6f36ce3a`](https://github.com/distribution/distribution/commit/6f36ce3a0183e750adef930ae4a4cb8e7d47683c) Allow private V2 registry endpoints
+  * [`751a1a8d`](https://github.com/distribution/distribution/commit/751a1a8dd0e1985eb921e888be3b027b7a6bfadb) Update push and pull to registry 2.1 specification
+  * [`ee1e1abb`](https://github.com/distribution/distribution/commit/ee1e1abb15a46b325595eab68276f30543a68e92) Remove dependencies on registry packages
+  * [`2fcad2a1`](https://github.com/distribution/distribution/commit/2fcad2a10fa5463bdad44b243f5c257455cb9e14) Registry V2 HTTP route and error code definitions
+  * [`e256a0e0`](https://github.com/distribution/distribution/commit/e256a0e0bc06aca81812960b7509d0fa76356ac5) Update token response handling
+  * [`24895820`](https://github.com/distribution/distribution/commit/24895820bd88f05bd38c041995ea4ca91b88aa35) Update push to use mount blob endpoint
+  * [`06d0ef41`](https://github.com/distribution/distribution/commit/06d0ef4179ee2d489018adac3800a491891d2336) Push flow
+  * [`6b400cd6`](https://github.com/distribution/distribution/commit/6b400cd63c203065dcf2f73256ec3caee012243b) Adds support for v2 registry login
+  * [`4eaf6443`](https://github.com/distribution/distribution/commit/4eaf64432145407281e3e25b9ce471df73e01b0a) Make .dockercfg with json.MarshallIndent
+  * [`1f983479`](https://github.com/distribution/distribution/commit/1f98347924e32e6d493911539fcf46eabdb2119e) Fix format calls as suggested by vet
+  * [`23f9f8c3`](https://github.com/distribution/distribution/commit/23f9f8c3f4d15e7bbb5d21714227049690642fb6) registry: fix minor type
+  * [`c899a49a`](https://github.com/distribution/distribution/commit/c899a49a95bc05b896b46460735a268678efc1a3) Moving NewIndexInfo, NewRepositoryInfo and associated helpers into config.go
+  * [`64b000c3`](https://github.com/distribution/distribution/commit/64b000c3ea01895124f3ce42e52366eb35c12b24) Deprecating ResolveRepositoryName
+  * [`eb9ddb7b`](https://github.com/distribution/distribution/commit/eb9ddb7b863ffcee628e92c039fc9f933233b3c6) Allow hyphens in namespaces.
+  * [`4170effd`](https://github.com/distribution/distribution/commit/4170effd5a09115f6791bf34afe6018206b5011a) registry: remove accidentally added --insecure-registry feature
+  * [`d1fcbd90`](https://github.com/distribution/distribution/commit/d1fcbd9028732cb8db82097ab63bd29476ac83ff) registry: handle unresolvable domain names in isSecure to allow HTTP proxies to work as expected.
+  * [`807bb5eb`](https://github.com/distribution/distribution/commit/807bb5eb186f6aaec6d5c6e9c96ab554d3e92e3e) registry: add tests for unresolvable domain names in isSecure
+  * [`b11b1e06`](https://github.com/distribution/distribution/commit/b11b1e06e944c9b68dfa94357989c9d326e07f97) Chnage LookupRemoteImage to return error This commit is patch for following comment // TODO: This method should return the errors instead of masking them and returning false
+  * [`cb4f9160`](https://github.com/distribution/distribution/commit/cb4f91608e945a8cb370c1324a193cd36b49aad1) Fix conflicts.
+  * [`bcf8beac`](https://github.com/distribution/distribution/commit/bcf8beacd46c76cb60ed85b57eb151553037e1b3) Merge branch master into bump_v1.4.0
+  * [`fdd4f4f2`](https://github.com/distribution/distribution/commit/fdd4f4f2d14705f172e8ae8f7110662de621cf08) validate image ID properly & before load
+  * [`6ad54e3d`](https://github.com/distribution/distribution/commit/6ad54e3df6085f905d742168f676620f80b422ef) Refactor put image function's redirect loop
+  * [`3911c8b8`](https://github.com/distribution/distribution/commit/3911c8b8dc8bcde030a5ad178bf69263b4b42fe8) Prevent loop with var overshadowing
+  * [`df85a0f7`](https://github.com/distribution/distribution/commit/df85a0f700b264dafcbfb3fd4f8d3e5d7eb64930) registry: fix ServerAddress setting
+  * [`ae0ebb9d`](https://github.com/distribution/distribution/commit/ae0ebb9d074e8fe05a0bfc7c057a5d0222df5128) Add the possibility of specifying a subnet for --insecure-registry
+  * [`f0920e61`](https://github.com/distribution/distribution/commit/f0920e61bfbbaa692b4a7ff5148e67317ad087b3) registry: parse INDEXSERVERADDRESS into a URL for easier check in isSecure
+  * [`cca910e8`](https://github.com/distribution/distribution/commit/cca910e878f20c842f599377470015d770784d99) Put mock registry address in insecureRegistries for unit tests
+  * [`80255ff2`](https://github.com/distribution/distribution/commit/80255ff22489d42040e00e25ee9e0b388ae78ef2) registry: refactor registry.IsSecure calls into registry.NewEndpoint
+  * [`524aa8b1`](https://github.com/distribution/distribution/commit/524aa8b1a68ae467315ff26ea9128aa3b996a5d8) registry: always treat 127.0.0.1 as insecure for all cases anytime anywhere
+  * [`8582d043`](https://github.com/distribution/distribution/commit/8582d04393a05b074c35915f612a69c376564be3) registry: default --insecure-registry to localhost and 127.0.0.1
+  * [`cd246bef`](https://github.com/distribution/distribution/commit/cd246befe28710ed350c94996e3ee887518a9a4b) registry: add tests for IsSecure
+  * [`7dd4199f`](https://github.com/distribution/distribution/commit/7dd4199fe8055877979a51426a2ff50e5e04c0f5) registry: don't iterate through certs
+  * [`47a494e0`](https://github.com/distribution/distribution/commit/47a494e0fd9d7b2d4aa31ce1bf48ed9992407f56) Fix login command
+  * [`1b72e023`](https://github.com/distribution/distribution/commit/1b72e0234eb0ccc1769059fcdf2d89369e5c7963) Do not verify certificate when using --insecure-registry on an HTTPS registry
+  * [`552c17d6`](https://github.com/distribution/distribution/commit/552c17d618033c0f07a4d063ce0d261db214bcb4) Don't hard code true for auth job
+  * [`50e11c9d`](https://github.com/distribution/distribution/commit/50e11c9d8ea20e950280757d909857cdecda1951) Refactor IsSecure change
+  * [`034c1cfb`](https://github.com/distribution/distribution/commit/034c1cfb9dcd6ba1b7a242ebfbabde80858a91fc) make http usage for registry explicit
+  * [`bcbb7e0c`](https://github.com/distribution/distribution/commit/bcbb7e0c416f95d35c5709df2049858dffedc358) registry/endpoint: make it testable
+  * [`ef57ab12`](https://github.com/distribution/distribution/commit/ef57ab120c604d1d52d402ef58ce0b33a67c0253) Use dual-stack Dialer when talking to registy
+  * [`22f87eb9`](https://github.com/distribution/distribution/commit/22f87eb9bed22ed4aba4de0146bcba2288df1a87) Fix error on successful login.
+  * [`1a8edd0d`](https://github.com/distribution/distribution/commit/1a8edd0d55316d28c46bcac559565d9440d5695f) excluding unused transformation to []byte
+  * [`0827b711`](https://github.com/distribution/distribution/commit/0827b71157a1d2afdca5d6fdf3f0b3b44efca826) Mass gofmt
+  * [`32654af8`](https://github.com/distribution/distribution/commit/32654af8b6e538aaf0a4f4261ced50de1a4fe806) Use logrus everywhere for logging
+  * [`7bfdb6d4`](https://github.com/distribution/distribution/commit/7bfdb6d495506c95768177fde302d19763a39932) registry: lint
+  * [`3a6fe4c5`](https://github.com/distribution/distribution/commit/3a6fe4c5c9bc8119c5468b3d1fa8b7046d87ca8f) On Red Hat Registry Servers we return 404 on certification errors.
+  * [`20867c3b`](https://github.com/distribution/distribution/commit/20867c3b1ffe5e4bca669295ad2d76b53f2ca672) Avoid fallback to SSL protocols < TLS1.0
+  * [`b62a9ac9`](https://github.com/distribution/distribution/commit/b62a9ac9895553bd14259e7769026e9f4d2a60d1) validate image ID properly & before load
+  * [`6638cd7b`](https://github.com/distribution/distribution/commit/6638cd7bc73015ca11a44abd14a6d06e4b6f49e9) Add the possibility of specifying a subnet for --insecure-registry
+  * [`8065dad5`](https://github.com/distribution/distribution/commit/8065dad50b9bacdf4a2f5cbc54a10745c81ab341) registry: parse INDEXSERVERADDRESS into a URL for easier check in isSecure
+  * [`8b0e8b66`](https://github.com/distribution/distribution/commit/8b0e8b66212a3e5cbd0f15973f53fa0154058145) Put mock registry address in insecureRegistries for unit tests
+  * [`44d97c1f`](https://github.com/distribution/distribution/commit/44d97c1fd016990ef0287625457fa3b16a1ed7df) registry: refactor registry.IsSecure calls into registry.NewEndpoint
+  * [`0481c669`](https://github.com/distribution/distribution/commit/0481c669c7ee82ddcb6b7ce78f14d5aa562505e5) Fix login command
+  * [`dff06789`](https://github.com/distribution/distribution/commit/dff06789099b1c515219e5df63a760150515b1d1) Avoid fallback to SSL protocols < TLS1.0
+  * [`798fd3c7`](https://github.com/distribution/distribution/commit/798fd3c7646559ec410b7147583c8bc959355716) Do not verify certificate when using --insecure-registry on an HTTPS registry
+  * [`27ddc260`](https://github.com/distribution/distribution/commit/27ddc260e215e97c3d4f8b3f787a40dfe60e1241) Don't hard code true for auth job
+  * [`2b9798fa`](https://github.com/distribution/distribution/commit/2b9798fa190ac8aef2a6f7630fb07f116bad6289) Refactor IsSecure change
+  * [`8b1c4073`](https://github.com/distribution/distribution/commit/8b1c40732aeca2c993fdb53febf5596701c869f2) make http usage for registry explicit
+  * [`f7165407`](https://github.com/distribution/distribution/commit/f71654074bdbfef00d5c365fcddafe1ee96baf37) Merge branch 'master' into bump_v1.3.0
+  * [`479ed10e`](https://github.com/distribution/distribution/commit/479ed10e614456ecc9f4214495de31b2a7089a50) Support tarsum dev version to fix issue with mtime
+  * [`1538e42d`](https://github.com/distribution/distribution/commit/1538e42d56b9ea95b4818e4acc95c2d905241ef6) Update manifest format to rename blobsums and use arrays of dictionaries
+  * [`f290f446`](https://github.com/distribution/distribution/commit/f290f446329fcf1c56c5705353b340050ef8a8c5) Use direct registry url
+  * [`c47aa21c`](https://github.com/distribution/distribution/commit/c47aa21c35255af07ef39308492fbfd485509713) Add comment for permission and fix wrong format variable
+  * [`b7f7b0a2`](https://github.com/distribution/distribution/commit/b7f7b0a2c992558c22d23254390f8a4223160541) Add provenance pull flow for official images
+  * [`d629bebc`](https://github.com/distribution/distribution/commit/d629bebce242acf85e59f4bdc6b12c0960493e7a) registry: getting Endpoint ironned out
+  * [`48b43c26`](https://github.com/distribution/distribution/commit/48b43c26459d6c8e033a92d47ec8cb81019df14c) Replace get.docker.io -> get.docker.com and test.docker.io -> test.docker.com
+  * [`b7da79fd`](https://github.com/distribution/distribution/commit/b7da79fd14bfc82d4b902c2ca935e1f0244d1775) Refactor all pre-compiled regexp to package level vars Addresses #8057
+  * [`898bcf0f`](https://github.com/distribution/distribution/commit/898bcf0f5d2cce3ac8e5aedcb6362743bcb0c27b) TarSum: versioning
+  * [`eaf57e8f`](https://github.com/distribution/distribution/commit/eaf57e8f559aec9d73cb1d6d3ba203ffa184b1a3) Fix SEGFAULT if dns resolv error
+  * [`307e253d`](https://github.com/distribution/distribution/commit/307e253d3330218cba4f40fc9b2d01ef5fcaecae) Restrict repository names from matching hexadecimal strings
+  * [`2c780195`](https://github.com/distribution/distribution/commit/2c78019539192273693460dc33af8b0b76bf5071) registry/session: fix panic in GetRemoteImageLayer
+  * [`27e0ec3d`](https://github.com/distribution/distribution/commit/27e0ec3d584ed32280b9384b1ec8103a91571700) Style fixes for registry/registry.go
+  * [`4d8f45a9`](https://github.com/distribution/distribution/commit/4d8f45a94d89c23d4b98d47318353e705494b534) fix return values in registry mock service
+  * [`2019191a`](https://github.com/distribution/distribution/commit/2019191a211fe06eefabf5987cba7ec52b8a5aaa) resolved merge conflict
+  * [`94c52da6`](https://github.com/distribution/distribution/commit/94c52da6c0934c6b8e0423c2764ac9cd26edda40) Expand hostname before passing it to NewRegistry()
+  * [`d768343c`](https://github.com/distribution/distribution/commit/d768343cbe275f34be77d71a2c7c22da256d63dd) Enable `docker search` on private docker registry. The cli interface works similar to other registry related commands:
+  * [`283fba48`](https://github.com/distribution/distribution/commit/283fba482103906eacfd1068a202c5e97b45f818) Expand hostname before passing it to NewRegistry()
+  * [`744919be`](https://github.com/distribution/distribution/commit/744919be3d5dde9abe48ef242c4134e8b4cd1898) Enable `docker search` on private docker registry. The cli interface works similar to other registry related commands:
+  * [`94ff3f3e`](https://github.com/distribution/distribution/commit/94ff3f3e4d08c1da67b54b176ad2df96fcf21fc1) move utils.Fataler to pkg/log.Fataler
+  * [`2a7cf96c`](https://github.com/distribution/distribution/commit/2a7cf96c8fbf7c18b96f20fd89a45e1dd6732f6f) Extract log utils into pkg/log
+  * [`7ef3a5bc`](https://github.com/distribution/distribution/commit/7ef3a5bc73e68b0638aa5794d52d20416fa00fde) registry.Registry -> registry.Session
+  * [`7f2dca77`](https://github.com/distribution/distribution/commit/7f2dca77d4cb830a321dd2e16d0d01121da29321) utils/tarsum* -> pkg/tarsum
+  * [`47261aa8`](https://github.com/distribution/distribution/commit/47261aa8cf7aadda67c2d554ee7985f0852d663e) Remove CheckSum from utils; replace with a TeeReader
+  * [`052128c4`](https://github.com/distribution/distribution/commit/052128c4fc159a7b5f1927a523e7c2826e71fe8f) Move parsing functions to pkg/parsers and the specific kernel handling functions to pkg/parsers/kernel, and parsing filters to pkg/parsers/filter. Adjust imports and package references.
+  * [`775ca3ca`](https://github.com/distribution/distribution/commit/775ca3caa33ca2976aef1a8e9abf5a9dd25075d7) move resumablerequestreader to pkg
+  * [`822f8c1b`](https://github.com/distribution/distribution/commit/822f8c1b5277c61d5e16777724b03094853f862d) update go import path and libcontainer
+  * [`78a499ac`](https://github.com/distribution/distribution/commit/78a499ac67b8f96c6aa1cb6ec4fd781d36f14c18) get layer: remove HEAD req & pass down response
+  * [`6365d94e`](https://github.com/distribution/distribution/commit/6365d94ef4a6f1a38611b9f2f04fc6bc8ad4fa99) Joining registry maintainers
+  * [`19b4616b`](https://github.com/distribution/distribution/commit/19b4616baa3e502e3d630e8f7dd7709560457fc5) Add Content-Type header in PushImageLayerRegistry
+  * [`d95235cc`](https://github.com/distribution/distribution/commit/d95235cc502ea2067d3aaed24b79e4fd578c45ab) Add support for client certificates for registries
+  * [`7cd8de13`](https://github.com/distribution/distribution/commit/7cd8de1329d3f893c140c04443467026df54b3e3) Fix go vet errors
+  * [`46cc7603`](https://github.com/distribution/distribution/commit/46cc7603d4d7cc0e018b0abf2aacf1f9366c510f) registry: remove unneeded time.Duration()
+  * [`128cc498`](https://github.com/distribution/distribution/commit/128cc498c6502867e8e4d84380230163cde80289) Merge branch 'master' into bump_v1.0.0
+  * [`4ec6e68e`](https://github.com/distribution/distribution/commit/4ec6e68e04a58a1abce9cd14967047ec6feeb334) Disable timeout for push
+  * [`5cef006c`](https://github.com/distribution/distribution/commit/5cef006c5a8ac0c0b771d78999119ff2db029e10) improve trusted location detection
+  * [`8e8ffacf`](https://github.com/distribution/distribution/commit/8e8ffacf49a1c9128b56eeb2bfd3e5d20e8d67d8) only forward auth to trusted locations
+  * [`0ac3b398`](https://github.com/distribution/distribution/commit/0ac3b3981fc85fcad9ce6c44531bc61ec746990f) Add redirect and env proxy support to docker login
+  * [`96412d40`](https://github.com/distribution/distribution/commit/96412d40fd7bfbd47041f6b5a7805cd66bb4982c) resume pulling the layer on disconnect
+  * [`3a21f339`](https://github.com/distribution/distribution/commit/3a21f339f1637aded4121715555c0e5fc7269f0e) Use Timeout Conn wrapper to set read deadline for downloading layer
+  * [`a9a754da`](https://github.com/distribution/distribution/commit/a9a754dad19368fa02f49f822b31358cc898f2f1) registry: adding vbatts to the MAINTAINERS
+  * [`dc023760`](https://github.com/distribution/distribution/commit/dc02376050ca86a609fbf4677b7f0625560e462e) Merge branch 'release' into merge_release_v0.11.1
+  * [`75fcb356`](https://github.com/distribution/distribution/commit/75fcb356951369076ebbff86008e36ca7fd07918) Merge branch 'master' into bump_v0.11.1
+  * [`57926292`](https://github.com/distribution/distribution/commit/57926292e91a8fdf0c315ed16b1053b1cc6900cf) Merge branch 'master' into bump_v0.11.0
+  * [`f293adf7`](https://github.com/distribution/distribution/commit/f293adf7f9b6077de409faedb135f5643fb7073b) import sha512 to make sha512 ssl certs work
+  * [`bbebff75`](https://github.com/distribution/distribution/commit/bbebff75b665c8bc632194d383503e1435d68011) Move 'search' to the registry subsystem
+  * [`8934560b`](https://github.com/distribution/distribution/commit/8934560bbc1212ea1c76fd8642985f0ad96fc935) Move 'auth' to the registry subsystem
+  * [`3e064ac7`](https://github.com/distribution/distribution/commit/3e064ac71cb318a3a60c2e058ecc7852fe50c208) Use proper scheme with static registry Docker-DCO-1.1-Signed-off-by: Michael Crosby <michael@crosbymichael.com> (github: crosbymichael)
+  * [`2b89f579`](https://github.com/distribution/distribution/commit/2b89f57964786c91b5cfe5c7983e6b2ecb8570f7) static_registry: update the test for the new struct
+  * [`c18c4b8d`](https://github.com/distribution/distribution/commit/c18c4b8d3c28a4fa2aa91c67633f55131068d4bc) registry: Info collection
+  * [`471d923b`](https://github.com/distribution/distribution/commit/471d923b1bca7ee48e30ff3b07ca8c63b2cde061) registry: make certain headers optional
+  * [`52893cae`](https://github.com/distribution/distribution/commit/52893cae738b64dee20a435a68ab37cc4b84b9a8) Added support for multiple endpoints in X-Docker-Endpoints header Docker-DCO-1.1-Signed-off-by: Joffrey F <joffrey@docker.com> (github: shin-)
+  * [`4bc35225`](https://github.com/distribution/distribution/commit/4bc3522500d5c3f22e00e7c97f6e844c2bd5bb21) allow dot in repo name
+  * [`dbb92965`](https://github.com/distribution/distribution/commit/dbb929653108f390a3023bea6e2028a20478ba1c) Added specific error message when hitting 401 over HTTP on push Docker-DCO-1.1-Signed-off-by: Joffrey F <joffrey@docker.com> (github: shin-)
+  * [`4f29181d`](https://github.com/distribution/distribution/commit/4f29181d9b516e006896bc0df8bc92a0e99b701a) Payload checksum now match the checksum simple
+  * [`d2b2bf03`](https://github.com/distribution/distribution/commit/d2b2bf039386b25ed82dcb08649fb9532a44a02f) Inverted layer checksum and tarsum.
+  * [`50ec0bbd`](https://github.com/distribution/distribution/commit/50ec0bbd4e5973cd42f8a61b0d5e8ca5e3a1fc71) Docker-DCO-1.1-Signed-off-by: Ryan Thomas <rthomas@atlassian.com> (github: rthomas)
+  * [`fffa920a`](https://github.com/distribution/distribution/commit/fffa920a895aa81b9d56b36474d98af1d3fbf39a) Docker-DCO-1.1-Signed-off-by: Ryan Thomas <rthomas@atlassian.com> (github: rthomas)
+  * [`9bad706a`](https://github.com/distribution/distribution/commit/9bad706a1ffd5e5b21088e1dc8b1e29fe140f030) Harmonize / across all name-related commands/Validate images names
+  * [`47c4e542`](https://github.com/distribution/distribution/commit/47c4e542ba329f6e1324fb5f3f468b6a8d434f5b) use mock for search
+  * [`f6fefb0b`](https://github.com/distribution/distribution/commit/f6fefb0bc1c18bc4889718dccf275c4ea3a41309) Merge auth package within registry
+  * [`93a3113d`](https://github.com/distribution/distribution/commit/93a3113d8dab41cf6b3ede2719579fe1468fbeda) Merge branch 'release' into merge_release_v0.9.0
+  * [`7cba1fbc`](https://github.com/distribution/distribution/commit/7cba1fbcc869ed61433439f93c45ea688731eb66) Merge branch 'master' into bump_v0.9.0
+  * [`1c101d00`](https://github.com/distribution/distribution/commit/1c101d006bceabd606de6938219a4399a6195d71) Remove manual http cookie management
+  * [`bac83c76`](https://github.com/distribution/distribution/commit/bac83c76084d2b8667b023b4506f385db993deb9) Fix registry auth by storing the string passed on the command line, and allowing for credential selection by normalizing on hostname. Also, remove remote ping calls from CmdPush and CmdPull.
+  * [`f29683f7`](https://github.com/distribution/distribution/commit/f29683f794763a1aacd96a4b5ac9a49db830a4b1) registry: Fixed unexported field
+  * [`ba8dbe4b`](https://github.com/distribution/distribution/commit/ba8dbe4b9b6d280a2aeaeefbcd238c598bdb1a73) registry: Removed checksumPayload from exported fields
+  * [`bae6dc35`](https://github.com/distribution/distribution/commit/bae6dc35bc18d86b0a62a48e5f8e1c0e6bea7e31) registry: Fixed tests
+  * [`3bf0ee5e`](https://github.com/distribution/distribution/commit/3bf0ee5e52b608b8b6d9bafa8a7fac6fb0fdf6f5) registry: Added simple checksums (sha256) for layers
+  * [`36b0a1e1`](https://github.com/distribution/distribution/commit/36b0a1e132fa26d85be9e3ddaaa48d18ecae647e) Merge branch 'master' into bump_v0.8.1
+* bump azure sdk ([#3916](https://github.com/distribution/distribution/pull/3916))
+  * [`9274def6`](https://github.com/distribution/distribution/commit/9274def67d1bb1750fcccb8e1f0658afc16bee7b) Fix login prompt on push and pull because of error message Docker-DCO-1.1-Signed-off-by: Michael Crosby <michael@crosbymichael.com> (github: crosbymichael)
+  * [`4fe7a141`](https://github.com/distribution/distribution/commit/4fe7a141bf34a911a58aa7ce2158f6702772a696) Added missing attributes to api search calls: - Added an argument to the call() method in order to control the auth sharing - Enabled it only for search. Pulls and pushes were enabled already. - Grouped a few variable declarations
+  * [`275109a6`](https://github.com/distribution/distribution/commit/275109a6ad91374c72172d9e4e9a94fdbbf6014b) Make sure new repositories can be pushed with multiple tags
+* go.mod: github.com/Azure/go-autorest/autorest v0.11.24 ([#3575](https://github.com/distribution/distribution/pull/3575))
+  * [`78bc8d73`](https://github.com/distribution/distribution/commit/78bc8d7377aa61d7667a96f8e8df9e176e6747f0) move legacy stuff outside the job
+* proxyBlobStore implements Put ([#3532](https://github.com/distribution/distribution/pull/3532))
+* (docs) Fix rendering of markdown links in OAuth docs HTML ([#3498](https://github.com/distribution/distribution/pull/3498))
+* [release/2.7 backport] Change should to must in v2 spec ([#3495](https://github.com/distribution/distribution/pull/3495))
+  * [`9bafa726`](https://github.com/distribution/distribution/commit/9bafa726be072c57d1570c5ea0275d3a1e66ea2c) Fixed registry unit tests
+  * [`79e0ed25`](https://github.com/distribution/distribution/commit/79e0ed25dbc4b48987743eaefa86afa99fe09e5b) Check standalone header when pinging a registry server. Standalone has to be true to use basic auth (in addition to previous requirements)
+* always allow swift overrides ([#3439](https://github.com/distribution/distribution/pull/3439))
+  * [`10eeaec7`](https://github.com/distribution/distribution/commit/10eeaec70cd3a2c5d52a132009cd3a8920641e3a) fix progressbar in docker push
+  * [`d2f7d65d`](https://github.com/distribution/distribution/commit/d2f7d65d71fb9a8cca25371b0132089c626d140b) Don't return req as result of setTokenAuth
+  * [`1ff180d1`](https://github.com/distribution/distribution/commit/1ff180d1b4e1c9f52b15f4cdc562f1975b1510e5) missed one call to setTokenAuth
+  * [`0fca0f12`](https://github.com/distribution/distribution/commit/0fca0f12f6e356549a75d884e1bc13418d8629e7) Factorized auth token setting
+  * [`d4a00ebe`](https://github.com/distribution/distribution/commit/d4a00ebecbc4967049e89f9b88b672e9e56e17ae) gofmt
+  * [`097f4124`](https://github.com/distribution/distribution/commit/097f41245a2abdb9f017bdf55f45d1e53ba1f3ee) Use basic auth for private registries when over HTTPS. RequestFactory is no longer a singleton (can be different for different instances of Registry) Registry now has an indexEndpoint member Registry methods that needed the indexEndpoint parameter no longer do so Registry methods will only use token auth where applicable if basic auth is not enabled.
+  * [`52a0a052`](https://github.com/distribution/distribution/commit/52a0a052e8e3e1bfdede68820467767218eb6b60) go fmt.
+  * [`c86cee21`](https://github.com/distribution/distribution/commit/c86cee210fe0ae19e9dd02cddf983c3bd8eba8bb) Closing connection after ping
+  * [`94472f9d`](https://github.com/distribution/distribution/commit/94472f9dad4fe7924aa7fc6abd15552432cf97d8) Merge branch 'release'
+* reloading CA certs ([#2857](https://github.com/distribution/distribution/pull/2857))
+  * [`c61f57d0`](https://github.com/distribution/distribution/commit/c61f57d040f2daf560a768a27c35de3525d2f3b3) Merge branch 'master' into bump_v0.6.7
+  * [`2c26420b`](https://github.com/distribution/distribution/commit/2c26420bc45631a6c0e96a5a82203f72adbb5aee) update docker search to reflect future changes of the api
+* cmd/digest: import crypto algorithms ([#2428](https://github.com/distribution/distribution/pull/2428))
+  * [`77f6f327`](https://github.com/distribution/distribution/commit/77f6f327044b664514598bc241ef58b51ebe5653) Removes \\n from debugf calls
+* api: url typo in specification ([#2338](https://github.com/distribution/distribution/pull/2338))
+  * [`2f94790d`](https://github.com/distribution/distribution/commit/2f94790d6718b9f6e7fb3c1032454266add5b440) registry: fix content-type for PushImageJSONIndex
+  * [`25a427b4`](https://github.com/distribution/distribution/commit/25a427b42392f347a535d2b732500845b8159eaf) Merge branch 'release'
+  * [`8d77082c`](https://github.com/distribution/distribution/commit/8d77082c92fdedd7d80702afc828873082884435) Fix some error cases where a HTTP body might not be closed
+* Convert Markdown frontmatter to YAML ([#2004](https://github.com/distribution/distribution/pull/2004))
+  * [`cbb906e4`](https://github.com/distribution/distribution/commit/cbb906e41ff761af938a387f9be4dd94a9fd1b7d) fix the error message so it is the same as the regex issue #1999
+* fixes link to building.md ([#1949](https://github.com/distribution/distribution/pull/1949))
+  * [`9c366e09`](https://github.com/distribution/distribution/commit/9c366e092dcd3a1abd8c7c8b4a43264615a64e27) Modify repository name regex to match index
+  * [`49736d5f`](https://github.com/distribution/distribution/commit/49736d5fc7f170788230c1f24eca3e903842fd69) Prevent panic upon error pulling registry
+  * [`ee38e490`](https://github.com/distribution/distribution/commit/ee38e49093fac2e99c256070948725e85994857c) Login against private registry
+* Commit uploaded blob with size ([#1473](https://github.com/distribution/distribution/pull/1473))
+  * [`a7b3e7eb`](https://github.com/distribution/distribution/commit/a7b3e7eb785edb9310b8eea91dc3d43fbeea4e89) registry: removing opaqueRequest
+  * [`ecd70a19`](https://github.com/distribution/distribution/commit/ecd70a194853f494496b888e427984666361360e) hot fix display in parallel pull and go fmt
+  * [`e55267bc`](https://github.com/distribution/distribution/commit/e55267bc9904d00fce99f283c3c7b4590f0be816) Add GitHub usernames to MAINTAINERS
+* Makefile: remove AUTHORS from default target ([#1481](https://github.com/distribution/distribution/pull/1481))
+  * [`42b6e56d`](https://github.com/distribution/distribution/commit/42b6e56d193098b5db444f19ab10a79910d48a78) Fix typo: fmt.Sprint -> fmt.Sprintf
+  * [`03c1bbbf`](https://github.com/distribution/distribution/commit/03c1bbbf6522a47a6f9589f9b7de13379f5f83fd) Adapted tests to latest registry changes
+  * [`5ea461f3`](https://github.com/distribution/distribution/commit/5ea461f3005a41c5985511a0bf758e50b793d940) Cleanup
+  * [`da046e94`](https://github.com/distribution/distribution/commit/da046e945f322614728ba2be56d253ab819d8d65) Mock access logs don't show up in non-debug mode
+  * [`7c3b31e5`](https://github.com/distribution/distribution/commit/7c3b31e5d482efdb7cc04c97d02cfa6abcb51fdd) gofmt
+  * [`4d9dcc3c`](https://github.com/distribution/distribution/commit/4d9dcc3cba3cc5ba3e7ec2eea2597c1fbd5f9d8c) New registry unit tests remade from scratch, using the mock registry
+  * [`93877a85`](https://github.com/distribution/distribution/commit/93877a859aed0c8ebeb0b73a0f27cc41a4f7a9c6) Mock registry: Fixed a bug where the index validation path would return a 200 status code instead of the expected 204
+  * [`04cbff8d`](https://github.com/distribution/distribution/commit/04cbff8d35ff871278bb60f7f85ca2df3eb59f4d) registry: Fixed a bug where token and cookie info wouldn't be sent when using LookupRemoteImage(). Fixed a bug where no error would be reported when getting a non-200 status code in GetRemoteImageLayer()
+  * [`28f0f0ff`](https://github.com/distribution/distribution/commit/28f0f0ffb8ff48b25aeaa9f1c510cabf4294a9a7) Disabled test server in the tests
+  * [`34fc4b84`](https://github.com/distribution/distribution/commit/34fc4b84074f60e1b09765e233b39b7f85151f8b) Mocked registry: Added X-Docker-Size when fetching the layer
+  * [`3ca4529f`](https://github.com/distribution/distribution/commit/3ca4529fbe7bb5eed0fd0108b1ae8924b3d1c7e9) Fixed mocked registry
+  * [`14cc9fcf`](https://github.com/distribution/distribution/commit/14cc9fcfda6a8a6f12b44ef426b57f01c426ae91) Implemented a Mocked version of the Registry server
+  * [`1fe03a4b`](https://github.com/distribution/distribution/commit/1fe03a4bf7d9a95f67f05375fee6d058880e96a9) Reduce connect and read timeout when pinging the registry (fixes issue #1363)
+* Rename Name method of Repository to Named ([#1408](https://github.com/distribution/distribution/pull/1408))
+  * [`fec63826`](https://github.com/distribution/distribution/commit/fec63826b9c2c7b626b30cf1bdb35535dfe45f17) Always consider localhost as a domain name when parsing the FQN repos name
+* Storage: Add CloseStreamWriter function ([#1382](https://github.com/distribution/distribution/pull/1382))
+  * [`762dfbfc`](https://github.com/distribution/distribution/commit/762dfbfced100ecddb79a255bdfc40c09a127e5c) reqFactory in Registry
+  * [`95b4a0c3`](https://github.com/distribution/distribution/commit/95b4a0c32a93250d1ca033870b0cff1d58cc7336) Return JSONError for HTTPResponse error
+  * [`11cd5760`](https://github.com/distribution/distribution/commit/11cd5760f9d866748866b9406318c37967bd05da) Return registy status code in error
+  * [`0b59dcfa`](https://github.com/distribution/distribution/commit/0b59dcfa2d594f095b8b2e21a7e6fd7f409b7bf2) Make sure the index also receives the checksums
+  * [`1c62aded`](https://github.com/distribution/distribution/commit/1c62adeda765eb39d35c1672c9eed41248e17932) Handle extra-paremeter within checksum calculations
+  * [`4a818a5e`](https://github.com/distribution/distribution/commit/4a818a5e7343dc4a65c564269877a0c5d23c77dc) Refactor checksum
+  * [`64a8dea9`](https://github.com/distribution/distribution/commit/64a8dea9d7a15e261ee16579991e51fbd48572bb) Make sure the cookie is used in all registry queries
+  * [`262838e0`](https://github.com/distribution/distribution/commit/262838e069651f3d9c119eb79aab1eab4ca354b0) Rename: VersionChecker->VersionInfo.
+  * [`5f13f194`](https://github.com/distribution/distribution/commit/5f13f19407a99995726909789883ea154c9a92f7) documentation.
+  * [`4b7dbfbc`](https://github.com/distribution/distribution/commit/4b7dbfbcc3dc481756106aee5bec2c6f84ade40e) reduce the number of string copy operations.
+  * [`14155d60`](https://github.com/distribution/distribution/commit/14155d603146104ede45471f754069598746315b) format in the user agent header should follow RFC 2616
+  * [`e9e0d3c1`](https://github.com/distribution/distribution/commit/e9e0d3c1c55140e04dbee1eb3d0069805663f7ca) Removed an unnecessary nil assignment
+  * [`6a2aee30`](https://github.com/distribution/distribution/commit/6a2aee3043508bee5cfe515468d27b1e10cee939) Removed an unnecessary error check.
+  * [`cf8afcf6`](https://github.com/distribution/distribution/commit/cf8afcf647aa1a49a118b2891ec545ed8ad04a1f) added client's kernel version
+  * [`342460ed`](https://github.com/distribution/distribution/commit/342460ed9aaf7f7cf8f92ba13ee0787308694988) inserted setUserAgent in each HTTP request
+  * [`2e95c379`](https://github.com/distribution/distribution/commit/2e95c379d16d7902a9337ecac46c0a46ddc2f2c4) Added version checker interface
+  * [`358574ab`](https://github.com/distribution/distribution/commit/358574ab57fea861789057e092813402f82b8af6) Hardened repos name validation
+  * [`bf8d59a1`](https://github.com/distribution/distribution/commit/bf8d59a1d434be76a0d15cfa85d8221b7780d4fb) Fixed potential security issue (never try http on official index when polling the endpoint). Also fixed local repos name when pulling index.docker.io/foo/bar
+  * [`67115ec4`](https://github.com/distribution/distribution/commit/67115ec4794a5d45fcaff332a732350f9e233b55) fmt.Errorf instead of errors.New
+  * [`98060903`](https://github.com/distribution/distribution/commit/98060903a9d86f96a9ed96c64a310d3c947910d2) Fixed ping URL
+  * [`16fa043e`](https://github.com/distribution/distribution/commit/16fa043e344eafa67121ffea9ed0032081653f59) Allowing namespaces in standalone registry
+  * [`c6068fef`](https://github.com/distribution/distribution/commit/c6068feffab5e2351a0bc7a395173103be531829) Restoring old changeset lost by previous merge
+  * [`6549d83e`](https://github.com/distribution/distribution/commit/6549d83e085312c9af12e591445c2bd2e2434a2e) Merging from master
+* Correct two golint comment issues ([#1111](https://github.com/distribution/distribution/pull/1111))
+  * [`7df93a5a`](https://github.com/distribution/distribution/commit/7df93a5ab391184ffb0cb399e45a11a4f7767a09) Implement several golint suggestions, including:
+  * [`7e215123`](https://github.com/distribution/distribution/commit/7e215123fea8096228c18616adf328f7f92565f2) fix two obvious bugs???
+  * [`ec6d1d60`](https://github.com/distribution/distribution/commit/ec6d1d60201a3f6a3efd3684db85c6505f57602d) Adding support for nicer URLs to support standalone registry (+ some registry code cleaning)
+  * [`258cbb06`](https://github.com/distribution/distribution/commit/258cbb06c949258d37f955f6a3baafc664bbaddd) Resolve conflict
+  * [`03a77bd8`](https://github.com/distribution/distribution/commit/03a77bd8511bf59481524bd70c5d313ae863cfeb) Fixed issue in registry.GetRemoteTags
+  * [`259eeb38`](https://github.com/distribution/distribution/commit/259eeb382c03fd672e83a67a95a7384d3b370019) Remove https prefix from registry
+  * [`e1d8d024`](https://github.com/distribution/distribution/commit/e1d8d0245fbb8b48546431cc938262c1a28bb8e2) Rolled back of previous commit (skip cert verification)
+  * [`dc97156c`](https://github.com/distribution/distribution/commit/dc97156c832f7262196d141844d9752299086b20) Skip certificate check (don't error out on self-signed certs)
+  * [`7a664e6a`](https://github.com/distribution/distribution/commit/7a664e6a5f0b8b8a11167789b817b2dd5185940d) Tentative support for independent registries
+  * [`0d85570c`](https://github.com/distribution/distribution/commit/0d85570c9b6d1a0cbe2221b77170f29f8a1a4d0e) URL schemes of both Registry and Index are now consistent
+  * [`580d393d`](https://github.com/distribution/distribution/commit/580d393d3c14dff51b13f6010b297077331b5c10) Merge branch 'master' into simpler-build-upload
+* add indentations ([#941](https://github.com/distribution/distribution/pull/941))
+  * [`ff418e9c`](https://github.com/distribution/distribution/commit/ff418e9c369b60e2e0e59d6fa077aeb5b0163114) gofmt and test sub directories in makefile
+  * [`f60888cc`](https://github.com/distribution/distribution/commit/f60888cc3b16805a0594228a9459f718e1985119) rebase master
+  * [`3238f3ea`](https://github.com/distribution/distribution/commit/3238f3ea49a0560df4ff1875aef13c4a4de1efcb) Use opaque requests when we need to preserve urlencoding in registry requests
+  * [`7e786279`](https://github.com/distribution/distribution/commit/7e78627908b160eff557e11369f29171ee840fb3) hotfix: nil pointer uppon some registry error
+  * [`508e1524`](https://github.com/distribution/distribution/commit/508e1524167ee352fe93191922e9618c4da39ca5) Merge branch 'master' into improve_progressbar_pull
+  * [`deddb3c7`](https://github.com/distribution/distribution/commit/deddb3c757d3cd5d4cfbc66d67c45641310ae777) Make the progressbar take the image size into consideration
+  * [`c7e86e5e`](https://github.com/distribution/distribution/commit/c7e86e5eabb9ad59dbe45ee958174933fa6838e3) use go 1.1 cookiejar and revome ResetClient
+  * [`95606a43`](https://github.com/distribution/distribution/commit/95606a43632393898f0cd0aab0168e35970fcea9) Merge branch 'master' into postupload-endpoints-header
+  * [`55205e23`](https://github.com/distribution/distribution/commit/55205e23b6fab4f2757c4ad122ac842cb6f15547) bump to master
+  * [`f9d88d82`](https://github.com/distribution/distribution/commit/f9d88d82469d5ec0329fcc09f8740074af44d32e) bump to master
+  * [`e6cc4ff6`](https://github.com/distribution/distribution/commit/e6cc4ff646a8b7ab42356d3cad72e93e28a6c3d3) move auth to the client WIP
+  * [`ca71aa4f`](https://github.com/distribution/distribution/commit/ca71aa4f8da365b2668577a811a42575d482fef8) Send X-Docker-Endpoints header when validating the images upload with the index at the end of a push
+* Added generic S3 compatible APIs support ([#808](https://github.com/distribution/distribution/pull/808))
+  * [`ead91d94`](https://github.com/distribution/distribution/commit/ead91d946e4dc870983ffbc19947924161401430) linted names
+  * [`f085aa4a`](https://github.com/distribution/distribution/commit/f085aa4adceff90e5690599e7996340ce2e68cd6) drop/omit
+* go vet experiment (do not merge) ([#810](https://github.com/distribution/distribution/pull/810))
+  * [`93c7079f`](https://github.com/distribution/distribution/commit/93c7079f8903be906e59dca89c5b23dff534e4f2) fix proxy
+  * [`b9e67a88`](https://github.com/distribution/distribution/commit/b9e67a8884b1d03536e0a50373aba6340d8bd892) Disabled HTTP keep-alive in the default HTTP client for Registry calls
+  * [`6189c3cb`](https://github.com/distribution/distribution/commit/6189c3cb0b517586ddab9db5a16bbed039b68a83) Minor changes in registry.go
+  * [`fc340ec9`](https://github.com/distribution/distribution/commit/fc340ec9667b9adb3df1ff6599b7bbc64b6838b7) Fixed missing Body.Close when doing some HTTP requests. It should improve some request issues.
+* Etags must be quoted according to http spec ([#739](https://github.com/distribution/distribution/pull/739))
+  * [`2312a0e4`](https://github.com/distribution/distribution/commit/2312a0e491868ac3d25cb6140d7ecffd6cdcff69) Cereate a new registry object for each request (~session)
+  * [`3e3a7c03`](https://github.com/distribution/distribution/commit/3e3a7c03aeb290d3f52052ab79b9eb51ae81aa30) Documented who decides what and how.
+* Allow conditional fetching of manifests with the registry client. ([#699](https://github.com/distribution/distribution/pull/699))
+  * [`6bd45ee6`](https://github.com/distribution/distribution/commit/6bd45ee686efd524d5820e708b461d68387fe413) fix docker login when same username
+  * [`9373c8e4`](https://github.com/distribution/distribution/commit/9373c8e4599de15889c6309375e220f4a6feb846) Update Push to reflect the correct API
+  * [`40ccd26d`](https://github.com/distribution/distribution/commit/40ccd26d824c5fce4dcfa5d8fc03ad09e755d387) Remove hijack from api when not necessary
+  * [`c8c892fe`](https://github.com/distribution/distribution/commit/c8c892fec4f2c85b2b1880a527488cedf3ba3e63) Disable registry unit tests
+  * [`5e6d1a0d`](https://github.com/distribution/distribution/commit/5e6d1a0d5679539d2868ee619f6592e97dc07bd9) Update tests to reflect new AuthConfig
+  * [`0933aa44`](https://github.com/distribution/distribution/commit/0933aa442492508bd6724cf883e6e423cd687090) Move authConfig from runtime to registry
+  * [`4a0228fd`](https://github.com/distribution/distribution/commit/4a0228fd8e329138986c449670310864b9e5a52b) Allow to change login
+  * [`a82a6bfd`](https://github.com/distribution/distribution/commit/a82a6bfdffed4453a99c2d42b6646cab3a234569) Upload images only when necessary
+  * [`ffa1e567`](https://github.com/distribution/distribution/commit/ffa1e56748ef01bdc054825b5a4d5403bba1970b) Move httpClient within registry object
+  * [`b5d89306`](https://github.com/distribution/distribution/commit/b5d8930631ad44ca7d6f6ae50b233b64b4cb7796) Remove stdout from registry
+  * [`a2e94b28`](https://github.com/distribution/distribution/commit/a2e94b289c620edd4d9998cb4ca347bde44c1eec) Refactor registry Push
+  * [`1b23cb09`](https://github.com/distribution/distribution/commit/1b23cb09da4b88e1aa57cb8ba663bef27b17db8e) Begin to implement push with new project structure
+  * [`36b58e5a`](https://github.com/distribution/distribution/commit/36b58e5abf2fc632a6481348ad52a9ecb055715c) Split registry into subpackage
+  * [`dd414106`](https://github.com/distribution/distribution/commit/dd41410647fe60a4f14e35bdc0c13fe501744398) Moved registry docs to registry subdirectory
+  * [`9f57550b`](https://github.com/distribution/distribution/commit/9f57550bb981a14351bfa7b124b0cc9dffedd0eb) Initial import of https://github.com/docker/distribution
+  * [`1f3cc591`](https://github.com/distribution/distribution/commit/1f3cc5912473c6565b0650aa2e61ca1c56d7986e) Document TOOMANYREQUESTS error code
+* Avoid formatting errors with %#v ([#1817](https://github.com/distribution/distribution/pull/1817))
+  * [`c8aba9b4`](https://github.com/distribution/distribution/commit/c8aba9b484f71c6b95ae6576c3e04b3d7a68e78f) registry: avoid formatting errors with %#v
+* Changes the client Tags All() method to follow links ([#1808](https://github.com/distribution/distribution/pull/1808))
+  * [`9e211edc`](https://github.com/distribution/distribution/commit/9e211edc9dee82b5ca2deec9f5a996cf1e946e4d) Changes the client Tags All() method to follow links
+* fixed s3 Delete bug due to read-after-delete inconsistency ([#1807](https://github.com/distribution/distribution/pull/1807))
+  * [`1c5cb127`](https://github.com/distribution/distribution/commit/1c5cb12745e1497e67999283cdf89d9805c1079a) fixed s3 Delete bug due to read-after-delete inconsistency
+* fix typos ([#1799](https://github.com/distribution/distribution/pull/1799))
+  * [`6eadd3f4`](https://github.com/distribution/distribution/commit/6eadd3f4dc3fedeebe231af218fe932654bdb905) fix typos
+* [Swift] Expose EndpointType parameter in driver ([#1739](https://github.com/distribution/distribution/pull/1739))
+  * [`7b97265d`](https://github.com/distribution/distribution/commit/7b97265d9551898e767c9c57e7bb2cc6a1606198) Expose EndpointType parameter in swift storage driver
+* Re-add support for non-resumable digests ([#1787](https://github.com/distribution/distribution/pull/1787))
+  * [`d2e5d5c2`](https://github.com/distribution/distribution/commit/d2e5d5c22c8cb2d37c527a1f1eaf95299f13584b) If resumable digest support is disabled, detct this when closing the blobwriter and allow the close to continue. Also update the name of the function.
+* Blobwriter: call BlobWriter.Size after BlobWriter.Close ([#1706](https://github.com/distribution/distribution/pull/1706))
+  * [`e57fd4fa`](https://github.com/distribution/distribution/commit/e57fd4faa67a431518e21079c0190adffb11dea3) StorageDriver: GCS: allow Cancel on a closed FileWriter
+  * [`af00617b`](https://github.com/distribution/distribution/commit/af00617b993a42614cd5793e2b186f390c6f7893) Blobwriter: call BlobWriter.Size after BlobWriter.Close
+  * [`ddec5464`](https://github.com/distribution/distribution/commit/ddec5464667eb1b364d1713e1eaf85b3c216cc63) StorageDriver: Test case for #1698
+* Integration token server supporting oauth ([#1465](https://github.com/distribution/distribution/pull/1465))
+  * [`d6a17782`](https://github.com/distribution/distribution/commit/d6a1778282213ffc9ecdebe8ec985a457b492527) Add post token implementation
+  * [`c21f4eb5`](https://github.com/distribution/distribution/commit/c21f4eb561496ebf7794b0375f6f3b6cfc6343bd) Add credential authenticator interface
+* Add option to get content digest from manifest get ([#1775](https://github.com/distribution/distribution/pull/1775))
+  * [`f3ae941c`](https://github.com/distribution/distribution/commit/f3ae941cca906a2b738a36df8c9442c7b2d2011a) Add option to get content digest from manifest get
+* Fixing link patch ([#1770](https://github.com/distribution/distribution/pull/1770))
+* Import docker-registry/next-generation branch ([#1](https://github.com/distribution/distribution/pull/1))
+* Update "Accept" header parsing for list values ([#1782](https://github.com/distribution/distribution/pull/1782))
+  * [`5de53e34`](https://github.com/distribution/distribution/commit/5de53e3448da08dcf98b68b9478ccb5b648f14a5) Update "Accept" header parsing for list values
+* Let's Encrypt support ([#1779](https://github.com/distribution/distribution/pull/1779))
+  * [`9a27ea73`](https://github.com/distribution/distribution/commit/9a27ea7323224ee6e58efd3b5153828dc063c873) Add support for Let's Encrypt
+* Clarify API documentation around catalog fetch behavior ([#1774](https://github.com/distribution/distribution/pull/1774))
+  * [`ec7c5913`](https://github.com/distribution/distribution/commit/ec7c59138161119d406d16cf4fbecd8178a571c9) Clarify API documentation around catalog fetch behavior
+* registry: use const for status code 429 ([#1772](https://github.com/distribution/distribution/pull/1772))
+  * [`4e09e1b6`](https://github.com/distribution/distribution/commit/4e09e1b6589cc362e2c96857447d4226416c1573) registry: use const for status code 429
+* fix typos ([#1765](https://github.com/distribution/distribution/pull/1765))
+  * [`6d0db0e2`](https://github.com/distribution/distribution/commit/6d0db0e2dd78975a6c75b5186e558bb7e9f2daa9) fix typos
+* Swift auth version param ([#1627](https://github.com/distribution/distribution/pull/1627))
+  * [`346bfed9`](https://github.com/distribution/distribution/commit/346bfed9079b8b0c07b88273c9518ee824f5096e) docs + fix test Signed-off-by: Nikita Tarasov <nikita@mygento.ru>
+  * [`007af250`](https://github.com/distribution/distribution/commit/007af250b4fe27b624f191add68fe0bd42d58538) fix test Signed-off-by: Nikita Tarasov <nikita@mygento.ru>
+  * [`b55719da`](https://github.com/distribution/distribution/commit/b55719daaac8f12f6f937a2bd60fca72b354b00e) test
+  * [`63fe2d14`](https://github.com/distribution/distribution/commit/63fe2d1429d8908b8b8abb59acf0cf887a662dbb) Update swift.go
+* Remove signature store from registry. ([#1687](https://github.com/distribution/distribution/pull/1687))
+  * [`d3b61b61`](https://github.com/distribution/distribution/commit/d3b61b612f5e14ba0d74872ed6af913d48719a37) Remove signature store from registry. Return a generated signature for manifest pull.
+* Pass through known errors ([#1688](https://github.com/distribution/distribution/pull/1688))
+  * [`28be207b`](https://github.com/distribution/distribution/commit/28be207bc06249b6cbfa073bc9276eeb92566dbc) Pass through known errors
+* Pass in `app` as context to apply{N}Middleware ([#1744](https://github.com/distribution/distribution/pull/1744))
+  * [`f1b815ed`](https://github.com/distribution/distribution/commit/f1b815ed9f983c164b5f90db92ca8063bd84d128) Pass in `app` as context to apply{N}Middleware
+* Add support for  blobAccessController middleware ([#1734](https://github.com/distribution/distribution/pull/1734))
+  * [`50e6eef0`](https://github.com/distribution/distribution/commit/50e6eef0761ecf06648e8ab74d5c9fc7aacc84dd) Add support for blobAccessController middleware
+* Add support for layers from foreign sources ([#1725](https://github.com/distribution/distribution/pull/1725))
+  * [`dd66aabe`](https://github.com/distribution/distribution/commit/dd66aabebafd0cf20f26d92a71e1a991d9309a39) Add support for layers from foreign sources
+  * [`bb841197`](https://github.com/distribution/distribution/commit/bb841197c2ba90394b3c00d08ec9cb5ee1e7024e) Add 'us-gov-west-1' to the valid region list.
+* Add regulator to filesystem ([#1695](https://github.com/distribution/distribution/pull/1695))
+  * [`1e05d81a`](https://github.com/distribution/distribution/commit/1e05d81a71700ca9b14a84c4f55185520c72c029) Don't wrap thead limits when using a negative int
+  * [`cbae4dd7`](https://github.com/distribution/distribution/commit/cbae4dd7bf2e4d23557893fa8123cdb52fe87b41) Implement regulator in filesystem driver
+  * [`a88088a5`](https://github.com/distribution/distribution/commit/a88088a59d590146e6e28867f4078b6d28a0fe51) Regulate filesystem driver to max of 100 calls
+* registry: do not use http.StatusTooManyRequests ([#1696](https://github.com/distribution/distribution/pull/1696))
+  * [`db274d3c`](https://github.com/distribution/distribution/commit/db274d3c00dfbf231154275432bd906672fd749a) registry: do not use http.StatusTooManyRequests
+* registry: type too many requests error ([#1693](https://github.com/distribution/distribution/pull/1693))
+  * [`8762c800`](https://github.com/distribution/distribution/commit/8762c800f1af28a609e7d76ba5bff960a5d02e95) registry: type too many requests error
+* [Swift] wait for DLO segments to show up when Close()ing the writer ([#1650](https://github.com/distribution/distribution/pull/1650))
+  * [`ea5abc99`](https://github.com/distribution/distribution/commit/ea5abc9935d6d9f915f837cdea850268f1df7f29) wait for DLO segments to show up when Close()ing the writer
+* Clean uploads ([#1669](https://github.com/distribution/distribution/pull/1669))
+  * [`2a2577d7`](https://github.com/distribution/distribution/commit/2a2577d7b1816956d6904c65b3869cec77002d0d) When a blob upload is committed prevent writing out hashstate in the subsequent close.
+* Move GC into storage package and add tests ([#1677](https://github.com/distribution/distribution/pull/1677))
+  * [`63d28d3b`](https://github.com/distribution/distribution/commit/63d28d3b81dda6fd95adf1244a36afe80dc32434) Add a test with a missing _manifests directory
+  * [`3a034b47`](https://github.com/distribution/distribution/commit/3a034b477e827559fe72c0a01bed12f2f758488c) Move garbage collect code into storage package
+  * [`898fdb48`](https://github.com/distribution/distribution/commit/898fdb48a1f694b4d317ad08e74d37254a5addfc) Ensure GC continues marking if _manifests is nonexistent
+* add middleware storage driver for redirect ([#1665](https://github.com/distribution/distribution/pull/1665))
+  * [`54edbdfe`](https://github.com/distribution/distribution/commit/54edbdfee655639ee747135133c78f2cdf427ee7) separate the go/non-go imports and reorder
+  * [`3336cc13`](https://github.com/distribution/distribution/commit/3336cc13e45a33fdcc5954064f8090d187979380) modify redirect test to include port
+  * [`fba2e3a2`](https://github.com/distribution/distribution/commit/fba2e3a206bdc39dbbfb57f3ec252307a720c5b9) scheme and host mandatory in baseurl
+  * [`cec7248b`](https://github.com/distribution/distribution/commit/cec7248bd1578f9f6929c306af20d3dd7cdced64) separate the go/non-go imports and reorder
+  * [`a691d82a`](https://github.com/distribution/distribution/commit/a691d82aee9784b83434fb3482ac89a4cec381d9) add middleware storage driver for redirect
+* Fix wording for dry-run flag in usage message for garbage collector. ([#1675](https://github.com/distribution/distribution/pull/1675))
+  * [`8775da93`](https://github.com/distribution/distribution/commit/8775da93d60e55f5f671909ceca467a2b7906e08) Fix wording for dry-run flag in useage message for garbage collector.
+* Add cn-north-1 to valid check ([#1660](https://github.com/distribution/distribution/pull/1660))
+  * [`fdb0fb77`](https://github.com/distribution/distribution/commit/fdb0fb77df6189794468565e95e79f9f6a97ea3c) add cn-north-1 to valid check
+* Add blobWrtiter.Close() call into blobWriter.Commit() ([#1666](https://github.com/distribution/distribution/pull/1666))
+  * [`6615b77a`](https://github.com/distribution/distribution/commit/6615b77a0903d24a6cccac1ae653eeae8e92c639) Add blobWrtiter.Close() call into blobWriter.Commit()
+* s3 driver: Sorting completed parts by part number for a better accordance with S3 spec ([#1670](https://github.com/distribution/distribution/pull/1670))
+  * [`d11a9795`](https://github.com/distribution/distribution/commit/d11a979591ce6f6c856366c1edd1bf539b740f39) Sorting completed parts by part number for a better accordance with the S3 spec
+* Only check validity of S3 region if not using custom endpoint ([#1604](https://github.com/distribution/distribution/pull/1604))
+  * [`c6552412`](https://github.com/distribution/distribution/commit/c655241209b18172aee2129957bbf9f460f563e7) Only check validity of S3 region if not using custom endpoint
+* registry/storage/swift: detect and fix outdated container listings ([#1605](https://github.com/distribution/distribution/pull/1605))
+  * [`84aa48b5`](https://github.com/distribution/distribution/commit/84aa48b56cf0acb29a3873e430c9e00d4c2027c1) detect outdated container listings during Stat() and getAllSegments()
+* Ensure we log io.Copy errors and bytes copied/total in uploads ([#1597](https://github.com/distribution/distribution/pull/1597))
+  * [`86ca50df`](https://github.com/distribution/distribution/commit/86ca50dfe516f3ac2b6b463b5c546308921c2bfe) Ensure we log io.Copy errors and bytes copied/total in uploads
+* don't swallow errors in Swift driver's GetContent() ([#1578](https://github.com/distribution/distribution/pull/1578))
+  * [`b015bf06`](https://github.com/distribution/distribution/commit/b015bf067648a263a8a2afd60b098fae69e75845) don't swallow errors in Swift driver's GetContent()
+* Fix signature handling with GC. ([#1560](https://github.com/distribution/distribution/pull/1560))
+  * [`3d4b652b`](https://github.com/distribution/distribution/commit/3d4b652b589e060439d60f9ab84f6a3676399228) Update the gc documentation.
+  * [`31ece3d3`](https://github.com/distribution/distribution/commit/31ece3d3b68875f0bb884deaef28833689536733) Fix signature handling with GC.
+  * [`15e3ffb3`](https://github.com/distribution/distribution/commit/15e3ffb3f296ff8548216dde820bb17af2bb8d8f) Add a --dry-run flag. If enabled this will print the mark and sweep process with removing any files.
+* garbagecollect: Clean up errors ([#1582](https://github.com/distribution/distribution/pull/1582))
+  * [`59ef6d2d`](https://github.com/distribution/distribution/commit/59ef6d2d40a44c6699ad30a890f93f9954984fff) garbagecollect: Clean up errors
+* Add documentation for how to register new StorageDrivers ([#1546](https://github.com/distribution/distribution/pull/1546))
+  * [`091ad891`](https://github.com/distribution/distribution/commit/091ad89197b7b0c22e04e0aac1749e2ca4218b43) Remove the example
+  * [`0f09bcd1`](https://github.com/distribution/distribution/commit/0f09bcd16a0ed5aa87c4ad84f033e9be3acaa138) Add documentation for how to register new StorageDrivers
+  * [`d52cbf92`](https://github.com/distribution/distribution/commit/d52cbf923ce982e80d0263336ffdb4cc12510d41) utulize config log format within gc
+* Send tag events to notification listeners ([#1522](https://github.com/distribution/distribution/pull/1522))
+  * [`f93d1660`](https://github.com/distribution/distribution/commit/f93d166068e23025f9c49b873b8d0d8e40828568) Propogate tag as a functional argument into the notification system to attach tags to manifest push and pull event notifications.
+* Return relative URLs  ([#1491](https://github.com/distribution/distribution/pull/1491))
+  * [`3dd506d8`](https://github.com/distribution/distribution/commit/3dd506d896764c2a5906f4c0b78b0b0b0fb59df4) Enable URLs returned from the registry to be configured as relative.
+* fix manifest revision search, closes #1535 ([#1547](https://github.com/distribution/distribution/pull/1547))
+  * [`5f38f0b1`](https://github.com/distribution/distribution/commit/5f38f0b1feda4d2da0d4ff20eedaa1ff9604b3d8) fix manifest revision search, closes #1535
+* registry: client: auth: type errors ([#1542](https://github.com/distribution/distribution/pull/1542))
+  * [`e6b317f9`](https://github.com/distribution/distribution/commit/e6b317f94fc232caec13232fe0bfc309fa358fbc) registry: client: auth: type errors
+* Don't return empty errcode.Errors slices ([#1531](https://github.com/distribution/distribution/pull/1531))
+  * [`9638c764`](https://github.com/distribution/distribution/commit/9638c7644e5fae4083556d6dd213241d02685162) Include status code in UnexpectedHTTPResponseError
+  * [`c94c2a47`](https://github.com/distribution/distribution/commit/c94c2a47a3167adcfe8cb17b96ec632e33334bbd) Don't return empty errcode.Errors slices
+* registry: client: repository: close response body ([#1538](https://github.com/distribution/distribution/pull/1538))
+  * [`20bba402`](https://github.com/distribution/distribution/commit/20bba4025a5ffae435e6450ef70e050897211bf4) registry: client: repository: close response body
+*  Update missing blob error checking with latest Azure API ([#1532](https://github.com/distribution/distribution/pull/1532))
+  * [`98140ca0`](https://github.com/distribution/distribution/commit/98140ca0ab7477a7ec19ec04f1f6053a320ccc87) Update missing blob error checking with latest Azure API
+* URL parse auth endpoints to normalize hostname to lowercase. ([#1502](https://github.com/distribution/distribution/pull/1502))
+  * [`e09891e2`](https://github.com/distribution/distribution/commit/e09891e2cfeac92c324067b6b5209e6ed98b784c) URL parse auth endpoints to normalize hostname to lowercase.
+* registry/storage/driver/s3-aws kms support ([#1523](https://github.com/distribution/distribution/pull/1523))
+  * [`789c90ac`](https://github.com/distribution/distribution/commit/789c90ac4216f03289ac4f53b11a53ed849dbe33) registry/storage/driver/s3-aws kms support
+* Adds new StorageDriver.FileWriter interface ([#1438](https://github.com/distribution/distribution/pull/1438))
+  * [`eea043dc`](https://github.com/distribution/distribution/commit/eea043dc7bc8aa404e8821041b412468ae936620) Removes ceph rados driver in favor of Swift API gateway support
+  * [`490a2f5a`](https://github.com/distribution/distribution/commit/490a2f5a55cb2135d6a2575969dcbc29a535996a) Updates Swift driver to support new storagedriver.FileWriter interface
+  * [`5b48c815`](https://github.com/distribution/distribution/commit/5b48c81545034e230b57d280914ccdecf1c4f8de) Support FileWriter interface for OSS storage driver
+  * [`9432b18e`](https://github.com/distribution/distribution/commit/9432b18e300e89cdef0d16dc9b8957191f2237e7) Storagedriver: GCS: add chunksize parameter
+  * [`115a6e58`](https://github.com/distribution/distribution/commit/115a6e58034155ae089c6cd65438c1b3e3bbdb3a) Storagedriver: GCS: implement resumable uploads
+  * [`34891eb7`](https://github.com/distribution/distribution/commit/34891eb7ab3bad5edd98fe97cffe66d561afd7ef) StorageDriver: Testsuite: call Close before getting Size
+  * [`c69c8a32`](https://github.com/distribution/distribution/commit/c69c8a3286c98d9f072c4c8a4e2eb2fffffaf2ab) Adds new storagedriver.FileWriter interface
+* Added support to specifiy custom endpoint ([#1512](https://github.com/distribution/distribution/pull/1512))
+  * [`19cfa36e`](https://github.com/distribution/distribution/commit/19cfa36ec8b0a56b725730183bf7350270d3d7c1) Added support to specifiy custom endpoint
+* Add client ID to token fetch to GET endpoint ([#1521](https://github.com/distribution/distribution/pull/1521))
+  * [`259ef42c`](https://github.com/distribution/distribution/commit/259ef42c8c2b04e3a6afbd8c7ebb175d084e83f4) Add client ID to token fetch to GET endpoint
+* Fix two misspellings in source code comments ([#1517](https://github.com/distribution/distribution/pull/1517))
+  * [`5ca3b616`](https://github.com/distribution/distribution/commit/5ca3b61609fee5c3a0d4cab19ad0fb5aabd67a4f) Fix two misspellings in source code comments
+* [driver/s3aws] Update s3aws driver parameter parsing to match s3goamz ([#1514](https://github.com/distribution/distribution/pull/1514))
+  * [`2494c28e`](https://github.com/distribution/distribution/commit/2494c28e1f590caacfaeb203c8b17deed2dd31d1) [driver/s3aws] Update s3aws driver parameter parsing to match s3goamz
+* Fix oauth cross repository push ([#1511](https://github.com/distribution/distribution/pull/1511))
+  * [`c536ae90`](https://github.com/distribution/distribution/commit/c536ae90a8f7ea43ce191096f335afe3fa370fa5) Fix oauth cross repository push
+* Add offline token option ([#1510](https://github.com/distribution/distribution/pull/1510))
+  * [`e0420f40`](https://github.com/distribution/distribution/commit/e0420f4045facaed733b5d0685320db7f8f11c9f) Add offline token option
+* Add oauth support to registry client auth ([#1475](https://github.com/distribution/distribution/pull/1475))
+  * [`6a6c22e2`](https://github.com/distribution/distribution/commit/6a6c22e2b9412502e98bcd3fd54e53c6a90c6ae2) Add options struct to initialize handler
+  * [`f49bf187`](https://github.com/distribution/distribution/commit/f49bf18768097d37bb7608725290d43e02be95ce) Fetch token by credentials and refresh token
+* StorageDriver: GCS: remove support for directory Moves ([#1388](https://github.com/distribution/distribution/pull/1388))
+  * [`396a73de`](https://github.com/distribution/distribution/commit/396a73deb761d077b4dee1947a3368d3dde9d00b) StorageDriver: GCS: remove support for directory Moves
+* Add information about manifest content types to API spec ([#1364](https://github.com/distribution/distribution/pull/1364))
+  * [`c89f5b37`](https://github.com/distribution/distribution/commit/c89f5b3775ad54fd93b6398cf6f2aa62970d4c17) Add information about manifest content types to API spec
+* garbage collection  ([#1386](https://github.com/distribution/distribution/pull/1386))
+  * [`b7d34241`](https://github.com/distribution/distribution/commit/b7d3424103a59f33ccdcda7019889dc54934119a) Implements garbage collection subcommand
+* Commit uploaded blob with size ([#1473](https://github.com/distribution/distribution/pull/1473))
+  * [`ecc560f4`](https://github.com/distribution/distribution/commit/ecc560f46f1f63556796fa0ff30bcd52030f514a) Commit blob with known size
+* Respect errors returned from middleware code ([#1474](https://github.com/distribution/distribution/pull/1474))
+  * [`776e01f8`](https://github.com/distribution/distribution/commit/776e01f8bc794bb4e6d0256930b1f1ce18691560) Defined ErrAccessDenied error
+* Fix some typos in comments and strings ([#1482](https://github.com/distribution/distribution/pull/1482))
+  * [`d16f3046`](https://github.com/distribution/distribution/commit/d16f3046c686b769011ae1ef9d1d22af724ba321) Fix some typos in comments and strings
+* Enable proxying registries to downgrade fetched manifests to Schema 1. ([#1471](https://github.com/distribution/distribution/pull/1471))
+  * [`29e0411f`](https://github.com/distribution/distribution/commit/29e0411f001abd373ff4bacfaae3119f05557944) Enable proxying registries to downgrade fetched manifests to Schema 1.
+* compare error output in tagstore unit test ([#1477](https://github.com/distribution/distribution/pull/1477))
+  * [`c58aa8a5`](https://github.com/distribution/distribution/commit/c58aa8a50a6def6855fa01b13e210450454c6c25) compare error output in tagstore unit test
+* Lazily evaluate auth challenges ([#1466](https://github.com/distribution/distribution/pull/1466))
+  * [`18fd1c07`](https://github.com/distribution/distribution/commit/18fd1c07025a9aaff9c65044a58cb1445f96cbd7) Extend authChallenger interface to remove type cast.
+  * [`7d16fee7`](https://github.com/distribution/distribution/commit/7d16fee7a4f743312979e3625a08f82ec8053626) To avoid any network use unless necessary, delay establishing authorization challenges with the upstream until any proxied data is found not to be local.
+* Fix description of StorageDriver.WriteStream ([#1469](https://github.com/distribution/distribution/pull/1469))
+  * [`2e824482`](https://github.com/distribution/distribution/commit/2e8244822c9efd25cbe735fad72175bc990354d3) Fix description of StorageDriver.WriteStream
+* Cleanup: remove unused log ([#1468](https://github.com/distribution/distribution/pull/1468))
+  * [`20bc910c`](https://github.com/distribution/distribution/commit/20bc910cdf76831901e4dafaaa1e44cff162280b) Cleanup: remove unused log
+* [driver/s3aws] Fix TestStorageClass ([#1467](https://github.com/distribution/distribution/pull/1467))
+  * [`c6871737`](https://github.com/distribution/distribution/commit/c6871737bc151f705aa30253b2fbb7f9209ad353) [driver/s3aws] Fix TestStorageClass
+* [driver/s3] Use aws/aws-sdk-go instead of goamz for s3 driver and cloudfront ([#1385](https://github.com/distribution/distribution/pull/1385))
+  * [`d5a38e4c`](https://github.com/distribution/distribution/commit/d5a38e4c5f23e794e30b986cbb3b13b8d0bf5b87) Adds new s3 driver using aws-sdk-go instead of goamz
+* enhance log message of oss driver ([#1462](https://github.com/distribution/distribution/pull/1462))
+  * [`7ca24a7f`](https://github.com/distribution/distribution/commit/7ca24a7f5a27949ff407fe9c8dea636606a118b4) fix gofmt
+  * [`ad6a0735`](https://github.com/distribution/distribution/commit/ad6a0735d22d6a0172c12acffc508b32049d66f7) closes #1461, enhance log message of oss driver
+* Export "no basic auth credentials" as an error value ([#1452](https://github.com/distribution/distribution/pull/1452))
+  * [`cffb4bbb`](https://github.com/distribution/distribution/commit/cffb4bbbfd9bb31323fcadafc3f6f2120d74f769) Export "no basic auth credentials" as an error value
+* Typo fixes in comments ([#1451](https://github.com/distribution/distribution/pull/1451))
+  * [`f77c82eb`](https://github.com/distribution/distribution/commit/f77c82ebb36276ca350cb1592169b2dd1ceea589) Typo fixes in comments
+* Fix schema1 manifest etag and docker content digest header ([#1445](https://github.com/distribution/distribution/pull/1445))
+  * [`ae595179`](https://github.com/distribution/distribution/commit/ae59517936a34586c6d244e272a82288f6511d6d) Fix schema1 manifest etag and docker content digest header
+* Add option to disable signatures ([#1420](https://github.com/distribution/distribution/pull/1420))
+  * [`956ece5c`](https://github.com/distribution/distribution/commit/956ece5c70133efd9c39eda72978c15ad83394ed) Add option to disable signatures
+* Improves flexibility of configuration handling for S3 driver ([#1414](https://github.com/distribution/distribution/pull/1414))
+  * [`4bb5f808`](https://github.com/distribution/distribution/commit/4bb5f808857ad85065036e42d3a808f741f16970) Improves flexibility of configuration handling for S3 driver
+* On redirect, only copy headers when they don't already exist in the redirected request ([#1419](https://github.com/distribution/distribution/pull/1419))
+  * [`bbf983c0`](https://github.com/distribution/distribution/commit/bbf983c06186f244562b9ed39ee26b1dcb7cfcbb) On redirect, only copy headers when they don't already exist in the redirected request
+* Correct type for repo reference ([#1425](https://github.com/distribution/distribution/pull/1425))
+  * [`9894643c`](https://github.com/distribution/distribution/commit/9894643c885f29c381b97e5f53905db3a8c46202) Correct type for repo reference Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Print the correct token expiration time ([#1417](https://github.com/distribution/distribution/pull/1417))
+  * [`091c12f8`](https://github.com/distribution/distribution/commit/091c12f86be0b7df6a039ad8cadb2e1909857fdb) Print the correct token expiration time Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Storage: remove bufferedFileWriter (dead code) ([#1350](https://github.com/distribution/distribution/pull/1350))
+  * [`7dee3d19`](https://github.com/distribution/distribution/commit/7dee3d19d9845f94c526429ed10b8d07214ca0f0) Storage: remove bufferedFileWriter (dead code)
+  * [`586b3d47`](https://github.com/distribution/distribution/commit/586b3d47a780c7976e1e5c02416fc5c7a950be57) Storage: blobwriter.Write/Seek test case
+* Adds "storageclass" configuration parameter for S3 driver. ([#1401](https://github.com/distribution/distribution/pull/1401))
+  * [`a2ade36e`](https://github.com/distribution/distribution/commit/a2ade36ecf84bf5f85902a2584db8bb8dc0f81c0) Adds test for S3 storage class configuration option
+  * [`8e791082`](https://github.com/distribution/distribution/commit/8e7910826e623687194301c79602f875c920c782) Adds "storageclass" configuration parameter for S3 driver.
+* Rename Name method of Repository to Named ([#1408](https://github.com/distribution/distribution/pull/1408))
+  * [`6158eb54`](https://github.com/distribution/distribution/commit/6158eb544d81dbc5ff03343dc6b90d5d516af6da) Rename Name method of Repository to Named
+  * [`95b9c728`](https://github.com/distribution/distribution/commit/95b9c7281b9c067936ae096db191774410585ab1) read the actual number of bytes according to the initial size.
+* Correct ErrAuthenticationFailure message ([#1410](https://github.com/distribution/distribution/pull/1410))
+  * [`95a50c72`](https://github.com/distribution/distribution/commit/95a50c7236f8d6d8a056f14ff098573bf1cb25b6) Correct ErrAuthenticationFailure message
+* Update auth context keys to use constant ([#1403](https://github.com/distribution/distribution/pull/1403))
+  * [`badd8c49`](https://github.com/distribution/distribution/commit/badd8c49b6e65e8529cc4274105a8ee7be985382) Update auth context keys to use constant
+* Simple integration test token server ([#1390](https://github.com/distribution/distribution/pull/1390))
+  * [`1eed0ddd`](https://github.com/distribution/distribution/commit/1eed0ddd072a3954bcbd879266c0053727056528) Update token header struct to use json.RawMessage pointer
+* Adds custom registry User-Agent header to s3 HTTP requests ([#1381](https://github.com/distribution/distribution/pull/1381))
+  * [`f41a408e`](https://github.com/distribution/distribution/commit/f41a408e346c5815f8d8144b9db2d04fa86829ae) Adds custom registry User-Agent header to s3 HTTP requests
+* Add manifest put by digest to the registry client ([#1393](https://github.com/distribution/distribution/pull/1393))
+  * [`f757372d`](https://github.com/distribution/distribution/commit/f757372dd81140683a22d6d1cd83232889bad878) Add manifest put by digest to the registry client Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Support range requests in the client's httpReadSeeker ([#1392](https://github.com/distribution/distribution/pull/1392))
+  * [`8e571dff`](https://github.com/distribution/distribution/commit/8e571dff41a6f544d16dd494d2136c8bb97e66f6) Add a CheckRedirect function to the HTTP client
+  * [`a58b7625`](https://github.com/distribution/distribution/commit/a58b7625ba24cd6700d36c992fe7edf6981c3895) Support range requests in the client's httpReadSeeker
+* Invalidate the blob store descriptor cache ([#1394](https://github.com/distribution/distribution/pull/1394))
+  * [`3e570e59`](https://github.com/distribution/distribution/commit/3e570e59f1cc01bdf82e9bf2bb2ea98b7acd020f) Invalidate the blob store descriptor caches when content is removed from from the proxy. Also, switch to reference in the scheduler API.
+  * [`a7740f5d`](https://github.com/distribution/distribution/commit/a7740f5d0f246f00c17437d7cfb952a299f1b416) Correct test digest lengths and enable all unit tests
+* Use reference package ([#1333](https://github.com/distribution/distribution/pull/1333))
+  * [`6149a8c6`](https://github.com/distribution/distribution/commit/6149a8c6343f01352876e2c91cc0281547abc823) Change URLBuilder methods to use references for tags and digests
+  * [`e9692b80`](https://github.com/distribution/distribution/commit/e9692b8037d032d3dfd6cd5c2f9737aa22884e57) Use reference package internally
+  * [`e9bcc96a`](https://github.com/distribution/distribution/commit/e9bcc96ad27c3e583c6a417ddea6d204765e1ef1) If the media type for a manifest is unrecognized, default to schema1
+* Handle nonstandard token endpoint errors ([#1379](https://github.com/distribution/distribution/pull/1379))
+  * [`59254013`](https://github.com/distribution/distribution/commit/59254013beefb037d060490a249cef9ce96261f8) Handle nonstandard token endpoint errors
+* StorageDriver GCS: improve test suite clean-up and add retrying to all GCS api calls ([#1372](https://github.com/distribution/distribution/pull/1372))
+  * [`59a96077`](https://github.com/distribution/distribution/commit/59a9607783490dbb185f8e63f1cab15064c85d9a) StorageDriver: GCS: retry all api calls
+  * [`ffc95277`](https://github.com/distribution/distribution/commit/ffc9527782299ccf1d2a6b30e8c793e7a2b46652) StorageDriver: Test suite: improve cleanup
+* Fix content type for schema1 signed manifests ([#1367](https://github.com/distribution/distribution/pull/1367))
+  * [`f9a3f028`](https://github.com/distribution/distribution/commit/f9a3f028b513be193d17bb6887c42c7a1d61376c) Fix content type for schema1 signed manifests
+* Do not require "charset=utf-8" for a schema1 with content type application/json ([#1363](https://github.com/distribution/distribution/pull/1363))
+  * [`3da0ee00`](https://github.com/distribution/distribution/commit/3da0ee00d87932eb7d32d8c61b8e0e2631a1909d) Do not require "charset=utf-8" for a schema1 with content type application/json
+* In testsuites.go, enlarge the size of randomBytes to 128M to fix the … ([#1355](https://github.com/distribution/distribution/pull/1355))
+  * [`d3d9282a`](https://github.com/distribution/distribution/commit/d3d9282a30472edf218d2d40828c332c27da09c3) In testsuites.go, enlarge the size of randomBytes to 128M to fix the crash of running TestConcurrentStreamReads
+* StorageDriver GCS test suite: try google.DefaultTokenSource first ([#1357](https://github.com/distribution/distribution/pull/1357))
+  * [`985c0d60`](https://github.com/distribution/distribution/commit/985c0d602fbc652c1152090cacd0edb173edc554) StorageDriver GCS: try google.DefaultTokenSource first
+* Change the parameters to the GCS drivers to allow CircleCI testing. ([#1332](https://github.com/distribution/distribution/pull/1332))
+  * [`5d35fa34`](https://github.com/distribution/distribution/commit/5d35fa34c151571b29d42fdfb266da997ebde6f8) Change the parameters to the GCS drivers to allow CircleCI testing.
+  * [`67aef89b`](https://github.com/distribution/distribution/commit/67aef89bc082ef4a3652fc96017318b4d215cf36) Splits up blob create options definitions to be package-specific
+* Fixes cross-repo blob mounting in the BlobUploadHandler ([#1348](https://github.com/distribution/distribution/pull/1348))
+  * [`e0d4a45c`](https://github.com/distribution/distribution/commit/e0d4a45c93cfcee3b1b29636d18e9bb3d4bfff34) Fixes cross-repo blob mounting in the BlobUploadHandler
+* Adds functional options arguments to the Blobs Create method, remove Mount operation ([#1344](https://github.com/distribution/distribution/pull/1344))
+  * [`36023174`](https://github.com/distribution/distribution/commit/36023174db108428751f21c3a115a019628d0689) Adds functional options arguments to the Blobs Create method
+* Fix manifest API unit tests ([#1335](https://github.com/distribution/distribution/pull/1335))
+  * [`93b65847`](https://github.com/distribution/distribution/commit/93b65847ca06b5bce74c5b7ec0b401094476c828) Fix manifest API unit tests Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Remove tags referencing deleted manifests. ([#1319](https://github.com/distribution/distribution/pull/1319))
+  * [`fea0a7ed`](https://github.com/distribution/distribution/commit/fea0a7ed4920e8cf0f150558ce8557242d8ccbe2) Remove tags referencing deleted manifests.
+* Adds cross-repository blob mounting behavior ([#1269](https://github.com/distribution/distribution/pull/1269))
+  * [`44d95e58`](https://github.com/distribution/distribution/commit/44d95e58418f802d444def6e127706c23b880a1c) Allows token authentication handler to request additional scopes
+  * [`41e30f62`](https://github.com/distribution/distribution/commit/41e30f626b4fe92085f77cdb31ff10f2dc3dcbcc) Adds cross-repository blob mounting behavior
+* Support large layer for OSS driver ([#1276](https://github.com/distribution/distribution/pull/1276))
+  * [`5dc714b3`](https://github.com/distribution/distribution/commit/5dc714b3471b2832841d12884892dfa90ca24fd6) Replace 404 to http.StatusNotFound
+  * [`dc6944d9`](https://github.com/distribution/distribution/commit/dc6944d91da0a999ac74f2d5408101c790003c1d) In HEAD request for missing resource, only 404 NOT FOUND is returned
+  * [`cfd2f039`](https://github.com/distribution/distribution/commit/cfd2f039209d43036f46de0b6ef8d7462766d598) Support large layer for OSS driver
+* Implement schema2 manifest formats ([#1281](https://github.com/distribution/distribution/pull/1281))
+  * [`bbabb55c`](https://github.com/distribution/distribution/commit/bbabb55ccbb9ef46c234b517785a91601543d88e) Move MediaType into manifest.Versioned
+  * [`fce65b72`](https://github.com/distribution/distribution/commit/fce65b72b3d5a11b413121344b964b15ede1f4c0) Recognize clients that don't support manifest lists
+  * [`7ef71988`](https://github.com/distribution/distribution/commit/7ef71988a8e3c4fb51041ac813c00b46bb706016) Add support for manifest list ("fat manifest")
+  * [`66a33baa`](https://github.com/distribution/distribution/commit/66a33baa36ed82f7412e01d2a996c3cd73ba3a9c) Add API unit testing for schema2 manifest
+  * [`f14c6a48`](https://github.com/distribution/distribution/commit/f14c6a4814bef8e3510e68fb909caf0f293294c2) Recognize clients that don't support schema2, and convert manifests to schema1 on the fly
+  * [`9c13a829`](https://github.com/distribution/distribution/commit/9c13a8295f4f2af968bc3e30d5acbc6b657b6141) Factor out schema-specific portions of manifestStore
+* More consistent return from ErrorCode.Error() ([#911](https://github.com/distribution/distribution/pull/911))
+  * [`7dd03e12`](https://github.com/distribution/distribution/commit/7dd03e12bbc8ac5a426881260352f1eeb7b78cf6) More consistent return from ErrorCode.Error()
+* GCS storage driver: fix retry function ([#1321](https://github.com/distribution/distribution/pull/1321))
+  * [`bf1e41a9`](https://github.com/distribution/distribution/commit/bf1e41a9f286cf93aee7a5a7d2d7c73e45674a9d) GCS driver: fix retry function
+* GCS Storagedriver: fix test failure caused by #1187 ([#1323](https://github.com/distribution/distribution/pull/1323))
+  * [`5c6fdc71`](https://github.com/distribution/distribution/commit/5c6fdc710f8680701720c98e7ebdcd4ab589f703) GCS Storagedriver: fix test failure caused by #1187
+* Print error for failed HTTP auth request. ([#1249](https://github.com/distribution/distribution/pull/1249))
+  * [`731befec`](https://github.com/distribution/distribution/commit/731befec93ae548c1d2e0f538fc66983bfa4e66d) Merge branch 'print-error-msg' of https://github.com/k4leung4/distribution into print-error-msg
+  * [`d38e02c5`](https://github.com/distribution/distribution/commit/d38e02c52f493cac9aac6c687e3987b09013d75a) Print error for failed HTTP auth request.
+  * [`b89c4e8c`](https://github.com/distribution/distribution/commit/b89c4e8cbf87cd8881c29df182244a2ad2bbdc20) Print error for failed HTTP auth request.
+* use the scheme and host from x-forward-proto and x-forward-host if the… ([#1097](https://github.com/distribution/distribution/pull/1097))
+  * [`9c7dc47d`](https://github.com/distribution/distribution/commit/9c7dc47d806a157e01be1c51d11842e69b614669) use the scheme and host from x-forward-proto and x-forward-host if they exits and correct the scheme for Location header during image upload
+* Relaxes filesystem driver permissions to 0777 (dirs) and 0666 (files) ([#1304](https://github.com/distribution/distribution/pull/1304))
+  * [`165507a6`](https://github.com/distribution/distribution/commit/165507a6220820658a3486b4d18bbb94e3aa60fc) Relaxes filesystem driver permissions to 0777 (dirs) and 0666 (files)
+* Serve blobs when a storage driver supports redirects but are disabled ([#1303](https://github.com/distribution/distribution/pull/1303))
+  * [`cf4fdc1b`](https://github.com/distribution/distribution/commit/cf4fdc1be00129df6c5a76b3e8e77b18486afe4b) Serve blobs when a storage driver supports redirects but are disabled
+* Implementation of the Manifest Service API refactor. ([#1268](https://github.com/distribution/distribution/pull/1268))
+  * [`8efb9ca3`](https://github.com/distribution/distribution/commit/8efb9ca329dc96191d80ba644959880d9dd88460) Implementation of the Manifest Service API refactor.
+* Remove unnecessary stat from blob Get method ([#1257](https://github.com/distribution/distribution/pull/1257))
+  * [`4ebaacfc`](https://github.com/distribution/distribution/commit/4ebaacfcdae9ebcdb02571f88047d4d0efaf89b1) Remove unnecessary stat from blob Get method
+* Remove tarsum support for digest package ([#1271](https://github.com/distribution/distribution/pull/1271))
+  * [`a077202f`](https://github.com/distribution/distribution/commit/a077202f8853c9d81d14f94279d7c1e4fc19ce69) Remove tarsum support for digest package
+  * [`58232e50`](https://github.com/distribution/distribution/commit/58232e50cf60edfa6d4014b2e8399c4049759b98) Simplify digest.FromBytes calling convention
+* registry/storage/driver: checking that non-existent path returns PathNotFoundError ([#1187](https://github.com/distribution/distribution/pull/1187))
+  * [`d68acc86`](https://github.com/distribution/distribution/commit/d68acc869e89b7e54369c6bf13ff6b520783e927) storage/driver/s3: adjust s3 driver to return unmunged path
+  * [`533c912d`](https://github.com/distribution/distribution/commit/533c912d3ef08116102acde16d19bf42327b6064) Fix the issue for listing root directory
+  * [`3a5c6446`](https://github.com/distribution/distribution/commit/3a5c6446d851d25757ea84ab1f4b1a3ab5609c4b) Fix for stevvooe:check-storage-drivers-list-path-not-found in OSS driver
+  * [`aa08ced9`](https://github.com/distribution/distribution/commit/aa08ced9d73502222ad04931598ef7770e630d6d) driver/swift: treat empty object list as a PathNotFoundError
+  * [`c39158d4`](https://github.com/distribution/distribution/commit/c39158d48ca60f99d1274152b53d2f4fa7b4e5b8) driver/rados: treat OMAP EIO as a PathNotFoundError
+  * [`10f7b7bf`](https://github.com/distribution/distribution/commit/10f7b7bf95f200630ab23ca1d2a01f48ef22d129) storage/driver/s3: correct response on list of missing directory
+  * [`dc5b71af`](https://github.com/distribution/distribution/commit/dc5b71afb032cb2e7dbc5fde869abf4c5f901510) storage/driver/base: use correct error format style
+  * [`c46d32bf`](https://github.com/distribution/distribution/commit/c46d32bfbb68a5b6b331c0100c4e091e9e5da281) driver/filesystem: address filesystem driver on behavior of List
+  * [`4829e968`](https://github.com/distribution/distribution/commit/4829e9685ecdf72a99d26aa5326fbbc88603262d) registry/storage/driver: checking that non-existent path returns PathNotFoundError
+* storage/driver: decrease memory allocation done during testsuite ([#1246](https://github.com/distribution/distribution/pull/1246))
+  * [`be2985a3`](https://github.com/distribution/distribution/commit/be2985a35de0e984630d312b99e0af63bd4f3750) storage/driver: decrease memory allocation done during testsuite
+* Fix comment for PathRegexp ([#1238](https://github.com/distribution/distribution/pull/1238))
+  * [`d6cc3296`](https://github.com/distribution/distribution/commit/d6cc32965e0543438d31db47dd5f0dc1280296a6) Fix comment for PathRegexp
+* Make the catalog more efficient ([#1241](https://github.com/distribution/distribution/pull/1241))
+  * [`ecb84029`](https://github.com/distribution/distribution/commit/ecb84029ecc0efd55d087583d127755755be36db) Make the catalog more efficient
+* Add clearer messaging around missing content-length headers. ([#1243](https://github.com/distribution/distribution/pull/1243))
+  * [`fb214214`](https://github.com/distribution/distribution/commit/fb2142147fbde48cbcba16863e6080b452106ae0) Add clearer messaging around missing content-length headers. Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Use bulk delete to remove segments in Swift driver ([#1157](https://github.com/distribution/distribution/pull/1157))
+  * [`b596464d`](https://github.com/distribution/distribution/commit/b596464d382d97b399852432fc2cb31918c230b5) Use bulk delete to remove segments in Swift driver
+* Validate digest length on parsing ([#1231](https://github.com/distribution/distribution/pull/1231))
+  * [`1f5f9bad`](https://github.com/distribution/distribution/commit/1f5f9bad398e374eaf4fffffa5da2c96d7d4e06a) Validate digest length on parsing
+* Remove name verification ([#1211](https://github.com/distribution/distribution/pull/1211))
+  * [`e1cf7c41`](https://github.com/distribution/distribution/commit/e1cf7c418b81b5bc6700f9efcd6ddf7f4ec06816) Map error type to error code
+  * [`beeff299`](https://github.com/distribution/distribution/commit/beeff299f86c658756e6f755ade148bb9a51069b) Use well-known error type
+  * [`82999376`](https://github.com/distribution/distribution/commit/8299937613b6a5ae6dd1767e7ff633be5fbf893a) Verify manifest name format
+  * [`6fb61830`](https://github.com/distribution/distribution/commit/6fb6183083a626be81d595800fcfea56ea7e0624) Verify manifest name length
+  * [`a9a1b579`](https://github.com/distribution/distribution/commit/a9a1b57900460b10bdf27eb642c5e5f02f844b22) Remove name verification
+  * [`8257e8c4`](https://github.com/distribution/distribution/commit/8257e8c42a8157c671b390e4cbb158c5481a6c8e) Use case of type name
+* storage: enforce sorted traversal during Walk ([#1227](https://github.com/distribution/distribution/pull/1227))
+  * [`6693e966`](https://github.com/distribution/distribution/commit/6693e9667cd9e06319a5945c64d0fbc48859d49d) storage: add further tests for Walk implementation
+  * [`93f92498`](https://github.com/distribution/distribution/commit/93f92498ce26873fe40ddc71381e1f615cc58ceb) storage: enforce sorted traversal during Walk
+  * [`7bf8f846`](https://github.com/distribution/distribution/commit/7bf8f846c277b67a55e377d7bafbabdf892b0514) storage: correctly handle error during Walk
+  * [`bf2cc0a9`](https://github.com/distribution/distribution/commit/bf2cc0a9d65b6a6f1f17d28c7e2ba1c0a01086fd) Avoid stat round-trips when fetching a blob
+* De-obfuscate error message ([#1166](https://github.com/distribution/distribution/pull/1166))
+  * [`f01a70c8`](https://github.com/distribution/distribution/commit/f01a70c8a63731a3d35473ab3a4367b8465efb80) De-obfuscate error message
+* Fix failing test case for URL escaping problem. ([#1125](https://github.com/distribution/distribution/pull/1125))
+  * [`9293e3db`](https://github.com/distribution/distribution/commit/9293e3db11aa72cb4ce0c330a84dbe24d3237595) Fix failing test case
+* Ensure read after write for segments ([#1141](https://github.com/distribution/distribution/pull/1141))
+  * [`34c1d0ed`](https://github.com/distribution/distribution/commit/34c1d0ed5076994ef18338bb1ee0a8390357fd6f) Ensure read after write for segments
+* Fix empty delete requests with Swift fs driver ([#1172](https://github.com/distribution/distribution/pull/1172))
+  * [`accfa46f`](https://github.com/distribution/distribution/commit/accfa46f9ba4966af57ac2bed36ac84de71d6396) Fix empty delete requests with Swift fs driver
+* Manifest Verification ([#1156](https://github.com/distribution/distribution/pull/1156))
+  * [`78b6d648`](https://github.com/distribution/distribution/commit/78b6d648fa685930b366f1775a8092cd80a640c8) Before allowing a schema1 manifest to be stored in the registry, ensure that it contains equal length History and FSLayer arrays.
+* Add Storage Driver Context. ([#1150](https://github.com/distribution/distribution/pull/1150))
+  * [`e79324ed`](https://github.com/distribution/distribution/commit/e79324edd8794711003e4602917b36adc175a4a0) Add a generic error type to capture non-typed errors
+  * [`7840a5bc`](https://github.com/distribution/distribution/commit/7840a5bc8f4991b1a9f1b7c9304b0212d21073f4) Fix for issue 664: https://github.com/docker/distribution/issues/664 Errors thrown by storage drivers don't have the name of the driver, causing user confusion about whether the error is coming from Docker or from a storage driver. This change adds the storage driver name to each error message.
+* Redirect support in Swift driver ([#1114](https://github.com/distribution/distribution/pull/1114))
+  * [`11546b53`](https://github.com/distribution/distribution/commit/11546b53097bb7e01376a6a7462ed14d9e657434) Add support for temporary URL for Swift driver
+  * [`854fa0a4`](https://github.com/distribution/distribution/commit/854fa0a4dd7fed6812b97b94ac1b4b5f37121ac7) registry/storage: close filereader after allocation
+  * [`00f02b5f`](https://github.com/distribution/distribution/commit/00f02b5fbc344e2fd11d7f0914a15d50f6194fd8) Buffer writing the scheduler entry state to disk by periodically checking for changes to the entries index and saving it to the filesystem.
+* Storage driver for Google Cloud Storage ([#756](https://github.com/distribution/distribution/pull/756))
+  * [`98ad17f7`](https://github.com/distribution/distribution/commit/98ad17f757f962843274a97070f4c48c6dcd5444) Storage driver for: Google Cloud Storage (gcs)
+* Simplify proxy scheduler ([#1096](https://github.com/distribution/distribution/pull/1096))
+  * [`84595fc6`](https://github.com/distribution/distribution/commit/84595fc628757b055892313d545f11fa02015565) Simplify proxy scheduler
+  * [`b38b98c8`](https://github.com/distribution/distribution/commit/b38b98c8a8e098b20d8695833788b0df13439c47) Add `expires_in` and `issued_at` to the auth spec.
+* Redundant digest verification in validateBlob when pushing a new layer ([#1098](https://github.com/distribution/distribution/pull/1098))
+  * [`c40b2e23`](https://github.com/distribution/distribution/commit/c40b2e2341565e0e1afd7ae36d096f981a6fd4f6) Redundant digest verification in validateBlob
+* Update "type auth.Challenge" comment example code ([#1115](https://github.com/distribution/distribution/pull/1115))
+  * [`8263cdeb`](https://github.com/distribution/distribution/commit/8263cdeb5719f0322c580bf4215dcd35db274c17) Update "type auth.Challenge" comment example code
+* Correct two golint comment issues ([#1111](https://github.com/distribution/distribution/pull/1111))
+  * [`fc5ee720`](https://github.com/distribution/distribution/commit/fc5ee720d1f8a231d6c774f44ba7af34ee8a8c37) Correct two golint comment issues
+* Fix a race condition in pull through cache population ([#1006](https://github.com/distribution/distribution/pull/1006))
+  * [`36fa22c8`](https://github.com/distribution/distribution/commit/36fa22c82157c2ed148712cf7200bb24697167ca) Fix a race condition in pull through cache population by removing the functionality of readers joining current downloads. Concurrent requests for the same blob will not block, but only the first instance will be comitted locally.
+* Add a read-only mode as a configuration option ([#827](https://github.com/distribution/distribution/pull/827))
+  * [`cbf83ecd`](https://github.com/distribution/distribution/commit/cbf83ecd316fa16c6452fbe3601674bfca18b04a) Add an "enabled" parameter under "readonly", and make it as if the mutable handlers don't exist when read-only mode is enabled
+  * [`df9758ba`](https://github.com/distribution/distribution/commit/df9758ba39bb732bc9f3e85f16485e336f37cb6c) Add a read-only mode as a configuration option
+  * [`26762a54`](https://github.com/distribution/distribution/commit/26762a54fe39f8872a5ffffb6ffac319c268ef07) Correct unmarshal order for SignedManifest
+* Add http.host parameter ([#1035](https://github.com/distribution/distribution/pull/1035))
+  * [`6573d5c1`](https://github.com/distribution/distribution/commit/6573d5c119d81e68adc49b865bd9dc39445ca369) Add http.host parameter
+* [api spec] Update authN and authZ errors ([#1033](https://github.com/distribution/distribution/pull/1033))
+  * [`fa4c33f5`](https://github.com/distribution/distribution/commit/fa4c33f5f3b02f95869ae374015387a08284b8b8) [api spec] Update authN and authZ errors
+  * [`582a0661`](https://github.com/distribution/distribution/commit/582a0661bf62ef49e2911d6b8ce6d7e6e68e1cf8) Update to provide small and clear interfaces
+  * [`b72f1fd2`](https://github.com/distribution/distribution/commit/b72f1fd2e3a596cfa5e14d5c8c87290dd6907faf) Add a new reference package abstracting repositories, tags and digests
+  * [`d5ca577a`](https://github.com/distribution/distribution/commit/d5ca577ad1fbc81ff10704336cc0de2167e6c8b2) Allow hostname components in component names.
+* Skip creating swift container if already exists ([#950](https://github.com/distribution/distribution/pull/950))
+  * [`8ceca304`](https://github.com/distribution/distribution/commit/8ceca304b02f4fec848795eddb8c6d2081e6b9b7) Skip creating swift container if already exists
+* Avoid importing "testing" in externally-facing code ([#1024](https://github.com/distribution/distribution/pull/1024))
+  * [`b045aa2a`](https://github.com/distribution/distribution/commit/b045aa2a3d408638ad22589dc7a4e919df074765) Avoid importing "testing" in externally-facing code
+* Don't return nil, nil from functions ([#1001](https://github.com/distribution/distribution/pull/1001))
+  * [`9fb5fe4f`](https://github.com/distribution/distribution/commit/9fb5fe4fbbf640fe424abf5d4c1613703288060b) Don't return a nil array and a nil error if the Tags endpoint cannot be found Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+  * [`b8a1ec41`](https://github.com/distribution/distribution/commit/b8a1ec4155ffe83bd147cfdbac1d113111aa3e8e) Avoid returning nil, nil when fetching a manifest by tag by introducing a new error ErrManifestNotModified which can be checked by clients.
+  * [`84e7c07c`](https://github.com/distribution/distribution/commit/84e7c07c42d75e81cab30c3087b0cbf7d14e02ba) Remove initial access check from S3 driver
+* context: WithVersion and context package cleanup ([#974](https://github.com/distribution/distribution/pull/974))
+  * [`49f080ac`](https://github.com/distribution/distribution/commit/49f080acc8d4979eb2a1640111c74e31059b9b94) Add WithVersion to context and other cleanup
+  * [`cabf1fd2`](https://github.com/distribution/distribution/commit/cabf1fd236717f8431d421a8e512018cce7b5caf) Allow interface{} keys when using logger
+* Only use the distribution/context package in registry.go ([#977](https://github.com/distribution/distribution/pull/977))
+  * [`6403bf64`](https://github.com/distribution/distribution/commit/6403bf64d56144417a1a056439866fb8c1d31918) Only use the distribution/context package in registry.go
+  * [`045db617`](https://github.com/distribution/distribution/commit/045db61784fc401ac278a6ef56bc5cdee04975a4) Add a cobra command that implements the entire main function for registry
+  * [`8dd51d64`](https://github.com/distribution/distribution/commit/8dd51d64603b8682222d6d1ce50f4939fdd04c57) Move initialization code from main.go to the registry package
+  * [`8f5f6a4e`](https://github.com/distribution/distribution/commit/8f5f6a4e590e8fb91bf9516c9da9a7bf24e81144) Add TrustId parameter to swift driver
+* Correctly sanitize location url preserving parameters ([#934](https://github.com/distribution/distribution/pull/934))
+  * [`6e7718df`](https://github.com/distribution/distribution/commit/6e7718dfce492f78916389561abc7764af646a1a) Correctly sanitize location url preserving parameters
+* Move manifest package to schema1 ([#912](https://github.com/distribution/distribution/pull/912))
+  * [`bb098c72`](https://github.com/distribution/distribution/commit/bb098c72a2bba06089bf54957a1d8b3b73bed49b) Move manifest package to schema1
+* Add configurable file-existence and HTTP health checks ([#901](https://github.com/distribution/distribution/pull/901))
+  * [`5b804f76`](https://github.com/distribution/distribution/commit/5b804f76009e7a4df08b3e5dcb6ebf4dac8151c4) Add headers parameter for HTTP checker
+  * [`ca3d4602`](https://github.com/distribution/distribution/commit/ca3d460278e7e0df31428e349aa1a761dd68f826) Add a TCP health checker
+  * [`cdc3143b`](https://github.com/distribution/distribution/commit/cdc3143b7e8dfc52223fb34bc611842662b942cb) Expose a Registry type in health package, so unit tests can stay isolated from each other
+  * [`bbd46991`](https://github.com/distribution/distribution/commit/bbd4699166bcf57ce025b66b934fba03d39e9753) Switch tests to import "github.com/docker/distribution/context"
+  * [`68e8532c`](https://github.com/distribution/distribution/commit/68e8532cefe7c27cee9cc07fb3d2d781ead65fec) Add storagedriver section to health check configuration
+  * [`c48e4609`](https://github.com/distribution/distribution/commit/c48e460933d15050ff502ba53624aa68f74b7873) Add configurable file-existence and HTTP health checks
+* Functional options for NewRegistryWithDriver ([#893](https://github.com/distribution/distribution/pull/893))
+  * [`7fb68446`](https://github.com/distribution/distribution/commit/7fb68446cc565d532fe8b7f44242d99a50e61f8e) Functional options for NewRegistryWithDriver
+* Fix CloseNotifier handling and avoid "the ResponseWriter does not implement CloseNotifier" warnings in logs ([#896](https://github.com/distribution/distribution/pull/896))
+  * [`142b68aa`](https://github.com/distribution/distribution/commit/142b68aaa2c27215b3fdc29a17ed77112bd415e7) Add a unit test which verifies the ResponseWriter endpoints see implements CloseNotifier
+  * [`11133181`](https://github.com/distribution/distribution/commit/11133181fce484fee59479785df6ad5b2531411a) Fix CloseNotifier handling and avoid "the ResponseWriter does not implement CloseNotifier" warnings in logs
+* Fix tests after #846 ([#894](https://github.com/distribution/distribution/pull/894))
+  * [`2e4c6434`](https://github.com/distribution/distribution/commit/2e4c643419b151680d24d8f7db58682f0e621c95) Fix tests after #846
+* Add a section to the config file for HTTP headers to add to responses ([#846](https://github.com/distribution/distribution/pull/846))
+  * [`d9a20377`](https://github.com/distribution/distribution/commit/d9a20377f342308a4f1413b4db0020107009a48f) Add a section to the config file for HTTP headers to add to responses
+* Remove pathMapper object ([#889](https://github.com/distribution/distribution/pull/889))
+  * [`614e8c82`](https://github.com/distribution/distribution/commit/614e8c8277275d01d9f8de950a4569ccc08de284) Remove pathMapper object
+* registry/storage: use correct manifest link ([#864](https://github.com/distribution/distribution/pull/864))
+  * [`5878a8f4`](https://github.com/distribution/distribution/commit/5878a8f401ef5a4d32cff2d85ef107680bd7ed97) Maintain manifest link compatibility
+  * [`5dd78c82`](https://github.com/distribution/distribution/commit/5dd78c821aab8b1c85e10f6f953642900b02e37e) Use correct path for manifest revision path
+  * [`43fc9a19`](https://github.com/distribution/distribution/commit/43fc9a195d28f7c0c9d9d288c5f018efbd40f984) Change some incorrect error types in proxy stores from API errors to distribution errors. Fill in missing checks for mutations on a registry pull-through cache. Add unit tests and update documentation.
+  * [`ed3ecfdc`](https://github.com/distribution/distribution/commit/ed3ecfdccbe8030657d383a2bfad65cd25cd4419) Move common error codes to errcode package
+  * [`288c46e9`](https://github.com/distribution/distribution/commit/288c46e99899ba0e3a8851f5c02a6660eb63ef17) Provide simple storage driver health check
+  * [`9bf231e0`](https://github.com/distribution/distribution/commit/9bf231e0fa158d2c7ae11a2636a97a7d1b5c6a30) fix(rados): Create OMAP for root directory
+  * [`e7435725`](https://github.com/distribution/distribution/commit/e7435725af6e12525d5e85a23302290453e9c35c) Don't panic when a http.ResponseWriter does not implement CloseNotifier
+* Add pull through cache ability to the Registry. ([#779](https://github.com/distribution/distribution/pull/779))
+  * [`d1cb12fa`](https://github.com/distribution/distribution/commit/d1cb12fa3dda1a268a41dc5a613e1640aba7300d) Add pull through cache functionality to the Registry which can be configured with a new `proxy` section in the configuration file.
+* Spelling corrections ([#805](https://github.com/distribution/distribution/pull/805))
+  * [`40563361`](https://github.com/distribution/distribution/commit/405633610000f5665ebb312661454b997285232e) Add blob delete entry to api description and regenerate api.md Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+  * [`83c8617c`](https://github.com/distribution/distribution/commit/83c8617cb1ff258344c8cecb86fbd48521f8d29d) Spelling corrections Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Storage Driver for Aliyun OSS ([#514](https://github.com/distribution/distribution/pull/514))
+  * [`f01a0694`](https://github.com/distribution/distribution/commit/f01a0694c14b4ce835ebea13a978e5a125fd0d0f) remove unused code and fix todo format
+  * [`90595c7e`](https://github.com/distribution/distribution/commit/90595c7ed9aef1a9c4a16d97083fa70db23bb784) fix goimports
+  * [`235ccc05`](https://github.com/distribution/distribution/commit/235ccc05904427fe0f82246d5d7289b2a0d97b49) add include_oss build tag
+  * [`9c27080c`](https://github.com/distribution/distribution/commit/9c27080c7a18bb8afcec3d88bb6873799701bcea) Update the comment for the consistency model
+  * [`5d34d317`](https://github.com/distribution/distribution/commit/5d34d31739e812153d530bfc65eec63e9834660c) Update the comments for consistence model
+  * [`faee4224`](https://github.com/distribution/distribution/commit/faee4224209eb9b41cf3ba242a1e18ce434eba80) fix testcase TestReadStreamWithOffset incompatible with oss
+  * [`a9c3f86c`](https://github.com/distribution/distribution/commit/a9c3f86ce06c4a7390192296ea12a6fad20937e3) fix oss: got 403 in TestContinueStreamAppendLarge
+  * [`440664a1`](https://github.com/distribution/distribution/commit/440664a109f85b178c23405e5067b69455ad62b4) Update the OSS test case for latest code change
+  * [`fc20dd72`](https://github.com/distribution/distribution/commit/fc20dd72d6926650e7c4a6a52929b372198fb4d3) check access key and secret before run
+  * [`d28a3fa2`](https://github.com/distribution/distribution/commit/d28a3fa28a4a97e3d1708b7e3a452fd500aad762) add endpoint support
+  * [`46148721`](https://github.com/distribution/distribution/commit/46148721e188955ba5196f5895ebbc3274690cb4) Add the secure access with HTTPS
+  * [`bffce572`](https://github.com/distribution/distribution/commit/bffce5722e7ea1563c0bac4809cf7a1f4a994795) Fix the warning of golint
+  * [`d7917988`](https://github.com/distribution/distribution/commit/d79179884af9e42ff239b034d5a015eaa4a579ac) Support OSS driver
+* Use CloseNotifier to supress spurious HTTP 400 errors on early disconnect ([#763](https://github.com/distribution/distribution/pull/763))
+  * [`b51913f6`](https://github.com/distribution/distribution/commit/b51913f6198ccacdc408c0d2af583f15f2889820) Set the response code to 499 when a client disconnects during an upload
+  * [`b0d13304`](https://github.com/distribution/distribution/commit/b0d133045d3bbdb45bafe8c1fc37a8d6682036b5) Factor CloseNotifier use into a new function
+  * [`8fbc1de0`](https://github.com/distribution/distribution/commit/8fbc1de08140fce66690fc7b498a9028a8458966) Use CloseNotifier to supress spurious HTTP 400 errors on early disconnect
+* Fix vet issue ([#803](https://github.com/distribution/distribution/pull/803))
+  * [`54f0c70d`](https://github.com/distribution/distribution/commit/54f0c70d88a95ff2aa37e7fdb01c691c1c9c97e2) Fix vet issue
+* Add image name tests around hostnames ([#791](https://github.com/distribution/distribution/pull/791))
+  * [`6a11f5a0`](https://github.com/distribution/distribution/commit/6a11f5a024c9446bb09958416c47ab7813448568) Add image name tests around hostnames
+* Allow disabling of storage driver redirects ([#740](https://github.com/distribution/distribution/pull/740))
+  * [`29a810b6`](https://github.com/distribution/distribution/commit/29a810b68be7d1f8696019539bb31ec3f9a9dc7f) Allow disabling of starage driver redirects
+* Log a single line when a response completes. ([#609](https://github.com/distribution/distribution/pull/609))
+  * [`fd404e78`](https://github.com/distribution/distribution/commit/fd404e78500fbc1ccc68d2476bf0053e6aaab21e) When a request completes ensure only one log line is printed which includes the http response.
+* Automatically generate a HTTP secret if none is provided ([#780](https://github.com/distribution/distribution/pull/780))
+  * [`e83af616`](https://github.com/distribution/distribution/commit/e83af616d6b6f4f81bfd8131a9d843c445857ac3) Automatically generate a HTTP secret if none is provided
+  * [`9d73bfe5`](https://github.com/distribution/distribution/commit/9d73bfe5781bc4433c65618ac41d1b1157a1950e) Fix for api_test.go
+* Manifest PUT should return 201 Created ([#744](https://github.com/distribution/distribution/pull/744))
+  * [`24408263`](https://github.com/distribution/distribution/commit/24408263d994e911834fc3eb06f054a9c19332ac) Manifest PUT should return 201 Created
+  * [`6b457322`](https://github.com/distribution/distribution/commit/6b4573225c7034a05775953b67e6c6ffa7da5682) Make the registry client more tolerant about HTTP status codes
+* Authorization interface cleanup ([#736](https://github.com/distribution/distribution/pull/736))
+  * [`e42a8ca5`](https://github.com/distribution/distribution/commit/e42a8ca5803a036e4259ab66fbac942c00af0733) auth.AccessController interface now uses distribution/context
+  * [`4a2300aa`](https://github.com/distribution/distribution/commit/4a2300aaa92156ef6388521c2b9eabeae4e3cf08) Simplify auth.Challenge interface to SetHeaders
+* Etags must be quoted according to http spec ([#739](https://github.com/distribution/distribution/pull/739))
+  * [`345174a3`](https://github.com/distribution/distribution/commit/345174a34b54a33d687ade2c7f992c68bb0f1d66) Etags must be quoted according to http spec
+* Manifest and layer soft deletion ([#677](https://github.com/distribution/distribution/pull/677))
+  * [`390bb97a`](https://github.com/distribution/distribution/commit/390bb97a889cd3d528b11b01c3fdc2e821844fa0) Manifest and layer soft deletion.
+  * [`911c0d9f`](https://github.com/distribution/distribution/commit/911c0d9f85a965f6b85d4939ea5824cc8915a235) Do not replace logger when adding hooks
+* Clean up pagination specification ([#729](https://github.com/distribution/distribution/pull/729))
+  * [`153ef321`](https://github.com/distribution/distribution/commit/153ef32124575a42aab686fa3544cc1bbc235f97) Clean up pagination specification
+* Remove dead code ([#732](https://github.com/distribution/distribution/pull/732))
+  * [`0ec762c0`](https://github.com/distribution/distribution/commit/0ec762c0f02cbad9dec96cd27e4ccaa6036da7f5) Remove dead code
+* Storage support openstack swift ([#493](https://github.com/distribution/distribution/pull/493))
+  * [`b2935158`](https://github.com/distribution/distribution/commit/b2935158b2c8f88ccbf332f9361960eebeb0e979) Remove IPC support from test file
+  * [`81765f8c`](https://github.com/distribution/distribution/commit/81765f8cbb7b5d426b1444937ff22c672a87b217) Catch either missing containers or objects
+  * [`52d28ec8`](https://github.com/distribution/distribution/commit/52d28ec81a9e826ada36069e6709beb4db64b563) Do not use Swift server side copy for manifests to handle >5G files
+  * [`000dec3c`](https://github.com/distribution/distribution/commit/000dec3c6f6e92ec20cb86d1375ec82d2f6062b3) Inline Swift errors handling
+  * [`661f197f`](https://github.com/distribution/distribution/commit/661f197f68ab05d292f4cf1bf13f2c96b778cab6) Retrieve all the objects using pagination
+  * [`704e0822`](https://github.com/distribution/distribution/commit/704e08225447affb2b60c2c52d98657c0a72d5fc) Do not create objects for directories
+  * [`f190aa4a`](https://github.com/distribution/distribution/commit/f190aa4a7c7f1f922cc6239215d8cb5255beddcf) Refactor segment path concatenation code
+  * [`08072828`](https://github.com/distribution/distribution/commit/0807282859290e813d08c82f37ea4f0d8e100268) Use http.StatusRequestedRangeNotSatisfiable instead of error code
+  * [`7a5aa32a`](https://github.com/distribution/distribution/commit/7a5aa32a64abf390f92c7dd684c514664f0d9268) Use file instead of filepath as it may cause troubles on Windows
+  * [`91d74a3e`](https://github.com/distribution/distribution/commit/91d74a3ee2cafdd0117da4a12a3420309b66bc15) Protect against deletion of objects with the same prefix
+  * [`01686e2c`](https://github.com/distribution/distribution/commit/01686e2c0754f039e42302251f2e5eff7a51e3e9) Show distribution version in User-Agent
+  * [`913fe195`](https://github.com/distribution/distribution/commit/913fe195fd496e91b5167e19eb33c965d2171493) Do not use suite style testing for Swift specific tests
+  * [`1b28eea2`](https://github.com/distribution/distribution/commit/1b28eea2329483f8e381050f2e80e1a50913e1c2) Rename environment variables to run Swift testsuite
+  * [`2524f300`](https://github.com/distribution/distribution/commit/2524f300dcd381cd6cdedf20b001d690924e1500) Check file has been opened before closing it
+  * [`fbc74a64`](https://github.com/distribution/distribution/commit/fbc74a6457bedfead409567a4c2dc60e15cd5856) Rename DriverParameters structure to Parameters
+  * [`80bfcb68`](https://github.com/distribution/distribution/commit/80bfcb68a87ecfda86e38fc0fc87000cf675e231) Change folder mime type to application/vnc.swift.directory
+  * [`7b0276dc`](https://github.com/distribution/distribution/commit/7b0276dce55e95061bbedab1f2fa325de8e61a63) Add code documentation
+  * [`5cce023a`](https://github.com/distribution/distribution/commit/5cce023aa987a73b1c2e78348f0592397075a454) Do not read segment if no padding is necessary
+  * [`d91c4cb6`](https://github.com/distribution/distribution/commit/d91c4cb6947559ff9c3dff44242d950fd5297b9f) Improve 404 errors handling
+  * [`9ab55eae`](https://github.com/distribution/distribution/commit/9ab55eae39b544aa3d9383cd315eaa4d7a541339) Use only one Swift container for both files and manifests
+  * [`a1ae7f71`](https://github.com/distribution/distribution/commit/a1ae7f712220347308f85d34d5a256aaa331149a) Increase default chunk size to 20M
+  * [`062d6266`](https://github.com/distribution/distribution/commit/062d6266cf5153bf40dbe01d781cdeace7653aa1) Add support for Openstack Identity v3 API
+  * [`3f9e7ed1`](https://github.com/distribution/distribution/commit/3f9e7ed169af1bc5879d669e1b68cc52220f0ecb) Use 'prefix' parameter instead of 'path' when listing files
+  * [`1d46bb2b`](https://github.com/distribution/distribution/commit/1d46bb2bccf69ebf81585d821467fdded6fd36fb) Create full folder hierarchy instead of just the top level folder
+  * [`4e619bc9`](https://github.com/distribution/distribution/commit/4e619bc9b100a7afcd3018af5492e29dd964a8e5) Remove one level of indentation in swift path handling code
+  * [`75ce67c4`](https://github.com/distribution/distribution/commit/75ce67c469a634ea92d8793deb85457242548284) Use mitchellh/mapstructure library to parse Swift parameters
+  * [`ea81e208`](https://github.com/distribution/distribution/commit/ea81e208a4263b73fc6d330256afacd0721af680) Move Dynamic Large Object handling to dedicated methods
+  * [`8a22c0f4`](https://github.com/distribution/distribution/commit/8a22c0f4e10824ad58de51a1038e0effe77569e8) Simplify code that handles non existing manifests
+  * [`16a49ade`](https://github.com/distribution/distribution/commit/16a49ade166bd3d80c164c1798edf9e8cecbee39) Handle error during copy of original content
+  * [`9f7f23e3`](https://github.com/distribution/distribution/commit/9f7f23e3738a3ce1474d8d651b7e6b76f9722219) Update the import path for swift driver test
+  * [`1f4eb7b7`](https://github.com/distribution/distribution/commit/1f4eb7b73523d596b4314202d803f56475ac1bdf) Use gofmt to format the code of swift driver.
+  * [`cce49561`](https://github.com/distribution/distribution/commit/cce4956131f8083ffaa5f032fd8ea8747a269117) Add Openstack Swift storage driver
+* Catalog for V2 API Implementation ([#653](https://github.com/distribution/distribution/pull/653))
+  * [`a49594a0`](https://github.com/distribution/distribution/commit/a49594a0e19560969396f5fcbed657062524be8f) Add Registry to client bindings for Repositories
+  * [`bf62b7eb`](https://github.com/distribution/distribution/commit/bf62b7ebb72d4872f438704e27506d18873262ae) Create Repositories method
+  * [`f3207e76`](https://github.com/distribution/distribution/commit/f3207e76c878e4859018185c4fec9162d327e1e8) Catalog for V2 API Implementation
+  * [`0790a298`](https://github.com/distribution/distribution/commit/0790a298ed04744b6d65d21f21c17a70cd67c02b) Paginate catalog and tag results with Link header
+  * [`1d68d81b`](https://github.com/distribution/distribution/commit/1d68d81b424ae295bdbca431f8f5419b06c1cd32) Catalog V2 API specification proposal
+* Add additional test coverage for the regexp contained in RepositoryNameRegexp ([#724](https://github.com/distribution/distribution/pull/724))
+  * [`683dc197`](https://github.com/distribution/distribution/commit/683dc197782ea8f4ea2b5aaef624d6cbc4e637a4) Unify the testcases for the two tests in names_test.go
+  * [`ceb2c7de`](https://github.com/distribution/distribution/commit/ceb2c7de44405da054be5e391c1ceeb4fb2c7da4) Add additional test coverage for the regexp contained in RepositoryNameRegexp
+* Make Error.Error() return the post-arg-substitution Message ([#726](https://github.com/distribution/distribution/pull/726))
+  * [`aae59d54`](https://github.com/distribution/distribution/commit/aae59d54ef604e02732b493a73b464f85f8f1005) Make Error.Error() return the post-arg-substitution Message
+* Close reader after the test is finished. ([#709](https://github.com/distribution/distribution/pull/709))
+  * [`feebd69d`](https://github.com/distribution/distribution/commit/feebd69d26df453d60427018af086198d800c71a) Close reader after the test is finished.
+* Use "Size" field to describe blobs over "Length" ([#713](https://github.com/distribution/distribution/pull/713))
+  * [`249ad3b7`](https://github.com/distribution/distribution/commit/249ad3b76d33fe6584b5de4811d2bbc99bc3fe68) Use "Size" field to describe blobs over "Length"
+* Export ServeJSON for serving error codes ([#705](https://github.com/distribution/distribution/pull/705))
+  * [`81c21411`](https://github.com/distribution/distribution/commit/81c21411e89a491ada9d8759824040ee032bf3d3) Export ServeJSON for serving error codes
+* Reduces log level of auth error lines from error->warn ([#706](https://github.com/distribution/distribution/pull/706))
+  * [`41aadeac`](https://github.com/distribution/distribution/commit/41aadeac9a5cb72682d6a6d4e36e57592b36909c) Reduces log level of auth error lines from error->warn
+* External manifest verification ([#633](https://github.com/distribution/distribution/pull/633))
+  * [`cd31d466`](https://github.com/distribution/distribution/commit/cd31d466e44186885e836b967cf346b2112feb7d) Allow Manifest Service to be configured with function arguments
+* Add ability to pass in substitution args into an Error ([#651](https://github.com/distribution/distribution/pull/651))
+  * [`db30d384`](https://github.com/distribution/distribution/commit/db30d384e059883556813606226ceb30380e1961) Add ability to pass in substitution args into an Error
+* Allow conditional fetching of manifests with the registry client. ([#699](https://github.com/distribution/distribution/pull/699))
+  * [`caf989a5`](https://github.com/distribution/distribution/commit/caf989a5723711f66bf8d797f7f08425374763ab) Allow conditional fetching of manifests with the registry client.
+  * [`6f2f8499`](https://github.com/distribution/distribution/commit/6f2f84996d239531cd32a4bebbea208153466a20) Fix build when using build tag 'noresumabledigest'
+* Allow single character repository names ([#689](https://github.com/distribution/distribution/pull/689))
+  * [`a58848a0`](https://github.com/distribution/distribution/commit/a58848a0b7230492127240caa23a278f0004b835) Allow single character repository names
+* Refactor client auth ([#544](https://github.com/distribution/distribution/pull/544))
+  * [`970efb6b`](https://github.com/distribution/distribution/commit/970efb6ba7550d5abab99f4d9d7541daba67ca0a) Fix typo in Version doc
+  * [`376cc5fe`](https://github.com/distribution/distribution/commit/376cc5fe756175bc1efbd1aeb99d53cfa24252ba) Add challenge manager interface
+  * [`5a3a9c6a`](https://github.com/distribution/distribution/commit/5a3a9c6a77f04c9f2358f7f3f2e351760ad6f1bd) Separate version and challenge parsing from ping
+  * [`b66ee14e`](https://github.com/distribution/distribution/commit/b66ee14e624e57ff7810938568bc21917c05793d) Refactor client auth
+* Remove half-baked Storage Driver IPC support ([#670](https://github.com/distribution/distribution/pull/670))
+  * [`6167220c`](https://github.com/distribution/distribution/commit/6167220cdddac3589205ef49e81dab311a35a287) Remove half-baked Storage Driver IPC support
+* Increase timeout of http.Client for Docker Registry V2 client ([#656](https://github.com/distribution/distribution/pull/656))
+  * [`855ecb84`](https://github.com/distribution/distribution/commit/855ecb8440bd1c8e52198a8d9e50d5bbbcc7c507) Remove timeout for http.Client in registry/client/repository.go.
+* Pass correct context into tracer ([#675](https://github.com/distribution/distribution/pull/675))
+  * [`fa17f925`](https://github.com/distribution/distribution/commit/fa17f9254f4be558dde6cc8107e07334317fc817) Pass correct context into tracer Signed-off-by: Richard Scothern <richard.scothern@gmail.com>
+* Prevent the ErrUnsupportedMethod error from being returned up the stack. ([#671](https://github.com/distribution/distribution/pull/671))
+  * [`6d46ae5f`](https://github.com/distribution/distribution/commit/6d46ae5fdb72d07dc077cac6a0c1c36d988d9ac4) Prevent the ErrUnsupportedMethod error from being returned up the stack.
+* Cache headers for manifests. ([#645](https://github.com/distribution/distribution/pull/645))
+  * [`6bedf7d1`](https://github.com/distribution/distribution/commit/6bedf7d1cd00223b0f3e81eabf78dbd2148382a7) Add Etag header for manifests.
+* Add 'message' back to BlobTest sample json ([#647](https://github.com/distribution/distribution/pull/647))
+  * [`805b135b`](https://github.com/distribution/distribution/commit/805b135bcc896e03d957f37ce401a0f4ca0f5883) Add 'message' back to BlobTest sample json
+* Add back in the "errors" wrapper in the Errors serialization ([#646](https://github.com/distribution/distribution/pull/646))
+  * [`365de1b2`](https://github.com/distribution/distribution/commit/365de1b215b9d263551f3d51f522534fd8b58d23) Add back in the "errors" wrapper in the Errors serialization
+* Move challenge http status code logic ([#638](https://github.com/distribution/distribution/pull/638))
+  * [`cff1a5ff`](https://github.com/distribution/distribution/commit/cff1a5ffdcca2ca5cc348eefa3be5d2999d52bb9) Move challenge http status code logic
+  * [`f9e152d9`](https://github.com/distribution/distribution/commit/f9e152d912ea660e06aec313f519bf5ff62720da) Ensure that rados is disabled without build tag
+* storage/driver/azure: Update vendored Azure SDK ([#623](https://github.com/distribution/distribution/pull/623))
+  * [`5c372ded`](https://github.com/distribution/distribution/commit/5c372ded1b2e1941e24ee7b97dfe96fca314124d) storage/driver/azure: Update vendored Azure SDK
+* Implementation of a basic authentication scheme using standard .htpasswd ([#608](https://github.com/distribution/distribution/pull/608))
+  * [`f6ee0f46`](https://github.com/distribution/distribution/commit/f6ee0f46af41827082ee63ab261b6ddcbe4aa807) Minor formatting fixes related to htpasswd auth
+  * [`e667be38`](https://github.com/distribution/distribution/commit/e667be389a1700c6c98be72405879d755a7003f4) Rename the basic access controller to htpasswd
+  * [`14f3b07d`](https://github.com/distribution/distribution/commit/14f3b07db099d41b47e956ba8509a71f2f022012) Harden basic auth implementation
+  * [`427c4578`](https://github.com/distribution/distribution/commit/427c457801637e3d5b8a0e1f88cc1095a3f193c9) Refactor Basic Authentication package
+  * [`35044456`](https://github.com/distribution/distribution/commit/350444568082cfc54a10c30e229b00aeeb0e8e1a) Unexported function to comply with golint
+  * [`fe9ca889`](https://github.com/distribution/distribution/commit/fe9ca88946c54cd14ea3481caaad1541dd2461cf) Removed dashes from comments, unexported htpasswd struct
+  * [`15bbde99`](https://github.com/distribution/distribution/commit/15bbde99c1cbb7ecd21e6ea310bd592a45fb2125) Fixed golint, gofmt warning advice.
+  * [`ff67393b`](https://github.com/distribution/distribution/commit/ff67393b2b47608c654559fdd51d3c3fe9ee2b5c) Added support for bcrypt, plaintext; extension points for other htpasswd hash methods.
+  * [`d2b7988b`](https://github.com/distribution/distribution/commit/d2b7988b7f18568112ae65f4382d40e0f7388114) Aligned formatting with gofmt
+  * [`7733b6c8`](https://github.com/distribution/distribution/commit/7733b6c892ebf15b603385152ba0a526c5c2af94) Fixed WWW-Authenticate: header, added example config and import into main, fixed golint warnings
+  * [`60262521`](https://github.com/distribution/distribution/commit/60262521bd2122e1b98554587891d88baa557d29) Implementation of a basic authentication scheme using standard .htpasswd files
+* Move ErrorCode logic to new errcode package ([#548](https://github.com/distribution/distribution/pull/548))
+  * [`56349665`](https://github.com/distribution/distribution/commit/56349665b758d500eac09798c369b546125b439b) Round 4
+  * [`b8b16b78`](https://github.com/distribution/distribution/commit/b8b16b78f4fe510e4f0b9310957aba6675bcd623) Round 3 - Add Register function
+  * [`00b1e8fc`](https://github.com/distribution/distribution/commit/00b1e8fca06c30abfc0fa1fdf228f3739ec7534b) Round 2 Make Errors a []Error
+  * [`f565d6ab`](https://github.com/distribution/distribution/commit/f565d6abb75a3860c7fa602e1bd756cdb1434eaf) Move ErrorCode logic to new errcode package Make HTTP status codes match the ErrorCode by looking it up in the Descriptors
+  * [`280b9c50`](https://github.com/distribution/distribution/commit/280b9c50ac0c4bd83e26a4ce8d79783aeb38bf39) Saner default data location
+* Clarify digest in API specification ([#599](https://github.com/distribution/distribution/pull/599))
+  * [`60967cbd`](https://github.com/distribution/distribution/commit/60967cbd6b68a7c839b3e73cf0871c279c79d601) Clarify that manifests can only be deleted by digest
+  * [`630334b3`](https://github.com/distribution/distribution/commit/630334b304de82b0f8694ed9d8599579933a8d8c) Add more repository name validation test cases
+* doc/spec: coherence between requests and parameters + typo ([#580](https://github.com/distribution/distribution/pull/580))
+  * [`040d7038`](https://github.com/distribution/distribution/commit/040d7038b88ae8114d21bb9b6ff705372b1c22ee) doc: coherence between requests and parameters + typo
+* Feature: Add Hook for Web Application Panic ([#394](https://github.com/distribution/distribution/pull/394))
+  * [`9d7c6923`](https://github.com/distribution/distribution/commit/9d7c6923c19c2afd3e1553a81dbfbc4d99803765) Feature: Web Panic Reporting via hooks
+* Fix rados build, remove uuid dependency ([#578](https://github.com/distribution/distribution/pull/578))
+  * [`4bc53818`](https://github.com/distribution/distribution/commit/4bc53818cb1423f19a9449c8979f467aea816819) Fix rados build, remove uuid dependency
+* fixed typos ([#574](https://github.com/distribution/distribution/pull/574))
+  * [`58912344`](https://github.com/distribution/distribution/commit/589123441b4fdee54af9d5d235adadc94519223a) fixed typos
+* Storage Driver: Ceph Object Storage (RADOS) ([#443](https://github.com/distribution/distribution/pull/443))
+  * [`2c1a83f9`](https://github.com/distribution/distribution/commit/2c1a83f940ba34c7feab1a04882019413db02584) Storage Driver: Ceph Object Storage (RADOS)
+* Replace uuid dependency with internal library ([#556](https://github.com/distribution/distribution/pull/556))
+  * [`f8c0086e`](https://github.com/distribution/distribution/commit/f8c0086e93112279086a807a61adbf32d0463019) Replace uuid dependency with internal library
+* Remove digest package's dependency on external sha implementation ([#546](https://github.com/distribution/distribution/pull/546))
+  * [`bdaed4c7`](https://github.com/distribution/distribution/commit/bdaed4c78916e910b8f345585265355252f6912d) Refactor specification of supported digests
+  * [`a0d242d9`](https://github.com/distribution/distribution/commit/a0d242d9df4adc1820c70b03efd2269c68f65bf0) Remove digest package's dependency on external sha implementation
+  * [`d4c50637`](https://github.com/distribution/distribution/commit/d4c50637f9fb1e8f18dfe8947973dbee2bfead83) Better error message when failing to get AWS auth
+* Decouple redis dependency from blob descriptor cache ([#542](https://github.com/distribution/distribution/pull/542))
+  * [`812c8099`](https://github.com/distribution/distribution/commit/812c8099a6761b93850dd8f185be79b7b498fe03) Decouple redis dependency from blob descriptor cache
+* client: fix a typo preventing compilation ([#543](https://github.com/distribution/distribution/pull/543))
+  * [`cd543091`](https://github.com/distribution/distribution/commit/cd5430916fdfb03dc03a9577534d538080305d9a) client: fix a typo preventing compilation
+* Add client implementation of distribution interface ([#387](https://github.com/distribution/distribution/pull/387))
+  * [`754a8e80`](https://github.com/distribution/distribution/commit/754a8e80f258573b7104d5657dd357859db9356a) Remove error message shortening
+  * [`aac3ce46`](https://github.com/distribution/distribution/commit/aac3ce46c7ba78740bc556fb732c131cc4e8887e) Only do auth checks for endpoints starting with v2
+  * [`7e4d5eaf`](https://github.com/distribution/distribution/commit/7e4d5eafae5b0f56c539ac8a04c88b9f07d9823c) Update transport package to sever distribution dependency
+  * [`3b5a2bbe`](https://github.com/distribution/distribution/commit/3b5a2bbebcd1bdc0809232920a477e452ebf21a5) Add unauthorized error check
+  * [`b4972a6b`](https://github.com/distribution/distribution/commit/b4972a6bab3965ecd186c392d058f7bb43fd8e7a) Break down type dependencies
+  * [`8db2145b`](https://github.com/distribution/distribution/commit/8db2145b819626a0f78023de09aef22664544a80) Feedback update
+  * [`eb2ac430`](https://github.com/distribution/distribution/commit/eb2ac4301f26b6031c7aad48657a5ac30adca8a4) Lint and documentation fixes
+  * [`131b608a`](https://github.com/distribution/distribution/commit/131b608aeb1d9fb3d2b88cc5f81fbdd99433ca84) Create client transport package
+  * [`e0e13209`](https://github.com/distribution/distribution/commit/e0e13209d84f84ce1af6da47fc1a2198a2f6fe35) Remove unused and duplicate error types
+  * [`296a8415`](https://github.com/distribution/distribution/commit/296a8415b9e214e4c99ade87471aea74b65cfb96) Update to track refactor updates
+  * [`568df315`](https://github.com/distribution/distribution/commit/568df315fff0e8514cd262d75a62f6c00228ffe9) Open cache interface
+  * [`60b314ad`](https://github.com/distribution/distribution/commit/60b314ade54d2326e921c1d21c7ab095e63d40b7) Rename layer files to blob
+  * [`67e2e834`](https://github.com/distribution/distribution/commit/67e2e83434225becedf530dde7064ab5ac18ee14) Update to use blob interfaces
+  * [`6bf4c45e`](https://github.com/distribution/distribution/commit/6bf4c45e52078dc51b77ab477d9c0798f470107a) Add missing defer on Tags
+  * [`89c396e0`](https://github.com/distribution/distribution/commit/89c396e0f5881ad1d1faaa939462b804c235266e) Simplify configuration and transport
+  * [`8b0ea19d`](https://github.com/distribution/distribution/commit/8b0ea19d392c5b5159f80657152c9bfc1b95586a) Add base transport to interface
+  * [`a9b0f49c`](https://github.com/distribution/distribution/commit/a9b0f49c8bfe10e182d36549a1c0313afbbf99d7) Removed unused mirror flags
+  * [`17cbbf64`](https://github.com/distribution/distribution/commit/17cbbf648fe31b942316140744d4f20a000f2d9a) Update ReadFrom to wrap reader in NopCloser
+  * [`ecaa643c`](https://github.com/distribution/distribution/commit/ecaa643cb24288523eb2108f00c54fb7db7cfe7e) Create authentication handler
+  * [`7d630192`](https://github.com/distribution/distribution/commit/7d630192dda132713aba1583d4937fb75951b785) Add tags implementation
+  * [`2eb9b286`](https://github.com/distribution/distribution/commit/2eb9b286ed575fa2165b38a971da7fcf4003510f) Use distribution context instead of google
+  * [`b78727cb`](https://github.com/distribution/distribution/commit/b78727cbf91ffddfc4af042a7d9039dbe70ce9f1) Cleanup session and config interface
+  * [`07cee840`](https://github.com/distribution/distribution/commit/07cee840a424e81933c7d5a65ac6bf080584d8d1) Split layer and upload from repository
+  * [`03e08731`](https://github.com/distribution/distribution/commit/03e0873125a724b26a1ed2f6f037720598c9d3c1) Add unit tests for auth challenge and endpoint
+  * [`837a12db`](https://github.com/distribution/distribution/commit/837a12db15700bccef76463ad95f79301d821e33) Remove deprecated client interface
+  * [`4c8e4dc3`](https://github.com/distribution/distribution/commit/4c8e4dc373e7cd61524751829bc58106e80b8cb5) Add client implementation of distribution interface
+* Fix typo: respository->repository ([#534](https://github.com/distribution/distribution/pull/534))
+  * [`ea39e348`](https://github.com/distribution/distribution/commit/ea39e348049393de7060b5a71063d971ebdaed5d) Fix typo: respository->repository
+* Refactor Blob Service API ([#519](https://github.com/distribution/distribution/pull/519))
+  * [`08401cfd`](https://github.com/distribution/distribution/commit/08401cfdd6586d23d76d6be89449872c33bb1ff7) Refactor Blob Service API
+* Set cache headers for layers. ([#518](https://github.com/distribution/distribution/pull/518))
+  * [`2db0327d`](https://github.com/distribution/distribution/commit/2db0327dc1cc11feb3b4135f723e9b6cda704c80) Set cache headers for layers.
+  * [`b292f31d`](https://github.com/distribution/distribution/commit/b292f31d381c5de1882ff259c13c8bd605755bee) [Server] Listen and serve on a unix socket
+  * [`12354621`](https://github.com/distribution/distribution/commit/123546212c513cfd2651b52ef7bee73c5e85ee1d) Modify blob upload API
+  * [`7f3a57fd`](https://github.com/distribution/distribution/commit/7f3a57fdbb3fa63f5428a1f9b5cb9a60541ad84e) Ensure the instrumentedResponseWriter correctly sets the http status in the context.
+* Add golang/x/net/context.Context to storage driver method calls ([#410](https://github.com/distribution/distribution/pull/410))
+  * [`5d9105bd`](https://github.com/distribution/distribution/commit/5d9105bd25827e5397a5a1c079a45d7085b76e26) Make Storage Driver API calls context aware.
+* Update API spec to reference digest instead of tarsum ([#476](https://github.com/distribution/distribution/pull/476))
+  * [`6fbda8fa`](https://github.com/distribution/distribution/commit/6fbda8fa2690a15b09a51f68b00516ace337bacf) Update API spec to reference digest instead of tarsum
+  * [`80abf9fc`](https://github.com/distribution/distribution/commit/80abf9fce0dbe43443d98d6efb42f03008866f1d) Use done channel to avoid goroutine leak
+* Add configuration for upload purging ([#381](https://github.com/distribution/distribution/pull/381))
+  * [`5caa1fe3`](https://github.com/distribution/distribution/commit/5caa1fe3b0fe2fd0fdb6491ce8ac42a0c273fbd3) Add configuration for upload purging
+  * [`10f32bfc`](https://github.com/distribution/distribution/commit/10f32bfcd53f53e17d45ac4f218d49a8d9ad6e3d) simplify the embedded method expression of repository
+  * [`2c7489e6`](https://github.com/distribution/distribution/commit/2c7489e6b208c816b34c205ad8a4089afbe0a244) Updated urlbuilder X-Forwarded-Host logic
+* Attempt to address intermittent s3 RequestTimeout error ([#430](https://github.com/distribution/distribution/pull/430))
+  * [`0f897aea`](https://github.com/distribution/distribution/commit/0f897aea8fc9c3b5c0734e26f70c77049560e9f9) Attempt to address intermittent s3 RequestTimeout error
+* Expose storage driver names for tracing ([#420](https://github.com/distribution/distribution/pull/420))
+  * [`ecda1f4e`](https://github.com/distribution/distribution/commit/ecda1f4eff147603738593f156c0b7a78278311c) Include driver name in trace messsages
+  * [`b361b481`](https://github.com/distribution/distribution/commit/b361b4811ba1b0df7c41bd14ff01afb303481044) Require storage drivers to report their name
+* Correctly check s3 chunksize parameter ([#429](https://github.com/distribution/distribution/pull/429))
+  * [`0d8cb4dc`](https://github.com/distribution/distribution/commit/0d8cb4dca8d8a554720c1f37e08a11b39d70df61) Correctly check s3 chunksize parameter
+* Return after error in handler ([#428](https://github.com/distribution/distribution/pull/428))
+  * [`8d4b636a`](https://github.com/distribution/distribution/commit/8d4b636a60ffd7838e798f940a355c019f747101) Return after error in handler
+* Pool buffers used in S3.WriteStream ([#419](https://github.com/distribution/distribution/pull/419))
+  * [`c49f7cd0`](https://github.com/distribution/distribution/commit/c49f7cd0154b3bfc18d53e48a9fb46586092f71f) Pool buffers used in S3.WriteStream
+* Allow configuration of chunksize parameter ([#418](https://github.com/distribution/distribution/pull/418))
+  * [`e4794ff7`](https://github.com/distribution/distribution/commit/e4794ff73dc42e51021f4013c581f1d108a025c6) Allow configuration of chunksize parameter
+* Check error returned from io.Copy ([#414](https://github.com/distribution/distribution/pull/414))
+  * [`f1ea982e`](https://github.com/distribution/distribution/commit/f1ea982e82289edc14eb1c63c432851d5b1a59eb) Check error returned from io.Copy
+* Backoff retry on verification to give s3 time to propagate ([#408](https://github.com/distribution/distribution/pull/408))
+  * [`36ffe0c1`](https://github.com/distribution/distribution/commit/36ffe0c134aba840c81e961fb33260f6fb360d7b) Backoff retry on verification to give s3 time to propagate
+* log canonical digest on verification error ([#407](https://github.com/distribution/distribution/pull/407))
+  * [`77b30cfb`](https://github.com/distribution/distribution/commit/77b30cfb2573520edd1cbdf41f03d779e97fa63b) log canonical digest on verification error
+* Attempt to deal with eventual consistency by retrying ([#405](https://github.com/distribution/distribution/pull/405))
+  * [`d4ce8f5e`](https://github.com/distribution/distribution/commit/d4ce8f5ef8adc994b34bf02b45d3081cb697d8eb) Attempt to deal with eventual consistency by retrying
+* Add logging for generic handler errors. ([#404](https://github.com/distribution/distribution/pull/404))
+  * [`43181105`](https://github.com/distribution/distribution/commit/431811056bb995a4e48471c74deea5d975283ce9) Add logging for generic handler errors.
+* registry/storage/driver: add path and other info to filesytem trace methods. ([#375](https://github.com/distribution/distribution/pull/375))
+  * [`bc2b6efa`](https://github.com/distribution/distribution/commit/bc2b6efaa693eb1746a38492f3c58b5a732df3ad) Add path and other info to filesytem trace methods.
+* fix some typos in source comments ([#384](https://github.com/distribution/distribution/pull/384))
+  * [`f3f46307`](https://github.com/distribution/distribution/commit/f3f46307f2a4009bc7005a73fcd764b783bc8336) fix some typos in source comments
+* registry/storage: automatically purge old upload files ([#333](https://github.com/distribution/distribution/pull/333))
+  * [`0b2feaf6`](https://github.com/distribution/distribution/commit/0b2feaf611de8ca1e4b8f382162806653cc99db8) Automatically purge old upload files.
+* context, registry/handlers: instantiate http context before dispatch ([#369](https://github.com/distribution/distribution/pull/369))
+  * [`136f0ed8`](https://github.com/distribution/distribution/commit/136f0ed8bb00d19ae67f54b4063a59096d927dea) Instantiate http context before dispatch
+* Use a build flag to disable resumable digests ([#364](https://github.com/distribution/distribution/pull/364))
+  * [`480d864f`](https://github.com/distribution/distribution/commit/480d864fc417d083b6422b88929750291e72da14) Use a build flag to disable resumable digests.
+  * [`16174241`](https://github.com/distribution/distribution/commit/16174241d1ab1dff5996973ae04f73790a33c4d3) Update final upload chunk api doc
+  * [`98985526`](https://github.com/distribution/distribution/commit/98985526561569713b14ce55ae370184b63fd01a) Add auth.user.name to logging context
+* context, storagedriver: trace function calls to Base storage driver ([#343](https://github.com/distribution/distribution/pull/343))
+  * [`12bf470b`](https://github.com/distribution/distribution/commit/12bf470b2f42c0b65d18a880ffc2f17498d9af4c) Trace function calls to Base storage driver
+  * [`36a07699`](https://github.com/distribution/distribution/commit/36a076995bcb190b854c8d40fd00b1f3dfb9ebc7) Disassociate instance id from application
+* Prevent Close() from being called after Finish() ([#349](https://github.com/distribution/distribution/pull/349))
+  * [`4ac515fd`](https://github.com/distribution/distribution/commit/4ac515fde468f8d0845ae68fa4416ed4525bce90) Prevent Close() from being called after Finish()
+* Rename top level registry interface to namespace ([#307](https://github.com/distribution/distribution/pull/307))
+  * [`e83e3761`](https://github.com/distribution/distribution/commit/e83e37618f4b977c28aae7b56c3212f8d4c0005f) Rename top level registry interface to namespace
+  * [`250e61e2`](https://github.com/distribution/distribution/commit/250e61e2a13b4b82fcc01b40d5853a32aa91c8f9) Prevent false sharing in signature fetch
+* registry/storage/driver: defer case-sensitive support to storage backend ([#332](https://github.com/distribution/distribution/pull/332))
+  * [`2b4ad94c`](https://github.com/distribution/distribution/commit/2b4ad94ceec4b659b16ce9b3c17ca69e506bbc6f) Defer case-sensitive support to storage backend
+* registry/storage: parallelize signature fetch in signature store ([#330](https://github.com/distribution/distribution/pull/330))
+  * [`def60f34`](https://github.com/distribution/distribution/commit/def60f3426b25c73d99f2ce2a449de7c9043e4b7) Parallelize signature fetch in signature store
+  * [`8c0859e3`](https://github.com/distribution/distribution/commit/8c0859e39cc36530a91ed67de1d5573528bf09e6) Handle cloudFront bucket prefix issue
+* registry: integrate layer info cache with registry and storage ([#312](https://github.com/distribution/distribution/pull/312))
+  * [`6b748a74`](https://github.com/distribution/distribution/commit/6b748a74ef9cb9677e3bda151cf2111b70375d2c) Move expvar under the registry section
+  * [`4e1ecad6`](https://github.com/distribution/distribution/commit/4e1ecad6cc31a080b0c0044abf99c55d2338e3bf) Allow control over which storage cache to use
+  * [`6ab228f7`](https://github.com/distribution/distribution/commit/6ab228f79828dda905a33952c3a5f1554ee0deb5) Integrate layer info cache with registry and storage
+  * [`a7c2dcee`](https://github.com/distribution/distribution/commit/a7c2dceea5f40dc14ad4b0e2facebfb3fecbcd91) Define and implement layer info cache
+  * [`38ae1cb4`](https://github.com/distribution/distribution/commit/38ae1cb4613e68e32025493459239519ea66ec59) Add redis pool to registry webapp
+* digest, registry/storage: use resumable digest ([#295](https://github.com/distribution/distribution/pull/295))
+  * [`b96de45b`](https://github.com/distribution/distribution/commit/b96de45be83506f195903c7ab85d61a1003d5b96) Use resumable digest for efficient upload finish
+* registry/api/v2: stronger validation for uuid field in urls ([#314](https://github.com/distribution/distribution/pull/314))
+  * [`6eb804a1`](https://github.com/distribution/distribution/commit/6eb804a1ecfde5366ae05464776b748210754f0c) Stronger validation for uuid field in urls
+  * [`06acde06`](https://github.com/distribution/distribution/commit/06acde06cb89fcc944666806528f48b3ad88d729) Avoid crash on invalid Move arguments
+* Updating MSOpenTech/azure-sdk-for-go to latest master ([#294](https://github.com/distribution/distribution/pull/294))
+  * [`dffd1bab`](https://github.com/distribution/distribution/commit/dffd1babd2e95763302bd5aedbba3ab0b88a2260) Updating MSOpenTech/azure-sdk-for-go to latest master
+  * [`594f733e`](https://github.com/distribution/distribution/commit/594f733e03e9e21153457eff5ccf5d5eb32fa033) storage/driver/azure: Allow non-default realms
+* Refactor Layer interface to return a Handler ([#261](https://github.com/distribution/distribution/pull/261))
+  * [`6d140193`](https://github.com/distribution/distribution/commit/6d1401936821950867515244647d995dde261390) Refactor Layer interface to return a Handler
+* Insert request method option storage driver URLFor ([#258](https://github.com/distribution/distribution/pull/258))
+  * [`fdd63147`](https://github.com/distribution/distribution/commit/fdd631477622bdb475a6078007ea2975b2231175) Insert request method option storage driver URLFor
+* Send WWW-Authenticate header for silly auth ([#256](https://github.com/distribution/distribution/pull/256))
+  * [`4b5af16f`](https://github.com/distribution/distribution/commit/4b5af16fdc2e7cfe8d2364e033164b710d8482fa) Send WWW-Authenticate header for silly auth
+* registry/middleware, registry/storage, configuration: refactoring cloudfront + generic middlewares ([#244](https://github.com/distribution/distribution/pull/244))
+  * [`83571e57`](https://github.com/distribution/distribution/commit/83571e574c0b3fc05b9185adb3f63fffbb4525d4) don't panic during a request when configuring repository middleware. Return a 500 with an appropriate error Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)
+  * [`5c3f53b7`](https://github.com/distribution/distribution/commit/5c3f53b70f8f576aca701eb07ef32b3abfdf7bd3) Fix Godoc typos
+  * [`6a72d1ae`](https://github.com/distribution/distribution/commit/6a72d1aefbecd6f85f469565b210d9021d131b4d) Final polish to cloudfront and larger middleware refactor Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)
+  * [`30bcc17b`](https://github.com/distribution/distribution/commit/30bcc17b85aa745deab58c545f40d8e6f79962d5) Middleware!
+  * [`952f39ed`](https://github.com/distribution/distribution/commit/952f39edffff1f7508366696745a6a76f9390915) Refactoring cloudfactory layer handler into a more generic storage middleware concept.
+* digest: Minor refactoring ([#251](https://github.com/distribution/distribution/pull/251))
+  * [`3e658d29`](https://github.com/distribution/distribution/commit/3e658d29a667dee19e4e35e578fd0274a7df221b) digest: Minor refactoring
+* minor refactor + tests for app.go just to improve test coverage. ([#247](https://github.com/distribution/distribution/pull/247))
+  * [`eccae81c`](https://github.com/distribution/distribution/commit/eccae81c9e9daa992baae805c54913ca0a643664) minor refactor + tests for app.go just to improve test coverage. Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)
+* Remove max repository component length restriction ([#242](https://github.com/distribution/distribution/pull/242))
+  * [`ccfadc93`](https://github.com/distribution/distribution/commit/ccfadc93aa34a849e681b645c915ebf62b5fb4b4) Remove max repository component length restriction
+* notifications: update notification event Target fields ([#239](https://github.com/distribution/distribution/pull/239))
+  * [`4e3bf4ba`](https://github.com/distribution/distribution/commit/4e3bf4bad4df87f447678dd675b5f44de0ff8c58) Update notification event Target fields
+* digest, registry/storage, registry/handlers: switch to SHA256 as canonical digest ([#238](https://github.com/distribution/distribution/pull/238))
+  * [`2a786bfc`](https://github.com/distribution/distribution/commit/2a786bfc23934590f1ea8e0ab4e230d93e1d2c60) fixing up tests to work with for non-tarsum future Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)
+  * [`98daae17`](https://github.com/distribution/distribution/commit/98daae176ab559396c96ee0601a144429219ed69) Switch to SHA256 as canonical digest
+* doc: move storage driver readmes into docs ([#243](https://github.com/distribution/distribution/pull/243))
+  * [`19061f34`](https://github.com/distribution/distribution/commit/19061f347e12128a1cf5a810833a750826a16110) doc: move storage driver readmes into docs
+* doc/spec, registry: immutable manifest reference support ([#211](https://github.com/distribution/distribution/pull/211))
+  * [`008236cf`](https://github.com/distribution/distribution/commit/008236cfef2e9eaada4eaf2a99dfd11f902122e9) Implement immutable manifest reference support
+  * [`f46a1b73`](https://github.com/distribution/distribution/commit/f46a1b73e8d7b26716a5164afd7f9fc756e7fca7) spec: fetch manifests by tag or digest
+* Expose Signatures() on Repository ([#234](https://github.com/distribution/distribution/pull/234))
+  * [`a65662c1`](https://github.com/distribution/distribution/commit/a65662c10f18a9f0829585a1d7643d634c28ce0b) Expose Signatures() on Repository
+* Remove unnecessary close in client ([#231](https://github.com/distribution/distribution/pull/231))
+  * [`0b34048f`](https://github.com/distribution/distribution/commit/0b34048fe36460c96a02b5ea0345f64618ba6172) Remove unnecessary close in client
+* registry/storage: buffered wrapper for fileWriter ([#218](https://github.com/distribution/distribution/pull/218))
+  * [`b870e3fd`](https://github.com/distribution/distribution/commit/b870e3fdfbb6fa7cbf2209f9460ddd34424a6f8f) wrap buffered writer around filewriter
+* documentation for name validation grammar ([#212](https://github.com/distribution/distribution/pull/212))
+  * [`ac7af800`](https://github.com/distribution/distribution/commit/ac7af800fb069af6f84305a06e5b66877b4caaff) documentation for name validation grammar
+* doc/spec, registry/handlers: specify and implement Docker-Upload-UUID ([#213](https://github.com/distribution/distribution/pull/213))
+  * [`32f5965c`](https://github.com/distribution/distribution/commit/32f5965c0608997c44875ca464ccb11242c78f91) Specify and implement Docker-Upload-UUID
+* registry/api/v2: test cases for path traversal and bad characters ([#208](https://github.com/distribution/distribution/pull/208))
+  * [`3bf768a5`](https://github.com/distribution/distribution/commit/3bf768a58851c6e20b9a087ee0db51506158b4f7) Adding test cases to confirm path traversal attempts are mitigated and bad characters in URI return 404 Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)
+* registry/handlers: support prefixed registry app ([#202](https://github.com/distribution/distribution/pull/202))
+  * [`871cf9dd`](https://github.com/distribution/distribution/commit/871cf9dd0147fda76dc07c687483ff85b57f2ca0) Path prefix support for running registry somewhere other than root of server
+* Rename auth.token.{rootCertBundle -> rootcertbundle} ([#189](https://github.com/distribution/distribution/pull/189))
+  * [`b87459b3`](https://github.com/distribution/distribution/commit/b87459b363f7bd0769381632df2083f3080c2b44) Rename auth.token.rootCertBundle yml field
+* A digest missing parameter should result in a bad request ([#191](https://github.com/distribution/distribution/pull/191))
+  * [`606c5c8c`](https://github.com/distribution/distribution/commit/606c5c8c5785d758e7984e69cda0eb4c5fd26fcd) A digest missing parameter should result in a bad request
+* Fix S3 driver's list when the root directory is either "" or "/" ([#184](https://github.com/distribution/distribution/pull/184))
+  * [`58269e73`](https://github.com/distribution/distribution/commit/58269e73fc6bbf70ce82bdfae88ffdd58d6e5ff7) Fix S3 driver's list when the root directory is either "" or "/"
+  * [`02718ee2`](https://github.com/distribution/distribution/commit/02718ee277575a455d092d439375b7b62c673df9) Add an empty root directory s3 driver specific test
+  * [`3e906311`](https://github.com/distribution/distribution/commit/3e906311c6faaf8ae46436d5e56c144cf2d72620) Add error return to Repository method on Registry
+  * [`ed8827c3`](https://github.com/distribution/distribution/commit/ed8827c3c2de71c0decc615701202b0c8761e9a8) Move notifications package to distribution
+  * [`09bf7522`](https://github.com/distribution/distribution/commit/09bf7522347066980c75c5b84b0836cb0c581dcf) Remove Name from Layer and LayerUpload interface
+  * [`553d48d6`](https://github.com/distribution/distribution/commit/553d48d618411feaa6ae947a61f7fd9c9153e68e) Move layer interface definitions to distribution package
+* registry/storage/driver/azure: add README ([#168](https://github.com/distribution/distribution/pull/168))
+  * [`8728074d`](https://github.com/distribution/distribution/commit/8728074d65102e0a90619138a3f0d3507ce2cfba) storagedriver/azure: Add README
+  * [`fac0f541`](https://github.com/distribution/distribution/commit/fac0f5412d139055e64760cc6155d3b8aa82e1cd) Run goimports/gofmt on previous changes
+  * [`6e4f9a2e`](https://github.com/distribution/distribution/commit/6e4f9a2e3ed354911f93e92630188c3e97d61f4e) Move storagedriver package to registry/storage/driver
+  * [`71e7ac33`](https://github.com/distribution/distribution/commit/71e7ac33cac7d71ffcf492e618cc3b7a139a7656) Move storage package under registry package
+  * [`d6308bc6`](https://github.com/distribution/distribution/commit/d6308bc62b22b50ff968f5284cf6720e8f584290) Move client package under registry package
+  * [`c3b07952`](https://github.com/distribution/distribution/commit/c3b07952ad9a7d553a6374e68e2ea2997a381ea9) Move auth package under registry package
+  * [`3822e685`](https://github.com/distribution/distribution/commit/3822e685a03027d7b4408fbcc326428e0d2432fd) Move registry api definitions under registry package
+  * [`54ae545e`](https://github.com/distribution/distribution/commit/54ae545ed3cc5c95c46ff996f3b6f541ff6aaacc) Move registry package into handler package
+* Correctly return when repo name is not available ([#163](https://github.com/distribution/distribution/pull/163))
+  * [`287e11e1`](https://github.com/distribution/distribution/commit/287e11e1d494eb32bb7c13fe5ada2ca0dfbfc782) Correctly return when repo name is not available
+  * [`9bde7d98`](https://github.com/distribution/distribution/commit/9bde7d9835c583cbfcacbadd9a4725ec703b1a0a) Integrate context with storage package
+  * [`3e840699`](https://github.com/distribution/distribution/commit/3e84069959b650440ca8f4bdaf4f1f3b4b7a5bac) Integrate contextual logging with regsitry app
+* Use context for auth access controllers ([#140](https://github.com/distribution/distribution/pull/140))
+  * [`904b35a2`](https://github.com/distribution/distribution/commit/904b35a24f80c08b42ca1f6e737fd3903ec744a5) Use context for auth access controllers
+* Manifest PUT should return 202 Accepted status ([#141](https://github.com/distribution/distribution/pull/141))
+  * [`1f06e4f8`](https://github.com/distribution/distribution/commit/1f06e4f816404b0c702d8b6296ca91e98f738304) Manifest PUT should return 202 Accepted status
+  * [`1089cae2`](https://github.com/distribution/distribution/commit/1089cae282196e8fe0cbc5733882787cf4c1b7a3) Separate request data from actor in Event
+  * [`2aed7c2d`](https://github.com/distribution/distribution/commit/2aed7c2d0ce0f0451ac7bba61705d9da75d72c74) Webhook notification support in registry webapp
+  * [`b6270d9c`](https://github.com/distribution/distribution/commit/b6270d9c14caf4627e9ca42e15c0f573c428cee6) Handle empty blob files more appropriately
+  * [`33a1f4ef`](https://github.com/distribution/distribution/commit/33a1f4ef7d4552cb423f446d544af95ca0965259) Address server errors received during layer upload
+* Add Docker Distribution API Version header ([#89](https://github.com/distribution/distribution/pull/89))
+  * [`acfcc955`](https://github.com/distribution/distribution/commit/acfcc955deeda2987733993fd1d04459bf98c662) Add Docker Distribution API Version header
+  * [`825da388`](https://github.com/distribution/distribution/commit/825da388a45c2cc6cb20c5291d39140716446caa) Update the registry app to use the new storage interfaces
+  * [`594263a3`](https://github.com/distribution/distribution/commit/594263a3f5a63c84f38ca8decfa82d732179268a) Correctly handle missing layer upload
+* Spool uploads remotely ([#53](https://github.com/distribution/distribution/pull/53))
+  * [`cd92071c`](https://github.com/distribution/distribution/commit/cd92071caa2556480a2c39e6dff690458b4ea21b) Directly manage layerUploadState in webapp
+  * [`fdcfc56f`](https://github.com/distribution/distribution/commit/fdcfc56f7bd6853cbe375f85bd99bbabb9325245) Refactor handling of hmac state packing
+* Adds support for content redirects for layer downloads ([#55](https://github.com/distribution/distribution/pull/55))
+  * [`9d3436c1`](https://github.com/distribution/distribution/commit/9d3436c18e9f520a511128246394e8835309959d) Fixes tests, moves layerhandler in config file
+  * [`b11d549f`](https://github.com/distribution/distribution/commit/b11d549fd071def4409c63c0531490372ddeb184) Adds support for content redirects for layer downloads
+  * [`c02f1a55`](https://github.com/distribution/distribution/commit/c02f1a5507353fff1b430f9c1dc90fca0ba70df1) Move registry package out of repo root
+  * [`b2da4f33`](https://github.com/distribution/distribution/commit/b2da4f338cac0e46d87a0f44a79db3c56ac863ca) Moved imported orca docs into ucp directory
+  * [`a56d36fd`](https://github.com/distribution/distribution/commit/a56d36fdaaf2bb566bc68e611228566e300094c7) Initial commit -f https://github.com/docker/orca
+  * [`be487836`](https://github.com/distribution/distribution/commit/be4878366956fd7005a02ca097acbb85947fbc96) Moved docker-trusted-registry imported docs to apidocs and docker-trusted-registry subdirectories
+  * [`d4f01b81`](https://github.com/distribution/distribution/commit/d4f01b812c8216b615990ee4ad947465312fac00) Initial import of https://github.com/docker/dhe-engine
+  * [`e9de6f2a`](https://github.com/distribution/distribution/commit/e9de6f2a441b28900e8d12c2a9b8afed472ae184) Moved cs-engine docs to the cs-engine subdirectory
+  * [`734f334d`](https://github.com/distribution/distribution/commit/734f334d9ccdca799b0ffaa2eda7e0efb1fd16b7) Initial import of https://github.com/docker/cs-docker
+  * [`f0a62ccf`](https://github.com/distribution/distribution/commit/f0a62ccf9b365a29dec583be7856fb5e877ec3d9) Initial repo commit
+  * [`342aff71`](https://github.com/distribution/distribution/commit/342aff714c42a3b9ba0f08b98157c972effedb61) Revert "Remove old documentation source, add README on migration"
+* ci: use proper git ref for versioning ([#3585](https://github.com/distribution/distribution/pull/3585))
+  * [`fabf9cd4`](https://github.com/distribution/distribution/commit/fabf9cd4e94c4d529b1904320b16f431bc599305) ci: use proper git ref for versioning
+* go.mod: github.com/Azure/go-autorest/autorest v0.11.24 ([#3575](https://github.com/distribution/distribution/pull/3575))
+  * [`4f1c1e42`](https://github.com/distribution/distribution/commit/4f1c1e4268e1c6ec9e4defab4fb3a82ffe13ef74) go.mod: github.com/Azure/go-autorest/autorest v0.11.24
+* Update golangci-lint version and fix reports ([#3580](https://github.com/distribution/distribution/pull/3580))
+  * [`ebd3f441`](https://github.com/distribution/distribution/commit/ebd3f441464ea9fa2e42f834411562b67f86d1a2) Update golangci-lint version and fix reports
+* Fix: Avoid a false type assertion in the inmemory driver ([#3579](https://github.com/distribution/distribution/pull/3579))
+  * [`676691ce`](https://github.com/distribution/distribution/commit/676691ce6d5eb4f400612529b02cdb87cc33bda1) Fix: Avoid a false type assertion in the inmemory driver
+* go.mod: spf13/cobra v1.0.0 ([#3228](https://github.com/distribution/distribution/pull/3228))
+  * [`79ead619`](https://github.com/distribution/distribution/commit/79ead619be7339720ffff4aacc41d7fdd980e701) go.mod: spf13/cobra v1.0.0
+  * [`f9c1b86f`](https://github.com/distribution/distribution/commit/f9c1b86feb36b530f7eab78e18e9a49decc87861) go.mod: add replace rule to prevent unwanted updateds of grpc and jwt-go
+* optimize: disable insecure cipher suites ([#3576](https://github.com/distribution/distribution/pull/3576))
+  * [`4363fb1e`](https://github.com/distribution/distribution/commit/4363fb1ef4676df2b9d99e3630e1b568141597c4) disable insecure cipher suites
+* update build workflow ([#3571](https://github.com/distribution/distribution/pull/3571))
+  * [`ea65fe2e`](https://github.com/distribution/distribution/commit/ea65fe2ea40b697c69fe75232e4635fe6e3d7b77) update build workflow
+* fix image cache incompletely ([#3567](https://github.com/distribution/distribution/pull/3567))
+  * [`706f2170`](https://github.com/distribution/distribution/commit/706f2170bd08fe0ce1b6f588d402a66f0f9dc74f) fix image cache incompletely
+* Improve how reference regexps are built ([#3566](https://github.com/distribution/distribution/pull/3566))
+  * [`89622d99`](https://github.com/distribution/distribution/commit/89622d99a13e25d9a17286eee562b9284e351fe8) Replace references to `re` with `regexp.MustCompile`
+  * [`1c89ce5f`](https://github.com/distribution/distribution/commit/1c89ce5fc1cec85e0726f598bccc12b873d04de3) Improve how reference regexps are built
+* feat: add option to disable combining the pending part ([#3556](https://github.com/distribution/distribution/pull/3556))
+  * [`117757a5`](https://github.com/distribution/distribution/commit/117757a5cb8ae931f5eab4de24763d8c0421c522) feat: add option to disable combining the pending part
+* Native cross-compilation, artifacts and multi-platform image ([#3315](https://github.com/distribution/distribution/pull/3315))
+  * [`936d7eda`](https://github.com/distribution/distribution/commit/936d7eda013a758eb2a65cd16b8cadc4cf0b8872) ci: upload conformance test results
+  * [`6332e963`](https://github.com/distribution/distribution/commit/6332e9631e6e484f6103e4e9ff86023b59b9fcfe) ci: fix conformance and e2e workflows
+  * [`4941d83c`](https://github.com/distribution/distribution/commit/4941d83cc70f5aaeadf8520c9ffafd689ca0a308) ci: build workflow to release artifacts and multi-platform image
+  * [`f13d1e02`](https://github.com/distribution/distribution/commit/f13d1e02fed90bbdbe8e09b34084c5d7d4ee43b0) dockerfile: native cross-compilation
+* Add dualstack option to S3 storage driver ([#3068](https://github.com/distribution/distribution/pull/3068))
+  * [`e2caaf9c`](https://github.com/distribution/distribution/commit/e2caaf9cba7c119868865ec35aa02cd0297ac810) Add dualstack option to S3 storage driver
+  * [`81a2d171`](https://github.com/distribution/distribution/commit/81a2d171eebe34475484a54f641a5a9acc2ca696) Update aws-sdk to 1.42.27
+* Add cncf-distribution-maintainers@cncf.io to maintainers file ([#3551](https://github.com/distribution/distribution/pull/3551))
+  * [`99c408aa`](https://github.com/distribution/distribution/commit/99c408aac6201dd331751ae9d06c785deae14668) Add cncf-distribution-maintainers@cncf.io to maintainers file
+* Add CNCF Security email account ([#3549](https://github.com/distribution/distribution/pull/3549))
+  * [`6f3cc81b`](https://github.com/distribution/distribution/commit/6f3cc81b47f27d954c1b816d0d375a42892b8088) Add CNCF Security email account
+* Fuzzing: Add 3 fuzzers ([#3458](https://github.com/distribution/distribution/pull/3458))
+  * [`d0ca0c33`](https://github.com/distribution/distribution/commit/d0ca0c330330270543d4971a641be55f0960e071) Fuzzing: Add 3 fuzzers
+* Update Milos' email address ([#3548](https://github.com/distribution/distribution/pull/3548))
+  * [`90d24a63`](https://github.com/distribution/distribution/commit/90d24a63d8204af42ae1bee41c0445cb89dc1f29) Fix email address for milos
+* Improve error message in case invalid env var found ([#2460](https://github.com/distribution/distribution/pull/2460))
+  * [`4f173262`](https://github.com/distribution/distribution/commit/4f173262e4d480e9701ff0f3994f90fdc1f1f1ae) patch-1 - adding more info to the error message
+  * [`579107cf`](https://github.com/distribution/distribution/commit/579107cf2e243e1c8a49e793baa9ca607bad1f13) Improve error message in case invalid env var found
+* Github Security Advisory [GHSA-qq97-vm5h-rrhg](https://github.com/distribution/distribution/security/advisories/GHSA-qq97-vm5h-rrhg)
+  * [`b59a6f82`](https://github.com/distribution/distribution/commit/b59a6f827947f9e0e67df0cfb571046de4733586) manifest: validate document type before unmarshal
+* go.mod: github.com/opencontainers/image-spec v1.0.2 ([#3534](https://github.com/distribution/distribution/pull/3534))
+  * [`6fbba6a9`](https://github.com/distribution/distribution/commit/6fbba6a99b1fd087092e9904645a60e63145fa91) go.mod: github.com/opencontainers/image-spec v1.0.2
+* fix go check issues ([#3529](https://github.com/distribution/distribution/pull/3529))
+  * [`f637481c`](https://github.com/distribution/distribution/commit/f637481c67241151dc6d6fe2b12852e2ad8d70c2) fix go check issues
+* Fixed typo in error message ([#3515](https://github.com/distribution/distribution/pull/3515))
+  * [`f619db73`](https://github.com/distribution/distribution/commit/f619db7336e0976844088bd955d7e98277d67662) Fixed typo in error message
+* bump up golang v1.17 ([#3518](https://github.com/distribution/distribution/pull/3518))
+  * [`3f4c558d`](https://github.com/distribution/distribution/commit/3f4c558dac40dfb4fe13285ffc43a0d738d3a3f0) bump up golang v1.17
+* Optimize storagedriver/s3 Walk (up to ~500x) + small bugfix ([#3480](https://github.com/distribution/distribution/pull/3480))
+  * [`cf81f67a`](https://github.com/distribution/distribution/commit/cf81f67a1605ca920802338237331543f29ce850) storagedriver/s3: Optimized Walk implementation + bugfix
+* updatefrequency should not be saved into duration ([#3411](https://github.com/distribution/distribution/pull/3411))
+  * [`f5709b28`](https://github.com/distribution/distribution/commit/f5709b285a553d2a2fc30497224373772a1001d6) updatefrequency should not be saved into duration
+* chore: update azure go-autorest dependencies ([#3138](https://github.com/distribution/distribution/pull/3138))
+  * [`3e68d47d`](https://github.com/distribution/distribution/commit/3e68d47da6cef859b677222dc7f0069f4d2faf61) chore: update azure go-autorest dependencies
+* docs: update release-tool link ([#3488](https://github.com/distribution/distribution/pull/3488))
+  * [`b07018ff`](https://github.com/distribution/distribution/commit/b07018ff3d384780835f47cced3e4ee36a40ac50) docs: update release-tool link
+* Change should to must in v2 spec ([#3487](https://github.com/distribution/distribution/pull/3487))
+  * [`1660df4b`](https://github.com/distribution/distribution/commit/1660df4b605cab74deaf851e43de9df104aaa0cd) Change should to must in v2 spec
+* Update to go 1.16, and run CI on 1.15.x and 1.16.x ([#3474](https://github.com/distribution/distribution/pull/3474))
+  * [`a07b54eb`](https://github.com/distribution/distribution/commit/a07b54eb684b32e8a1da5ae1cb0abb39cb88e48f) Update to go 1.16, and run CI on 1.15.x and 1.16.x
+* Updated s3 delete to no longer noop under a rare edge case ([#3479](https://github.com/distribution/distribution/pull/3479))
+  * [`9e873f31`](https://github.com/distribution/distribution/commit/9e873f31ec46f975a9170df9e59f1a4c03dbfb5b) storagedriver/s3: Adding back missing import.
+  * [`e625bc71`](https://github.com/distribution/distribution/commit/e625bc7160c0969156b2e8d31cfb7b1f747034df) storagedriver/s3: Removed temporary S3 test
+  * [`dc5b7710`](https://github.com/distribution/distribution/commit/dc5b77101d8f62271b0bab0e254a39b29dcb8373) storagedriver/s3: Cleaning up tests
+  * [`6da7217b`](https://github.com/distribution/distribution/commit/6da7217b99e64022cecfd003bc8e0e7c2531c057) storagedriver/s3: Optimize s3 Delete test cleanup.
+  * [`03f9eb3a`](https://github.com/distribution/distribution/commit/03f9eb3a18bb57bb0041c11f1f6c2835d06b6ac2) storagedriver/s3: Fixed a Delete noop edgecase
+  * [`05a258e7`](https://github.com/distribution/distribution/commit/05a258e711f82ff2671bdcfccbbc5bdb1ea4465b) storagedriver/s3: Added Delete tests to s3_test
+* Propose Sargun as a maintainer ([#3441](https://github.com/distribution/distribution/pull/3441))
+  * [`d3cd41aa`](https://github.com/distribution/distribution/commit/d3cd41aa84c177a2791e8688075c68891d1ed7cf) Propose Sargun as a maintainer
+* use memory as the cache in test ([#3450](https://github.com/distribution/distribution/pull/3450))
+  * [`0f50e038`](https://github.com/distribution/distribution/commit/0f50e0388dd7bc94c1b734ab92add7461b0db389) use memory as the cache in test
+* Fix OCI conformance workflow report and README badge ([#3442](https://github.com/distribution/distribution/pull/3442))
+  * [`351b2607`](https://github.com/distribution/distribution/commit/351b2607746380446f7fb8c5c60785bed9318764) Fix OCI conformance workflow report and README badge
+* Make GH workflows job names unique ([#3448](https://github.com/distribution/distribution/pull/3448))
+  * [`21ffbdbe`](https://github.com/distribution/distribution/commit/21ffbdbedd6eab104ceafa1d4741555763260212) Change GH workflows job names
+* Fixing http status for PUT/PATCH APIs ([#3444](https://github.com/distribution/distribution/pull/3444))
+  * [`9c7967a3`](https://github.com/distribution/distribution/commit/9c7967a32dae63b6ba27bfa5bb994e4c8929335b) Update PUT and PATCH APIs
+  * [`3f09e31e`](https://github.com/distribution/distribution/commit/3f09e31ea6fca88cad609267e7f3beb9fe43feda) Fixing http status for PUT/PATCH APIs
+* OCI: add conformance test github action ([#3382](https://github.com/distribution/distribution/pull/3382))
+  * [`aaca79bf`](https://github.com/distribution/distribution/commit/aaca79bfcfd65fdd3ef9119456621c51f9c222f4) add oci conformance test gitaction
+* Fix html not rendering markdown link properly ([#3410](https://github.com/distribution/distribution/pull/3410))
+  * [`fefc0e2b`](https://github.com/distribution/distribution/commit/fefc0e2b243946b5887bb0ef5a6c8393a6748913) Fix html not rendering markdown link properly
+* typo: a client implementation ([#3435](https://github.com/distribution/distribution/pull/3435))
+  * [`7244cd3b`](https://github.com/distribution/distribution/commit/7244cd3bdfd07845f627392327788f5f53da60df) typo: a client implementation
+* fix the /v2/_catalog n parameter description ([#3425](https://github.com/distribution/distribution/pull/3425))
+  * [`24e1ea0b`](https://github.com/distribution/distribution/commit/24e1ea0b939e6a647e148dcf84996ccd15739e3d) Merge branch 'patch-1' of github.com:lostsquirrel/distribution into patch-1
+  * [`933ee1fd`](https://github.com/distribution/distribution/commit/933ee1fd43aa9bbf39ddf9ac567f2d4082928190) fix the /v2/_catalog n parameter description
+  * [`6d9a3aba`](https://github.com/distribution/distribution/commit/6d9a3aba0453f5237ae4aa93177e749148b14652) fix the /v2/_catalog n parameter description
+* Update distribution logo ([#3434](https://github.com/distribution/distribution/pull/3434))
+  * [`8f211541`](https://github.com/distribution/distribution/commit/8f211541fad3753289175055ffb439e42b275ce6) Update link to logo
+  * [`9b8feef0`](https://github.com/distribution/distribution/commit/9b8feef026da5008689988468e5b63678efb1cda) Update distribution logo
+* Update API spec ([#3432](https://github.com/distribution/distribution/pull/3432))
+  * [`56413091`](https://github.com/distribution/distribution/commit/56413091129c20884db55d5506973cbff8db84e9) Update API spec
+* Add tag delete API ([#3427](https://github.com/distribution/distribution/pull/3427))
+  * [`033683d6`](https://github.com/distribution/distribution/commit/033683d629401c4cbe9f3f44239982bf2a743672) apply feedback
+  * [`81f081f9`](https://github.com/distribution/distribution/commit/81f081f91b1cf1c3c1375cf225de8ee05b00fb6b) Group case values
+  * [`1398d3b5`](https://github.com/distribution/distribution/commit/1398d3b5c6cc2e5162b21c2f7319972035df2edf) Remove unrelated spec update
+  * [`22053f57`](https://github.com/distribution/distribution/commit/22053f57b0580cb8eedbb105440aa625f0afdc7e) Fix listener tests
+  * [`6ae6df7d`](https://github.com/distribution/distribution/commit/6ae6df7d75aec4f40a8d22bc1d2ff4b0908bc9c8) Add tag delete API
+* Add tests for tags list pagination ([#3422](https://github.com/distribution/distribution/pull/3422))
+  * [`8ef268df`](https://github.com/distribution/distribution/commit/8ef268df251364fa907e025bdd8c1b731ba8f1a9) Add tests for tags list pagination
+* OCI: Add pagination on `/v2/<name>/tags/list` ([#3143](https://github.com/distribution/distribution/pull/3143))
+  * [`9cf39997`](https://github.com/distribution/distribution/commit/9cf39997afbfde59cd04801b8fd1dcd37144ed3d) added pagination error to api docs
+  * [`4da2712b`](https://github.com/distribution/distribution/commit/4da2712b527a170d15ed4c6e7bd63c3d47ff3cf3) added pagination to `v2/<name>/tags/list` endpoint
+  * [`febc8733`](https://github.com/distribution/distribution/commit/febc8733d2c4fce9d9d50105d8ccd6ce001c9444) added error codes for pagination
+* FOSSA scan enabled ([#3396](https://github.com/distribution/distribution/pull/3396))
+  * [`df39a779`](https://github.com/distribution/distribution/commit/df39a779dd343751c3aa845c9eac8e3dfdbe1abc) FOSSA scan enabled
+* add documentation how to access pull-through proxy stats ([#3415](https://github.com/distribution/distribution/pull/3415))
+  * [`09334b5e`](https://github.com/distribution/distribution/commit/09334b5e3b41df4c16569190642456664464e82c) fix typo
+  * [`8e8d5099`](https://github.com/distribution/distribution/commit/8e8d50995879bb7c495ac8ab0c833ceca7728e94) add documentation how to access pull-through proxy stats
+* OCI: add content range handling in patch blob ([#3227](https://github.com/distribution/distribution/pull/3227))
+  * [`d7a2b144`](https://github.com/distribution/distribution/commit/d7a2b14489cacf30b996700a7e0c8f555f0804e0) add content range handling in patch blob
+* OCI: verify digest and check blob presence when put manifest ([#3395](https://github.com/distribution/distribution/pull/3395))
+  * [`9e618c90`](https://github.com/distribution/distribution/commit/9e618c90c3544d38e722c5469bb774b548919f00) registry: verify digest and check blob presence when put manifest
+* Release ticker resources ([#3404](https://github.com/distribution/distribution/pull/3404))
+  * [`835651e5`](https://github.com/distribution/distribution/commit/835651e513c719cb94b8c5758ca0181590f8d23f) Release ticker resources
+* go.mod: gopkg.in/yaml.v2 v2.4.0, sirupsen/logrus v1.8.1 ([#3398](https://github.com/distribution/distribution/pull/3398))
+  * [`226ad1e6`](https://github.com/distribution/distribution/commit/226ad1e639b339be58afc301c76d2f35de05bb4f) go.mod: update logrus to v1.8.1
+  * [`06c8d441`](https://github.com/distribution/distribution/commit/06c8d441f8b7c69e3e05f69959da5cc2a680e6f5) go.mod: gopkg.in/yaml.v2 v2.4.0
+* Add configuration option for Redis TLS ([#3161](https://github.com/distribution/distribution/pull/3161))
+  * [`32ccbf19`](https://github.com/distribution/distribution/commit/32ccbf193d5016bd0908d2eb636333d3cca22534) Add configuration option for Redis TLS
+* close the io.ReadCloser from storage driver ([#3309](https://github.com/distribution/distribution/pull/3309))
+  * [`334a7e7f`](https://github.com/distribution/distribution/commit/334a7e7ff6e8ce161cc902be9400e26137ed2d06) close the io.ReadCloser from storage drive
+* Add docker image release workflow ([#3386](https://github.com/distribution/distribution/pull/3386))
+  * [`a0aad572`](https://github.com/distribution/distribution/commit/a0aad5720818a039a22b0099807beb06ef2174b0) Make workflow name shorter.
+  * [`23b57027`](https://github.com/distribution/distribution/commit/23b570272bd0582a6300ee951dd165a54978bd62) Add docker image release workflow
+* Add CodeQL Security Scanning ([#3341](https://github.com/distribution/distribution/pull/3341))
+  * [`62fc5c8a`](https://github.com/distribution/distribution/commit/62fc5c8a33294fcb6a5365570d64ed1c3585adf3) Remove autobuild
+  * [`a63bd4d3`](https://github.com/distribution/distribution/commit/a63bd4d3f19af17628770c18d942b62506932896) Add CodeQL Security Scanning
+* fix: disable DisableHTMLEscape on logrus json logging ([#3364](https://github.com/distribution/distribution/pull/3364))
+  * [`9c43ba9d`](https://github.com/distribution/distribution/commit/9c43ba9dcc3c812430daf6b2e163e9f41f5855de) fix: disable DisableHTMLEscape on logrus json logging
+* fix CI dependency error ([#3383](https://github.com/distribution/distribution/pull/3383))
+  * [`68ce1586`](https://github.com/distribution/distribution/commit/68ce15863a727f2bd030b9389bfae025b1a729d4) fix CI dependency error
+* Add code to handle pagination of parts. Fixes max layer size of 10GB bug ([#2815](https://github.com/distribution/distribution/pull/2815))
+  * [`bda79219`](https://github.com/distribution/distribution/commit/bda79219b2be81d8748499a00afb94bb5f67261d) Add code to handle pagination of parts. Fixes max layer size of 10GB bug
+* docs/spec/manifest-v2-2.md: fix ARM variant ([#3371](https://github.com/distribution/distribution/pull/3371))
+  * [`c432849e`](https://github.com/distribution/distribution/commit/c432849e44f960c95937e43cff2d010187f7cc0b) docs/spec/manifest-v2-2.md: fix ARM variant
+* log: Include configured fields in all logs ([#3136](https://github.com/distribution/distribution/pull/3136))
+  * [`43e50259`](https://github.com/distribution/distribution/commit/43e502590f60558ebf5567e0f59737e659539385) log: Include configured fields in all logs
+* Populate the platform information when calling the References() method of manifest list ([#2911](https://github.com/distribution/distribution/pull/2911))
+  * [`1a059fe7`](https://github.com/distribution/distribution/commit/1a059fe78d7fb9d7390a7cfd2ba34ce560553bce) Populate the platform information when calling the References() method of manifest list
+* Fix bug in parsing domain from repository reference ([#2979](https://github.com/distribution/distribution/pull/2979))
+  * [`a19e1847`](https://github.com/distribution/distribution/commit/a19e1847a3a815894bdc9ffdc064392c96fa38c6) Fix bug in parsing domain from repository reference
+* Add a basic e2e test for CI ([#3348](https://github.com/distribution/distribution/pull/3348))
+  * [`98868008`](https://github.com/distribution/distribution/commit/9886800868960a92007f29b499f1d519a449bc81) Add a basic e2e test for CI
+* manifests: Return UNSUPPORTED when deleting manifests by tag ([#3174](https://github.com/distribution/distribution/pull/3174))
+  * [`95f1eea5`](https://github.com/distribution/distribution/commit/95f1eea5f55e25cb5dc7b955862047836a79fd3f) manifests: Return UNSUPPORTED when deleting manifests by tag
+* Added flag for user configurable cipher suites ([#3169](https://github.com/distribution/distribution/pull/3169))
+  * [`1e625d00`](https://github.com/distribution/distribution/commit/1e625d007691e7786f8a2e94facd5baa81c97b88) Added flag for user configurable cipher suites
+* Bump Golang to `1.15`. ([#3222](https://github.com/distribution/distribution/pull/3222))
+  * [`49f7426d`](https://github.com/distribution/distribution/commit/49f7426dcb82ed7ed0c0460fe881c66df53d82b7) Bump Golang to `1.15` and Alpine to `3.12`.
+* Upgrade Logstash hook for Logrus to `1.0.0`. ([#3240](https://github.com/distribution/distribution/pull/3240))
+  * [`907e7be5`](https://github.com/distribution/distribution/commit/907e7be5450b10a9ebb9270adb7ac9ba5d6a9909) Bump Logstash hook for logrus to `v1.0.0`.
+* Add Codecov badge ([#3362](https://github.com/distribution/distribution/pull/3362))
+  * [`c95293bb`](https://github.com/distribution/distribution/commit/c95293bbdf78ddacb2a06e0df6e7829584cd1711) Add Codecov badge
+* go.mod: change imports to github.com/distribution/distribution/v3 ([#3225](https://github.com/distribution/distribution/pull/3225))
+  * [`1d338749`](https://github.com/distribution/distribution/commit/1d33874951b749df7e070b1c702ea418bbc57ed1) go.mod: change imports to github.com/distribution/distribution/v3
+* Relax filesystem driver folder permissions to 0777 (cont) ([#3204](https://github.com/distribution/distribution/pull/3204))
+  * [`2672c0eb`](https://github.com/distribution/distribution/commit/2672c0ebe2900bc1df1622a2ae4f36c61bac35e8) Relax filesystem driver folder permissions to 0777 (cont)
+* Update repo normalize error message to include the name of the repo. ([#3265](https://github.com/distribution/distribution/pull/3265))
+  * [`c26fa61e`](https://github.com/distribution/distribution/commit/c26fa61ec9234e3b52181c6d6dc1204f6713329f) Update repo normalize error message to include the name of the repo.
+* Fix minor spelling mistakes ([#3300](https://github.com/distribution/distribution/pull/3300))
+  * [`4d34a317`](https://github.com/distribution/distribution/commit/4d34a31762cea5780ddbe53b5f9dfed06a1777bb) Correct spelling: decription -> description
+  * [`084c0bd1`](https://github.com/distribution/distribution/commit/084c0bd1006fc1d985261ec99132d5b3da420d1b) Fix typo in docu of NewURLBuilderFromString()
+  * [`f0c93f65`](https://github.com/distribution/distribution/commit/f0c93f65a2c6c509a961245fba9cdf6281bdfeff) Fix typo in NewSimpleManager() documentation
+* scripts: remove unused md2man from dev-tools ([#3229](https://github.com/distribution/distribution/pull/3229))
+  * [`1cee02e7`](https://github.com/distribution/distribution/commit/1cee02e7aeebfd9c13c8c47085a0a14aa909600a) scripts: remove unused md2man from dev-tools
+* Update README a bit ([#3305](https://github.com/distribution/distribution/pull/3305))
+  * [`911eaf03`](https://github.com/distribution/distribution/commit/911eaf03e7732cbe75eff74520ddd61f3d4762d5) Update README a bit
+* get rid of apache2-utils ([#3146](https://github.com/distribution/distribution/pull/3146))
+  * [`fa289406`](https://github.com/distribution/distribution/commit/fa2894067c0c232e3de88fbc1edea0f4d4a6e3c2) get rid of apache2-utils
+* Honor contexts passed to registry client methods ([#2905](https://github.com/distribution/distribution/pull/2905))
+  * [`15f7bd29`](https://github.com/distribution/distribution/commit/15f7bd29a50d24a1ed1e5ca00be38ee12d90b091) Remove {get,head}WithContext()
+  * [`282351e9`](https://github.com/distribution/distribution/commit/282351e95434d62c5c16fc62c4b1d9d67ce56f7e) Use http.NewRequestWithContext()
+  * [`58331abf`](https://github.com/distribution/distribution/commit/58331abf588d0c7c31f36d5723d8a48c39dbaf56) Honor contexts passed to registry client methods
+* Fix typo for image digest regular expression in spec ([#3244](https://github.com/distribution/distribution/pull/3244))
+  * [`639de6a0`](https://github.com/distribution/distribution/commit/639de6a02fc25a68afb68ee1787dd83621e73178) Fix typo for digest regexp
+* Upgrade Gorilla Handlers to `1.5.1`. ([#3242](https://github.com/distribution/distribution/pull/3242))
+  * [`03aaf6ab`](https://github.com/distribution/distribution/commit/03aaf6ab51117e99b4f53fb0db84e1a5348892c9) Bump Gorilla Handlers to `v1.5.1`.
+* Clarify repo name regex intention ([#3201](https://github.com/distribution/distribution/pull/3201))
+  * [`32c77af6`](https://github.com/distribution/distribution/commit/32c77af6ac94ba4e34fc9aaa784c6ca69c114cf0) Clarify repo name regex intention
+* Update README badges ([#3352](https://github.com/distribution/distribution/pull/3352))
+  * [`5a3f698f`](https://github.com/distribution/distribution/commit/5a3f698f87d9918c77284b55a85300a4c6490654) Change Build Status badge URL
+  * [`6e4e8298`](https://github.com/distribution/distribution/commit/6e4e8298deeafcf6ee772e8255f91ba0072f06ac) Update README badges
+* Propose two maintainers from Mirantis ([#3353](https://github.com/distribution/distribution/pull/3353))
+  * [`0517a1c7`](https://github.com/distribution/distribution/commit/0517a1c77992153fe7c607cedabfc0a604fc7327) Propose two maintainers from Mirantis
+* Removing Travis ([#3350](https://github.com/distribution/distribution/pull/3350))
+  * [`bddb8d42`](https://github.com/distribution/distribution/commit/bddb8d42eae598566abd6d0fa6f32dcce33cbf41) Removing travis
+  * [`edf4afcb`](https://github.com/distribution/distribution/commit/edf4afcbeb3511452fe4835f2bcffe8110055b82) Revert "Merge branch 'main' of https://github.com/distribution/distribution into main"
+  * [`1100e30e`](https://github.com/distribution/distribution/commit/1100e30e1c99e11de64ab93737f6f97be48d525c) Merge branch 'main' of https://github.com/distribution/distribution into main
+* Update slack channel to CNCF slack ([#3343](https://github.com/distribution/distribution/pull/3343))
+  * [`b431b34f`](https://github.com/distribution/distribution/commit/b431b34fb8b6b91196feef683da67aeb499b3342) update slack channel to CNCF slack
+* Fixing push workflow ([#3344](https://github.com/distribution/distribution/pull/3344))
+  * [`402d3c94`](https://github.com/distribution/distribution/commit/402d3c943a1a3fb55855730cbde9cb4587d67541) Fixing push workflow
+  * [`b659eb06`](https://github.com/distribution/distribution/commit/b659eb060f7734e2b78a2cec91f5b3e62ace2006) Update ci.yml
+  * [`da9a88bc`](https://github.com/distribution/distribution/commit/da9a88bc97a8a64fde48b3defc8efcee5e9f4f01) Fixing push workflow
+* Adding first draft of CI on GitHub Actions ([#3338](https://github.com/distribution/distribution/pull/3338))
+  * [`64874d17`](https://github.com/distribution/distribution/commit/64874d17b18b53aeaf9eae3a66b5d22ce2a1d332) First draft of actions based ci
+* Adding Steve Lasker as a maintainer ([#3337](https://github.com/distribution/distribution/pull/3337))
+  * [`239c368f`](https://github.com/distribution/distribution/commit/239c368ff61d9d355111a2f78a0a88694f1e5a19) Per distribution call, adding Steve Lasker as a maintainer to help with OCI and Notary collaboration.
+* Replace Arko with Milos as a maintainer ([#3335](https://github.com/distribution/distribution/pull/3335))
+  * [`c30c5b31`](https://github.com/distribution/distribution/commit/c30c5b31b52172bd101a7ccf85902bcf892d6375) Replace Arko with Milos as a maintainer
+* Update roadmap ([#3334](https://github.com/distribution/distribution/pull/3334))
+  * [`67c504de`](https://github.com/distribution/distribution/commit/67c504de8b42a62ee2855d939c48a076c7f54770) Update roadmap, add code of conduct file
+* Dummy workflow to enable GitHub Actions ([#3314](https://github.com/distribution/distribution/pull/3314))
+  * [`07b948ea`](https://github.com/distribution/distribution/commit/07b948ea67b41052a302ace0248b59072cdb575b) Dummy workflow to enable GitHub Actions
+* Ignore self reference object on empty prefix ([#3302](https://github.com/distribution/distribution/pull/3302))
+  * [`87cbd09f`](https://github.com/distribution/distribution/commit/87cbd09fa7ffbdc1b8eb2ab5098a5e91e815c216) Ignore self reference object on empty prefix
+* Add Adopters ([#3306](https://github.com/distribution/distribution/pull/3306))
+  * [`2d16db2a`](https://github.com/distribution/distribution/commit/2d16db2ae7b8322904b8fb50a6a6fa1448e1884f) Add Adopters
+* Add new maintainers ([#3303](https://github.com/distribution/distribution/pull/3303))
+  * [`d11c4f9a`](https://github.com/distribution/distribution/commit/d11c4f9adea598f4288b9d880efa5c5044d6a2bb) Add new maintainers
+* #3288 Remove empty Content-Type header ([#3289](https://github.com/distribution/distribution/pull/3289))
+  * [`c8d90f90`](https://github.com/distribution/distribution/commit/c8d90f904f1e86e7aa5fa2baa76c40c1b60c3a3c) Remove empty Content-Type header
+* Upgrade Gorilla Mux to `1.8.0`. ([#3237](https://github.com/distribution/distribution/pull/3237))
+  * [`545596ae`](https://github.com/distribution/distribution/commit/545596ae2cbfb91dfe6e79afdc7259d0731a5052) Bump Gorilla Mux to `v1.8.0`.
+* Upgrade Redigo to `1.8.2`. ([#3239](https://github.com/distribution/distribution/pull/3239))
+  * [`264e26fd`](https://github.com/distribution/distribution/commit/264e26fd8cd42d81bf005514955776e3680c815e) Bump Redigo to `v1.8.2`.
+* Reopen PR #2973 (Support ECS TaskRole in S3 storage driver). ([#3245](https://github.com/distribution/distribution/pull/3245))
+  * [`34f13226`](https://github.com/distribution/distribution/commit/34f1322664a723138f489f2df21b51831de35759) Fix hardcoded credential provides.
+* Support ECS TaskRole in S3 storage driver ([#2973](https://github.com/distribution/distribution/pull/2973))
+  * [`9690d843`](https://github.com/distribution/distribution/commit/9690d843fa153973c16f6c86fe9bce3f2421f9ce) Support ECS TaskRole in S3 storage driver
+* Update logrus to v1.6.0, fixes #3223 ([#3224](https://github.com/distribution/distribution/pull/3224))
+  * [`9466dd4e`](https://github.com/distribution/distribution/commit/9466dd4e5a05dbe62c6720affda04af73f40cc5f) Update logrus to v1.6.0
+* vendor: opencontainers/go-digest v1.0.0 ([#3226](https://github.com/distribution/distribution/pull/3226))
+  * [`8a8d9152`](https://github.com/distribution/distribution/commit/8a8d91529d05e9ce9d1af4e99008c48c25712ad6) vendor: opencontainers/go-digest v1.0.0
+* Bump AWS SDK ([#3118](https://github.com/distribution/distribution/pull/3118))
+  * [`e1464fd3`](https://github.com/distribution/distribution/commit/e1464fd3172be169bfaf5f2f16479568c7f0f024) Bump AWS SDK
+* catalog: List repositories with no unique layers ([#3173](https://github.com/distribution/distribution/pull/3173))
+  * [`a784441b`](https://github.com/distribution/distribution/commit/a784441b6222bcf5e66feb0062d135dcc72dc9ee) catalog: List repositories with no unique layers
+* Add s390x support for travis ([#3140](https://github.com/distribution/distribution/pull/3140))
+  * [`a2ed1b5e`](https://github.com/distribution/distribution/commit/a2ed1b5e80d0a5d15bef9c58cfe1bbfae9b23bdb) Added dist: bionic, updated go version to 1.14.x and set GO111MODULE=on
+  * [`55f88c35`](https://github.com/distribution/distribution/commit/55f88c35b9f1bafe90b8fe0088748bc1b56d037b) Adding s390x support.
+* clean up code because err is always nil ([#3209](https://github.com/distribution/distribution/pull/3209))
+  * [`f361d443`](https://github.com/distribution/distribution/commit/f361d443b7d4e77a3da22112b5ab6426bec4f6f4) clean up code because err is always nil
+* docs: add redirect for old URL ([#3196](https://github.com/distribution/distribution/pull/3196))
+  * [`7728c5e4`](https://github.com/distribution/distribution/commit/7728c5e44534819a9adee2a1b54cb74f829ded3a) docs: add redirect for old URL
+* Fix CI failures, upgrade to Go 1.14+ ([#3187](https://github.com/distribution/distribution/pull/3187))
+  * [`81ba770e`](https://github.com/distribution/distribution/commit/81ba770effcdebec174a8a330a85e34622410641) Fix CI failures, upgrade to Go 1.14+
+* Fix err shadowing in gcs driver ([#3127](https://github.com/distribution/distribution/pull/3127))
+  * [`cdb4ba94`](https://github.com/distribution/distribution/commit/cdb4ba947a544623f8d47d43f9fda9cdabd6e6c5) Fix err shadowing in gcs driver
+* Fix gosimple checks ([#3128](https://github.com/distribution/distribution/pull/3128))
+  * [`78c2ab66`](https://github.com/distribution/distribution/commit/78c2ab66464a1f6e713975d727a3df814d799070) Fix gosimple checks
+* Update oci library ([#3121](https://github.com/distribution/distribution/pull/3121))
+  * [`bf56f348`](https://github.com/distribution/distribution/commit/bf56f348be647ad19c8204b18f0146be40db53dc) Update oci library
+* Redis cache fixes and metrics ([#3113](https://github.com/distribution/distribution/pull/3113))
+  * [`be29c05a`](https://github.com/distribution/distribution/commit/be29c05a1e82b084f2227596223df8254840c9a1) Remove deprecated cache metrics code
+  * [`495a4af7`](https://github.com/distribution/distribution/commit/495a4af7cf597f564abe98ba46d2c7a841899c7e) Fix goimports
+  * [`74d442a0`](https://github.com/distribution/distribution/commit/74d442a058a9c83cc01a74565e50b5c79b23815a) Consider redis.ErrNil as distribution.ErrBlobUnknown for Stat HGET
+  * [`79589266`](https://github.com/distribution/distribution/commit/795892662b69d79c730d1f9028314ac081cfe5af) redis metrics
+  * [`ce101280`](https://github.com/distribution/distribution/commit/ce101280fe93f446650d8dddb7e9d992fdbf467e) fix redis caching issue
+  * [`4c7c63b5`](https://github.com/distribution/distribution/commit/4c7c63b5575f1418ee41a4fcf3438a17149f5f93) Add cache unit test
+* Update reporting issues guidelines ([#3111](https://github.com/distribution/distribution/pull/3111))
+  * [`db3c418a`](https://github.com/distribution/distribution/commit/db3c418ada13a7a28dca6cbe6c7ab8f500c83a68) Update reporting issues guidelines
+* Use go-events package ([#2550](https://github.com/distribution/distribution/pull/2550))
+  * [`800cb958`](https://github.com/distribution/distribution/commit/800cb95821017a06634752e82085a5e78aae6d5a) Use go-events package
+* vendor: update docker/go-metrics v0.0.1 ([#3080](https://github.com/distribution/distribution/pull/3080))
+  * [`98dcc519`](https://github.com/distribution/distribution/commit/98dcc5195e17fd94d1539abe1240a938f516871e) vendor: update docker/go-metrics v0.0.1
+* Update governance and maintainers ([#3110](https://github.com/distribution/distribution/pull/3110))
+  * [`1e25ecef`](https://github.com/distribution/distribution/commit/1e25ecefe4c5e45ffdc5f147e2f7eb885a930970) Update governance and maintainers
+* Increase Unit Test Code Coverage ([#2272](https://github.com/distribution/distribution/pull/2272))
+  * [`e65b3f13`](https://github.com/distribution/distribution/commit/e65b3f131620453976ff53d0a76e231854f57a61) Fix CI for test updates
+  * [`efdba4f2`](https://github.com/distribution/distribution/commit/efdba4f21039c31a359fb07d8dd4979f4254e9f0) Increase Unit Test Code Coverage
+* Update readme and contributing docs ([#3071](https://github.com/distribution/distribution/pull/3071))
+  * [`f5e84a49`](https://github.com/distribution/distribution/commit/f5e84a4939e851b08af1a694c82af8e6a4cb71bf) Update readme and contributing docs
+* Update Golang 1.13.8 ([#3105](https://github.com/distribution/distribution/pull/3105))
+  * [`1f77c9a5`](https://github.com/distribution/distribution/commit/1f77c9a57f41079d47f65e061e95680711e91e5b) Update Golang 1.13.8
+* Fix typo cloudfront updatefrenquency ([#3020](https://github.com/distribution/distribution/pull/3020))
+  * [`0f5e2753`](https://github.com/distribution/distribution/commit/0f5e2753a60113ac7d6b9d30beb8f610f5b31f63) Fix typo cloudfront updatefrenquency
+* Fix the pointer initialization ([#2446](https://github.com/distribution/distribution/pull/2446))
+  * [`e6983745`](https://github.com/distribution/distribution/commit/e69837454adaffbcadfb11bb795db496a0cbb4ad) Add tests for configuration parser
+  * [`c9eba1a5`](https://github.com/distribution/distribution/commit/c9eba1a5bb737c9b2b5d793f6e5ceda9b976d9b1) Fix the pointer initialization
+* Update Golang 1.13.7, golang.org/x/crypto (CVE-2020-0601, CVE-2020-7919) ([#3089](https://github.com/distribution/distribution/pull/3089))
+  * [`9b6a0190`](https://github.com/distribution/distribution/commit/9b6a019081d1c4e7807ef4e85f1d119f1734a3d2) prevent dev-tools from updating go.mod
+  * [`7e290869`](https://github.com/distribution/distribution/commit/7e290869e71a65e5da34a3b5e544869446a4872f) vendor: update golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d (CVE-2020-7919)
+  * [`01654953`](https://github.com/distribution/distribution/commit/016549532f29fad544bf554fc8ae6c710e20b785) Dockerfile: use alpine 3.11
+  * [`974375f6`](https://github.com/distribution/distribution/commit/974375f66c5ad9336b17521f3ba641dfefd562bc) re-vendor with go 1.13
+  * [`4ae059c7`](https://github.com/distribution/distribution/commit/4ae059c714cb50a20a750a2d1863a048459e46a8) Update Golang 1.13.7 (CVE-2020-0601, CVE-2020-7919)
+* [master] Use same env var in Dockerfile and Makefile ([#3086](https://github.com/distribution/distribution/pull/3086))
+  * [`23f6bdd7`](https://github.com/distribution/distribution/commit/23f6bdd743fca081a1c0ba0e6ae4c0223c24e0f2) Use same env var in Dockerfile and Makefile
+* Migrate to golangci-lint ([#3023](https://github.com/distribution/distribution/pull/3023))
+  * [`66809646`](https://github.com/distribution/distribution/commit/66809646d94148c864ca6be883c63665fd259e12) Migrate to golangci-lint
+* Fix TestRegistryAsCacheMutationAPIs ([#3072](https://github.com/distribution/distribution/pull/3072))
+  * [`6ca7b9e9`](https://github.com/distribution/distribution/commit/6ca7b9e9fa5d60cf5174d0e6d260711a6e10fae7) Fix TestRegistryAsCacheMutationAPIs
+* make it possible to wrap the client transport in another one ([#2985](https://github.com/distribution/distribution/pull/2985))
+  * [`c486db2d`](https://github.com/distribution/distribution/commit/c486db2d715fd509b4d2a102337283350c7f1394) make it possible to wrap the client transport in another one
+* bump golang to 1.13.4 ([#3050](https://github.com/distribution/distribution/pull/3050))
+  * [`070cc010`](https://github.com/distribution/distribution/commit/070cc010f71230058859a6891cdeec2f429049f4) bump golang to 1.13.4
+* Fixing broken table ([#3053](https://github.com/distribution/distribution/pull/3053))
+  * [`b4694b0d`](https://github.com/distribution/distribution/commit/b4694b0d2d3ce79e70143a50920a9e629e85c536) Fixing broken table
+* Add pathspec for repo _layers directory and allow Repository.BlobStore to enumerate over blobs ([#3061](https://github.com/distribution/distribution/pull/3061))
+  * [`c9c33243`](https://github.com/distribution/distribution/commit/c9c33243002bc0a91aedb89d022bd5a6fd79ebe6) Add unit tests for BlobEnumerator
+  * [`5538da49`](https://github.com/distribution/distribution/commit/5538da49234f2dbdcf2495a90ea55006508a4b70) fixes to make layersPathSpec work
+  * [`fa7d9494`](https://github.com/distribution/distribution/commit/fa7d94940821080f25fb5442cebbdc01f6a691ba) allow Repository.BlobStore to enumerate over blobs
+  * [`cf771137`](https://github.com/distribution/distribution/commit/cf771137959253c7461275630c56a751fe24a231) add pathspec for repo _layers directory
+*  use latest version of alpine when building the Docker container ([#2991](https://github.com/distribution/distribution/pull/2991))
+  * [`a994bb83`](https://github.com/distribution/distribution/commit/a994bb839dfded39435fcdd2651d2afdb2a305b9) use latest version of alpine when building the Docker container
+* API to retrive tag's digests ([#2748](https://github.com/distribution/distribution/pull/2748))
+  * [`1251e51a`](https://github.com/distribution/distribution/commit/1251e51ad0d8bf24517010a259b8f56c31a60fb6) better name and updated tests
+  * [`9ebf151a`](https://github.com/distribution/distribution/commit/9ebf151ac2f72eaa597728390e10714cb99661a4) API to retrive tag's digests
+* use travis, not circle, build badge ([#3003](https://github.com/distribution/distribution/pull/3003))
+  * [`cc97b94f`](https://github.com/distribution/distribution/commit/cc97b94f5d826855899b6be3dc8f1adf971f4cea) use travis, not circle, build badge
+* registry: Fix typo in RepositoryRemover warning ([#2984](https://github.com/distribution/distribution/pull/2984))
+  * [`1c481d34`](https://github.com/distribution/distribution/commit/1c481d34d9b77b47273152cd19f70e26aabd952f) registry: Fix typo in RepositoryRemover warning
+* Test httpBlobUpload.Write method ([#2918](https://github.com/distribution/distribution/pull/2918))
+  * [`898b1f2a`](https://github.com/distribution/distribution/commit/898b1f2a5335f7bb5e2460b51d9ad490cf9eda79) test httpBlobUpload.Write method
+* Adding deprecated schema instructions ([#3000](https://github.com/distribution/distribution/pull/3000))
+  * [`07a50201`](https://github.com/distribution/distribution/commit/07a50201c959912907af2162a8f7cc284856c009) Adding deprecated schema instructions
+* swift: correct segment path generation ([#2950](https://github.com/distribution/distribution/pull/2950))
+  * [`b23dd1ef`](https://github.com/distribution/distribution/commit/b23dd1ef3742299a0d041086af4636815230332f) swift: correct segment path generation
+* allow for VERSION and REVISION to be passed in during docker builds ([#2955](https://github.com/distribution/distribution/pull/2955))
+  * [`92d213d2`](https://github.com/distribution/distribution/commit/92d213d2c1ab36260c9f19e29459980d2629cbe6) allow for VERSION and REVISION to be passed in during docker builds
+* Implement Repository Blobs upload resuming ([#2917](https://github.com/distribution/distribution/pull/2917))
+  * [`dd3bdee2`](https://github.com/distribution/distribution/commit/dd3bdee21c9948e56ff5984294e2c87dd44850e1) implement Repository Blobs upload resuming
+* Update the versions of several dependencies ([#2947](https://github.com/distribution/distribution/pull/2947))
+  * [`afe29bb6`](https://github.com/distribution/distribution/commit/afe29bb697cc160f21eb4384ed3f9aca13f1ceaa) update the golang compiler version and the versions of several dependencies
+* Add notification metrics ([#2522](https://github.com/distribution/distribution/pull/2522))
+  * [`92a64367`](https://github.com/distribution/distribution/commit/92a6436714be6438f1cc8e4490a0c638868881e9) rename the metrics label
+  * [`d5a615b8`](https://github.com/distribution/distribution/commit/d5a615b8c9a469c88bebec7294d0ae0c9931773a) update the event number
+  * [`09a63caa`](https://github.com/distribution/distribution/commit/09a63caa37ca9ad7b16b99d4806b82482ec796b5) run go fmt and goimports
+  * [`228bafca`](https://github.com/distribution/distribution/commit/228bafca0b419d16e50704d25d13b7d6a07c3925) run go fmt
+  * [`76da6290`](https://github.com/distribution/distribution/commit/76da6290b0b99d6d6ce635424426e7803edb4303) add label to the metrics
+  * [`8b706168`](https://github.com/distribution/distribution/commit/8b706168467e9352e0c567633c3c264a340de79d) Add notification metrics
+* Implement Repository ServeBlob ([#2921](https://github.com/distribution/distribution/pull/2921))
+  * [`c5d5f938`](https://github.com/distribution/distribution/commit/c5d5f938e3b069dbf3487e64c9d567bf9910f23b) fast-stop ServeBlob if we're doing a HEAD request
+  * [`3800c47f`](https://github.com/distribution/distribution/commit/3800c47fd21fa2df9fbcc2ca9e55d7870711bad4) Implement Repository ServeBlob
+* Handle Blob Create when the underlying registry doesn't provide 'Docker-Upload-UUID' ([#2927](https://github.com/distribution/distribution/pull/2927))
+  * [`a45e5cb1`](https://github.com/distribution/distribution/commit/a45e5cb13f9e2ecd3ec9408af674fe77b050d81e) handle create blob if the uuid couldn't be retrieved from headers or URL
+  * [`8b31a894`](https://github.com/distribution/distribution/commit/8b31a894bd44048dc8b88b255d68fa134184f819) deduce blob UUID from location if it wasn't provided in the headers
+* Extract blob upload resume into its own method ([#2930](https://github.com/distribution/distribution/pull/2930))
+  * [`94097512`](https://github.com/distribution/distribution/commit/94097512db140a5726bf92cee8b2327e4de320c5) extract blob upload resume into its own method
+* use latest version of alpine when building the Docker container ([#2946](https://github.com/distribution/distribution/pull/2946))
+  * [`45b2d049`](https://github.com/distribution/distribution/commit/45b2d0498d1a8beb8b41c61954270299f20d2dcf) use latest version of alpine when building the Docker container
+* fix no error returned in fetchTokenWithOAuth ([#2900](https://github.com/distribution/distribution/pull/2900))
+  * [`5afbf324`](https://github.com/distribution/distribution/commit/5afbf324000f8c9675ef02b9a7f88948f0c82a0e) fix no error returned in fetchTokenWithOAuth
+* Append the written bytes to the blob writer's size ([#2920](https://github.com/distribution/distribution/pull/2920))
+  * [`0e2d080a`](https://github.com/distribution/distribution/commit/0e2d080a8a86f64e2260ec8a1047b3a1a4916872) append the written bytes to the blob writer's size
+* change default Dockerfile to install ssl utils ([#2809](https://github.com/distribution/distribution/pull/2809))
+  * [`7df881dc`](https://github.com/distribution/distribution/commit/7df881dcbe5f220d9080dc98ff9cfd258932edf6) change default Dockerfile to install ssl utils
+* Fixes #2835 Process Accept header MIME types in case-insensitive way ([#2861](https://github.com/distribution/distribution/pull/2861))
+  * [`a683c7c2`](https://github.com/distribution/distribution/commit/a683c7c235e12a0dd0f03b64f8c41f06e1bd23bc) Fixes #2835 Process Accept header MIME types in case-insensitive way
+* Fix s3 driver for supporting ceph radosgw ([#2879](https://github.com/distribution/distribution/pull/2879))
+  * [`c18c6c33`](https://github.com/distribution/distribution/commit/c18c6c33b24010b3bfd3c49539f44c49681b4981) S3 Driver: added comment for missing KeyCount workaround
+  * [`f8777265`](https://github.com/distribution/distribution/commit/f87772650309d03049310dd7d623449554a10147) Fix s3 driver for supporting ceph radosgw
+* Fix typo: offest -> offset ([#2894](https://github.com/distribution/distribution/pull/2894))
+  * [`74f429a5`](https://github.com/distribution/distribution/commit/74f429a5ad400894cd0a9cf96a6204696887b37a) Fix typo: offest -> offset
+* migrate to go modules from vndr ([#2941](https://github.com/distribution/distribution/pull/2941))
+  * [`5223c274`](https://github.com/distribution/distribution/commit/5223c27422cc2c40901fe7e08053e3648b9b3300) migrate to go modules from vndr
+* replace rsc.io/letsencrypt in favour of golang.org/x/crypto ([#2926](https://github.com/distribution/distribution/pull/2926))
+  * [`8f9c8094`](https://github.com/distribution/distribution/commit/8f9c8094fbe639e6b4e56e5c574932e629b145ef) replace rsc.io/letsencrypt in favour of golang.org/x/crypto
+* support Alibaba Cloud CDN storage middleware ([#2849](https://github.com/distribution/distribution/pull/2849))
+  * [`51bb5cee`](https://github.com/distribution/distribution/commit/51bb5cee5b6ad10b0c7856164e7fce0823eb8374) import alicdn package
+  * [`fd77cf43`](https://github.com/distribution/distribution/commit/fd77cf43a6920459c59bb7d5df4e2bdd0e2159f9) change package name & format document
+  * [`3390f32a`](https://github.com/distribution/distribution/commit/3390f32aecd35b9c17eb110c9327f175048a5580) fix Context issue
+  * [`ae91d1f4`](https://github.com/distribution/distribution/commit/ae91d1f429a2006ce21b4419a3f15b52592ee4da) fix ci issue
+  * [`6e10631d`](https://github.com/distribution/distribution/commit/6e10631d9c8b28038468c9759df2cde15fc4b674) fix default cdn auth duration
+  * [`bbc9885a`](https://github.com/distribution/distribution/commit/bbc9885aa216988e7a3332f9da197933de2849e3) fix func name
+  * [`3aa2a282`](https://github.com/distribution/distribution/commit/3aa2a282f76b7d1f71d28d602cfb4f81b1388b94) support alicdn middleware
+* Fix cloudfront middleware ([#2837](https://github.com/distribution/distribution/pull/2837))
+  * [`e1e72e95`](https://github.com/distribution/distribution/commit/e1e72e9563743afc1649b23a2f651a7c3caaf369) Fix cloudfront documentation formatting
+  * [`f9a05061`](https://github.com/distribution/distribution/commit/f9a05061916d095e95566d23e968608ee0576446) Bugfix: Make ipfilteredby not required
+* Log authorized username ([#2854](https://github.com/distribution/distribution/pull/2854))
+  * [`ec6566c0`](https://github.com/distribution/distribution/commit/ec6566c02b9c452d8e465ffa41c1c20117228917) Log authorized username
+* registry: fix binary JSON content-type ([#2813](https://github.com/distribution/distribution/pull/2813))
+  * [`15b02047`](https://github.com/distribution/distribution/commit/15b0204758876befc0664b64ccfb05f924627b2d) registry: fix binary JSON content-type
+* Fix gometalint errors ([#2840](https://github.com/distribution/distribution/pull/2840))
+  * [`48818fde`](https://github.com/distribution/distribution/commit/48818fdea7d7b8c34ed1e4284e638007ebc2e5d7) Remove err nil check
+  * [`da8db466`](https://github.com/distribution/distribution/commit/da8db4666b08431e701b044c9077648533d97b7e) Fix gometalint errors
+* Add reference. ParseDockerRef utility function ([#2786](https://github.com/distribution/distribution/pull/2786))
+  * [`0ac367fd`](https://github.com/distribution/distribution/commit/0ac367fd6bee057d404c405a298b4b7aedf301ec) Add reference.ParseDockerRef utility function
+* Support BYOK for OSS storage driver ([#2791](https://github.com/distribution/distribution/pull/2791))
+  * [`b7839211`](https://github.com/distribution/distribution/commit/b7839211af4fd038dbedcec1b06091ea02559a97) Update doc for BYOK support in OSS storage driver
+  * [`90bed671`](https://github.com/distribution/distribution/commit/90bed6712616f818479c40917dcd1bab0482346c) Support BYOK for OSS storage driver
+* Registry - make minimum TLS version user configurable ([#2808](https://github.com/distribution/distribution/pull/2808))
+  * [`cdb62b2b`](https://github.com/distribution/distribution/commit/cdb62b2b77775db037532daad2a9678d8fe5877c) Registry - make minimum TLS version user configurable
+* Add docs for autoredirect config parameter ([#2801](https://github.com/distribution/distribution/pull/2801))
+* default autoredirect to false ([#2800](https://github.com/distribution/distribution/pull/2800))
+  * [`eb1a2cd9`](https://github.com/distribution/distribution/commit/eb1a2cd911f28b21375914420d5a464f45d4bd02) default autoredirect to false
+</p>
+</details>
+
+
+### Contributors
+
+* Aaron Lehmann
+* Aaron Schlesinger
+* Adam Dobrawy
+* Adam Kaplan
+* Adam Wolfe Gordon
+* AdamKorcz
+* Adrian Plata
+* Adrien Duermael
+* Ahmet Alp Balkan
+* Aidan Hobson Sayers
+* Akihiro Suda
+* Aleksejs Sinicins
+* Alex
+* Alex Laties
+* Alexander Larsson
+* Alexander Morozov
+* Alexey Gladkov
+* Alfonso Acosta
+* Andreas Hassing
+* Andrew Bulford
+* Andrew Hsu
+* Andrew Lavery
+* Andrew Lively
+* Andrew T Nguyen
+* Andrews Medina
+* Andrey Kostov
+* Andrii Soldatenko
+* Andy Goldstein
+* Anian Z
+* Anil Belur
+* Anis Elleuch
+* Ankush Agarwal
+* Anne Henmi
+* Anton Tiurin
+* Antonio Murdaca
+* Antonio Ojea
+* Arien Holthuizen
+* Arko Dasgupta
+* Arnaud Porterie
+* Arthur Baars
+* Arthur Gautier
+* Aviral Takkar
+* Ben De St Paer-Gotch
+* Ben Emamian
+* Ben Kochie
+* Ben Manuel
+* Bhavin Gandhi
+* Bill
+* Bouke van der Bijl
+* Bracken Dawson
+* Brandon Mitchell
+* Brandon Philips
+* Brett Higgins
+* Brian Bland
+* Brian Goff
+* Caleb Spare
+* Cezar Sa Espinola
+* Chad Faragher
+* Chaos John
+* Cheng Zheng
+* Chris Aniszczyk
+* Chris K. Wong
+* Chris Patterson
+* Christopher Yeleighton
+* Chuanying Du
+* Collin Shoop
+* Cory Snider
+* CrazyMax
+* Daehyeok Mun
+* Damien Mathieu
+* Dan Fredell
+* Dan Walsh
+* Daniel Helfand
+* Daniel Menet
+* Daniel Mizyrycki
+* Daniel Nephin
+* Daniel, Dao Quang Minh
+* Danila Fominykh
+* Dave
+* Dave Trombley
+* David Calavera
+* David Justice
+* David Karlsson
+* David Lawrence
+* David Luu
+* David Mackey
+* David Wu
+* David van der Spek
+* Dawn W Docker
+* Denis Andrejew
+* Derek
+* Derek McGowan
+* Dimitar Kostadinov
+* Djibril Koné
+* Don Bowman
+* Don Kjer
+* Donald Huang
+* Doug Davis
+* E. M. Bray
+* Elliot Pahl
+* Emmanuel Briney
+* Eng Zer Jun
+* Eohyung Lee
+* Eric Windisch
+* Eric Yang
+* Erik Hollensbe
+* Etki
+* Eugene Lubarsky
+* Fabio Falci
+* Feng Honglin
+* Fernando Mayo Fernandez
+* Flavian Missi
+* Frederick F. Kautz IV
+* Gábor Lipták
+* Gabor Nagy
+* Gaetan
+* Geoffrey Hausheer
+* Giovanni Toraldo
+* Gladkov Alexey
+* Gleb M Borisov
+* Glyn Owen Hanmer
+* Grant Watters
+* Greg Rebholz
+* Guillaume J. Charmes
+* Guillaume Rose
+* Hayley Swimelar
+* HuKeping
+* Hua Wang
+* Igor Dolzhikov
+* Ihor Dvoretskyi
+* Ilion Beyst
+* Irene Diez
+* Ismail Alidzhikov
+* Jack Baines
+* Jack Griffin
+* Jacob Atzen
+* Jake Moshenko
+* Jakob Ackermann
+* Jakub Mikulas
+* James Hewitt
+* James Lal
+* Jeffrey van Gogh
+* Jeremy THERIN
+* Jesse Brown
+* Jessica Frazelle
+* Jessie Frazelle
+* Jim Galasyn
+* Joao Fernandes
+* João Pereira
+* Johan Euphrosine
+* John Howard
+* John Mulhausen
+* John Starks
+* Jon Poler
+* Jonas Hecht
+* Jonathan Lee
+* Jonathan Rudenberg
+* Jordan Liggitt
+* Jose D. Gomez R
+* Josh Chorlton
+* Josh Dolitsky
+* Josh Hawn
+* Josiah Kiehl
+* Joyce Brum
+* Julien Bordellier
+* Justas Brazauskas
+* Justin Cormack
+* Justin I. Nevill
+* Keerthan Mala
+* Ken Cochrane
+* Kenny Leung
+* Kevin Robatel
+* Kirat Singh
+* L-Hudson
+* Lachlan Cooper
+* Laura Brehm
+* Lei Jitang
+* Lenny Linux
+* Li Yi
+* Liam White
+* Littlemoon917
+* Liu Hua
+* Luca Bruno
+* Lucas França de Oliveira
+* Lucas Santos
+* MATSUMOTO TAKEAKI
+* Ma Shimiao
+* Makoto Oda
+* Manish Tomar
+* Marco Hennings
+* Maria Bermudez
+* Mark Sagi-Kazar
+* Matin Rahmanian
+* Matt Duch
+* Matt Moore
+* Matthew Balvanz
+* Matthew Riley
+* Maurice Sotzny
+* Meaglith Ma
+* Michael Bonfils
+* Michael Crosby
+* Michael Vetter
+* Michal Gebauer
+* Michal Guerquin
+* Michal Minar
+* Mike Lundy
+* Mike Truman
+* Milos Gajdos
+* Misty Stanley-Jones
+* Morgan Bauer
+* Muesli
+* Nan Monnand Deng
+* Nat Zimmermann
+* Naveed Jamil
+* Neil Wilson
+* Nicolas De Loof
+* Nikita Tarasov
+* Novak Ivanovski
+* Nuutti Kotivuori
+* Oleg Bulatov
+* Olivier Gambier
+* Oscar Caballero
+* Pascal Borreli
+* Patrick Devine
+* Patrick Easters
+* Paul Cacheux
+* Pavel Antonov
+* Paweł Gronowski
+* Per Lundberg
+* Peter Choi
+* Peter Dave Hello
+* Peter Kokot
+* Phil Estes
+* Philip Misiowiec
+* Pieter Scheffers
+* Qiang Huang
+* ROY
+* Radon Rosborough
+* Ricardo Maraschini
+* Richard Scothern
+* Rick Wieman
+* Rik Nijessen
+* Rober Morales-Chaparro
+* Robert Kaussow
+* Robert Steward
+* Roberto G. Hashioka
+* Rusty Conover
+* Ryan Abrams
+* Ryan Thomas
+* Sam Alba
+* Samuel Karp
+* Sean P. Kane
+* Sebastiaan van Stijn
+* Serge Dubrouski
+* Sevki Hasirci
+* Shawn Chen
+* Shengjing Zhu
+* Shiela M Parker
+* Shishir Mahajan
+* Silvin Lubecki
+* Simon
+* Simone Locci
+* Smasherr
+* Solomon Hykes
+* Sora Morimoto
+* Srini Brahmaroutu
+* Stefan Lörwald
+* Stefan Majewsky
+* Stefan Nica
+* Stefan Weil
+* Stephen J Day
+* Steve Lasker
+* Steven Hanna
+* Steven Taylor
+* Sylvain Baubeau
+* T N
+* Tariq Ibrahim
+* TaylorKanper
+* Ted Reed
+* Terin Stock
+* Thomas Berger
+* Tianon Gravi
+* Tibor Vass
+* Tiger Kaovilai
+* Tobias Fuhrimann
+* Tobias Schwab
+* Tom Hayward
+* Tom Hu
+* Tonis Tiigi
+* Tony Holdstock-Brown
+* Tosone
+* Trapier Marshall
+* Trevor Wood
+* Troels Thomsen
+* Usha Mandya
+* Vaidas Jablonskis
+* Vega Chou
+* Veres Lajos
+* Victor Vieux
+* Victoria Bialas
+* Vidar
+* Vincent Batts
+* Vincent Demeester
+* Vincent Giersch
+* Vishesh Jindal
+* Wang Jie
+* Wang Yan
+* Wassim Dhif
+* Wei Fu
+* Wei Meng
+* Wenkai Yin
+* Xueshan Feng
+* Yannick Fricke
+* Yong Tang
+* Yong Wen Chua
+* Yu Wang
+* Zhang Wei
+* allencloud
+* amitshukla
+* andyzhangx
+* baojiangnan
+* bin liu
+* chlins
+* cressie176
+* cui fliter
+* davidli
+* ddelange
+* dependabot[bot]
+* drornir
+* duanhongyi
+* ducksecops
+* eyjhb
+* forkbomber
+* gary schaetz
+* ghodsizadeh
+* glefloch
+* gotgelf
+* hasheddan
+* jdolitsky
+* jerae-duffin
+* jhaohai
+* leonstrand
+* libo.huang
+* lisong
+* liuchang0812
+* lostsquirrel
+* mallchin
+* mqliang
+* nevermosby
+* olegburov
+* ollypom
+* paigehargrave
+* sangluo
+* sayboras
+* shin-
+* srajmane
+* stonezdj
+* sun jian
+* syntaxkim
+* t-eimizu
+* tgic
+* unclejack
+* wayne
+* weiyuan.yl
+* xiekeyang
+* yuzou
+* zhipengzuo
+* zounengren
+* 姜继忠
+
+### Dependency Changes
+
+* **cloud.google.com/go**                                                v0.110.7 **_new_**
+* **cloud.google.com/go/compute**                                        v1.23.0 **_new_**
+* **cloud.google.com/go/compute/metadata**                               v0.2.3 **_new_**
+* **cloud.google.com/go/iam**                                            v1.1.1 **_new_**
+* **cloud.google.com/go/storage**                                        v1.30.1 **_new_**
+* **github.com/AdaLogics/go-fuzz-headers**                               443f56ff4ba8 **_new_**
+* **github.com/Azure/azure-sdk-for-go/sdk/azcore**                       v1.6.0 **_new_**
+* **github.com/Azure/azure-sdk-for-go/sdk/azidentity**                   v1.3.0 **_new_**
+* **github.com/Azure/azure-sdk-for-go/sdk/internal**                     v1.3.0 **_new_**
+* **github.com/Azure/azure-sdk-for-go/sdk/storage/azblob**               v1.0.0 **_new_**
+* **github.com/AzureAD/microsoft-authentication-library-for-go**         v1.0.0 **_new_**
+* **github.com/aws/aws-sdk-go**                                          f831d5a0822a -> v1.48.10
+* **github.com/beorn7/perks**                                            4c0e84591b9a -> v1.0.1
+* **github.com/bshuster-repo/logrus-logstash-hook**                      d2c0ecc1836d -> v1.0.0
+* **github.com/cenkalti/backoff/v4**                                     v4.2.1 **_new_**
+* **github.com/cespare/xxhash/v2**                                       v2.2.0 **_new_**
+* **github.com/coreos/go-systemd/v22**                                   v22.5.0 **_new_**
+* **github.com/cyphar/filepath-securejoin**                              v0.2.4 **_new_**
+* **github.com/davecgh/go-spew**                                         v1.1.1 **_new_**
+* **github.com/dgryski/go-rendezvous**                                   9f7001d12a5f **_new_**
+* **github.com/docker/go-events**                                        e31b211e4f1c **_new_**
+* **github.com/docker/go-metrics**                                       399ea8c73916 -> v0.0.1
+* **github.com/felixge/httpsnoop**                                       v1.0.4 **_new_**
+* **github.com/go-jose/go-jose/v3**                                      v3.0.1 **_new_**
+* **github.com/go-logr/logr**                                            v1.3.0 **_new_**
+* **github.com/go-logr/stdr**                                            v1.2.2 **_new_**
+* **github.com/golang-jwt/jwt/v4**                                       v4.5.0 **_new_**
+* **github.com/golang/groupcache**                                       41bb18bfe9da **_new_**
+* **github.com/golang/protobuf**                                         8d92cf5fc15a -> v1.5.3
+* **github.com/google/s2a-go**                                           v0.1.4 **_new_**
+* **github.com/google/uuid**                                             v1.3.1 **_new_**
+* **github.com/googleapis/enterprise-certificate-proxy**                 v0.2.3 **_new_**
+* **github.com/googleapis/gax-go/v2**                                    v2.11.0 **_new_**
+* **github.com/gorilla/handlers**                                        60c7bfde3e33 -> v1.5.1
+* **github.com/gorilla/mux**                                             599cba5e7b61 -> v1.8.1
+* **github.com/grpc-ecosystem/grpc-gateway/v2**                          v2.16.0 **_new_**
+* **github.com/hashicorp/golang-lru/arc/v2**                             v2.0.5 **_new_**
+* **github.com/hashicorp/golang-lru/v2**                                 v2.0.5 **_new_**
+* **github.com/inconshreveable/mousetrap**                               76626ae9c91c -> v1.1.0
+* **github.com/jmespath/go-jmespath**                                    bd40a432e4c7 -> v0.4.0
+* **github.com/klauspost/compress**                                      v1.17.4 **_new_**
+* **github.com/kylelemons/godebug**                                      v1.1.0 **_new_**
+* **github.com/matttproud/golang_protobuf_extensions**                   c12348ce28de -> v1.0.4
+* **github.com/mitchellh/mapstructure**                                  482a9fd5fa83 -> v1.1.2
+* **github.com/pkg/browser**                                             681adbf594b8 **_new_**
+* **github.com/pmezard/go-difflib**                                      v1.0.0 **_new_**
+* **github.com/prometheus/client_golang**                                c332b6f63c06 -> v1.17.0
+* **github.com/prometheus/client_model**                                 99fa1f4be8e5 -> v0.5.0
+* **github.com/prometheus/common**                                       89604d197083 -> v0.44.0
+* **github.com/prometheus/procfs**                                       cb4147076ac7 -> v0.11.1
+* **github.com/redis/go-redis/extra/rediscmd/v9**                        v9.0.5 **_new_**
+* **github.com/redis/go-redis/extra/redisotel/v9**                       v9.0.5 **_new_**
+* **github.com/redis/go-redis/v9**                                       v9.1.0 **_new_**
+* **github.com/sirupsen/logrus**                                         3d4380f53a34 -> v1.9.3
+* **github.com/spf13/cobra**                                             312092086bed -> v1.8.0
+* **github.com/spf13/pflag**                                             564482062245 -> v1.0.5
+* **github.com/stretchr/testify**                                        v1.8.4 **_new_**
+* **go.opencensus.io**                                                   v0.24.0 **_new_**
+* **go.opentelemetry.io/contrib/exporters/autoexport**                   v0.46.1 **_new_**
+* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**      v0.46.1 **_new_**
+* **go.opentelemetry.io/otel**                                           v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc**  v0.44.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp**  v0.44.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                  v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**    v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**    v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/prometheus**                      v0.44.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/stdout/stdoutmetric**             v0.44.0 **_new_**
+* **go.opentelemetry.io/otel/exporters/stdout/stdouttrace**              v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/metric**                                    v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/sdk**                                       v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/sdk/metric**                                v1.21.0 **_new_**
+* **go.opentelemetry.io/otel/trace**                                     v1.21.0 **_new_**
+* **go.opentelemetry.io/proto/otlp**                                     v1.0.0 **_new_**
+* **golang.org/x/crypto**                                                c10c31b5e94b -> v0.17.0
+* **golang.org/x/net**                                                   4876518f9e71 -> v0.18.0
+* **golang.org/x/oauth2**                                                045497edb623 -> v0.11.0
+* **golang.org/x/sync**                                                  v0.3.0 **_new_**
+* **golang.org/x/sys**                                                   v0.15.0 **_new_**
+* **golang.org/x/text**                                                  v0.14.0 **_new_**
+* **golang.org/x/xerrors**                                               04be3eba64a2 **_new_**
+* **google.golang.org/api**                                              9bf6e6e569ff -> v0.126.0
+* **google.golang.org/appengine**                                        12d5545dc1cf -> v1.6.7
+* **google.golang.org/genproto**                                         b8732ec3820d **_new_**
+* **google.golang.org/genproto/googleapis/api**                          b8732ec3820d **_new_**
+* **google.golang.org/genproto/googleapis/rpc**                          b8732ec3820d **_new_**
+* **google.golang.org/grpc**                                             d3ddb4469d5a -> v1.59.0
+* **google.golang.org/protobuf**                                         v1.31.0 **_new_**
+* **gopkg.in/yaml.v2**                                                   v2.2.1 -> v2.4.0
+* **gopkg.in/yaml.v3**                                                   v3.0.1 **_new_**
+
+Previous release can be found at [v2.8.3](https://github.com/distribution/distribution/releases/tag/v2.8.3)
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ var Package = "github.com/distribution/distribution/v3"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v3.0.0+unknown"
+var Version = "v3.0.0-alpha.1"
 
 // Revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.


### PR DESCRIPTION
The amount of changes since the last release is rather overwhelming.

The full changelog has been compiled using https://github.com/containerd/release-tool

@distribution/distribution-maintainers PTAL