### PR TITLE
fix: update Dockerfile version output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM base AS version
 ARG PKG=github.com/distribution/distribution/v3
 RUN --mount=target=. \
   VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags) REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi); \
-  echo "-X ${PKG}/version.Version=${VERSION#v} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG}" | tee /tmp/.ldflags; \
+  echo "-X ${PKG}/version.version=${VERSION#v} -X ${PKG}/version.revision=${REVISION} -X ${PKG}/version.mainpkg=${PKG}" | tee /tmp/.ldflags; \
   echo -n "${VERSION}" | tee /tmp/.version;
 
 FROM base AS build


### PR DESCRIPTION
We changed what we print in the version info in https://github.com/distribution/distribution/pull/4204

But we haven't updated the `Dockerfile`. This PR fixes that.

The output now:
```shell
$ make image
docker buildx bake --set "*.tags=distribution/distribution:latest" image-local
[+] Building 77.7s (22/22) FINISHED                                                                                                                                                                                                                                   
...
...

$ docker run -it distribution/distribution --version
registry github.com/distribution/distribution/v3 3.0.0-alpha.1-13-gfb6ccc33.m
```