### PR TITLE
docs: remove legacy kramdown options from link

### DIFF
--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -38,7 +38,7 @@ The following table shows examples of allowed and disallowed mirror URLs.
 
 > **Note**
 >
-> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates){: target="blank" rel="noopener" class=“”}.
+> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates).
 
 ### Solution
 


### PR DESCRIPTION
I was reading https://distribution.github.io/distribution/recipes/mirror/#gotcha when I noticed some unexpected annotations after the "fair use policy" link:
```md
...Docker’s fair usage policy{: target=“blank” rel=“noopener” class=“”}.
```

 According to [Stack Overflow](https://stackoverflow.com/a/4705645/6571327), these are kramdown options that the current hugo documentation site isn't respecting. I searched the hugo docs and couldn't find an easy way to preserve `rel="noopener" target="_blank"` behavior, so I removed the annotation.