### PR TITLE
version: export getter functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ WHALE = "+"
 TESTFLAGS_RACE=
 GOFILES=$(shell find . -type f -name '*.go')
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
-GO_LDFLAGS=-ldflags '-extldflags "-Wl,-z,now" -s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)'
+GO_LDFLAGS=-ldflags '-extldflags "-Wl,-z,now" -s -w -X $(PKG)/version.version=$(VERSION) -X $(PKG)/version.revision=$(REVISION) -X $(PKG)/version.mainpkg=$(PKG) $(EXTRA_LDFLAGS)'
 
 BINARIES=$(addprefix bin/,$(COMMANDS))
 

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -114,7 +114,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		storageParams = make(configuration.Parameters)
 	}
 	if storageParams["useragent"] == "" {
-		storageParams["useragent"] = fmt.Sprintf("distribution/%s %s", version.Version, runtime.Version())
+		storageParams["useragent"] = fmt.Sprintf("distribution/%s %s", version.Version(), runtime.Version())
 	}
 
 	var err error

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -99,7 +99,7 @@ var ServeCmd = &cobra.Command{
 	Long:  "`serve` stores and distributes Docker images.",
 	Run: func(cmd *cobra.Command, args []string) {
 		// setup context
-		ctx := dcontext.WithVersion(dcontext.Background(), version.Version)
+		ctx := dcontext.WithVersion(dcontext.Background(), version.Version())
 
 		config, err := resolveConfiguration(args)
 		if err != nil {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -26,7 +26,7 @@ func InitOpenTelemetry(ctx context.Context) error {
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.ServiceNameKey.String(serviceName),
-		semconv.ServiceVersionKey.String(version.Version),
+		semconv.ServiceVersionKey.String(version.Version()),
 	)
 
 	exp, err := autoexport.NewSpanExporter(ctx)

--- a/version/get.go
+++ b/version/get.go
@@ -6,6 +6,24 @@ import (
 	"os"
 )
 
+// Package returns the overall, canonical project import path under
+// which the package was built.
+func Package() string {
+	return mainpkg
+}
+
+// Version returns returns the module version the running binary was
+// built from.
+func Version() string {
+	return version
+}
+
+// Revision returns the VCS (e.g. git) revision being used to build
+// the program at linking time.
+func Revision() string {
+	return revision
+}
+
 // FprintVersion outputs the version string to the writer, in the following
 // format, followed by a newline:
 //
@@ -16,7 +34,7 @@ import (
 //
 //	registry github.com/distribution/distribution v2.0
 func FprintVersion(w io.Writer) {
-	fmt.Fprintln(w, os.Args[0], Package, Version)
+	fmt.Fprintln(w, os.Args[0], Package(), Version())
 }
 
 // PrintVersion outputs the version information, from Fprint, to stdout.

--- a/version/version.go
+++ b/version/version.go
@@ -1,15 +1,15 @@
 package version
 
-// Package is the overall, canonical project import path under which the
+// mainpkg is the overall, canonical project import path under which the
 // package was built.
-var Package = "github.com/distribution/distribution/v3"
+var mainpkg = "github.com/distribution/distribution/v3"
 
-// Version indicates which version of the binary is running. This is set to
+// version indicates which version of the binary is running. This is set to
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v3.0.0-alpha.1"
+var version = "v3.0.0-alpha.1.m+unknown"
 
-// Revision is filled with the VCS (e.g. git) revision being used to build
+// revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.
-var Revision = ""
+var revision = ""

--- a/version/version.sh
+++ b/version/version.sh
@@ -10,17 +10,17 @@ set -e
 cat <<EOF
 package version
 
-// Package is the overall, canonical project import path under which the
+// mainpkg is the overall, canonical project import path under which the
 // package was built.
-var Package = "$(go list -m)"
+var mainpkg = "$(go list -m)"
 
-// Version indicates which version of the binary is running. This is set to
+// version indicates which version of the binary is running. This is set to
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "$(git describe --match 'v[0-9]*' --dirty='.m' --always)+unknown"
+var version = "$(git describe --match 'v[0-9]*' --dirty='.m' --always)+unknown"
 
-// Revision is filled with the VCS (e.g. git) revision being used to build
+// revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.
-var Revision = ""
+var revision = ""
 EOF

--- a/version/version.sh
+++ b/version/version.sh
@@ -12,7 +12,7 @@ package version
 
 // Package is the overall, canonical project import path under which the
 // package was built.
-var Package = "$(go list)"
+var Package = "$(go list -m)"
 
 // Version indicates which version of the binary is running. This is set to
 // the latest release tag by hand, always suffixed by "+unknown". During


### PR DESCRIPTION
Future-proof the version package's exported interface by only making the data available through getter functions. This affords us the flexibility to e.g. implement them in terms of ["runtime/debug".ReadBuildInfo()](https://pkg.go.dev/runtime/debug#ReadBuildInfo) in the future (if [go issue 50603](https://go.dev/issue/50603) is ever resolved).