### PR TITLE
feat: add GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Create a report to help us improve
+labels:
+  - kind/bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug!
+        If this is a security issue please report it to the [Distributions Security Mailing List](mailto:cncf-distribution-security@lists.cncf.io).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please give a clear and concise description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduce
+      description: Steps to reproduce the bug
+      placeholder: |
+        1. start registry version X ...
+        2. `docker push image:tag` ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What is the expected behavior?
+      placeholder: |
+        E.g. "registry returns an incorrect API error"
+  - type: textarea
+    id: version
+    attributes:
+      label: registry version
+      description: Output of `registry --version`. Alternatively tell us the docker image tag.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Info
+      description: Additional info you want to provide such as logs, system info, environment, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security and Vulnerabilities
+    url: https://github.com/distribution/distribution/blob/main/SECURITY.md
+    about: Please report any security issues or vulnerabilities responsibly to the distribution maintainers team. Please do not use the public issue tracker.
+  - name: Questions and Discussions
+    url: https://github.com/distribution/distribution/discussions/new/choose
+    about: Use Github Discussions to ask questions and/or open discussion topics.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,12 @@
+name: Feature request
+description: Missing functionality? Come tell us about it!
+labels:
+  - kind/feature
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the feature you want to see?
+    validations:
+      required: true


### PR DESCRIPTION
This adds a GH issue template as discussed in https://github.com/distribution/distribution/pull/4200

To get started it mostly borrows from the `moby/moby`

PTAL @thaJeztah @corhere @Jamstah 