### PR TITLE
fix: add labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,9 @@ area/storage/gcs:
 area/storage/azure:
   - registry/storage/azure
 
+area/cache:
+  - registry/storage/cache
+
 area/auth:
   - registry/auth
 

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,19 @@
+name: Pull Request Labeler
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        dot: true


### PR DESCRIPTION
Whilst in https://github.com/distribution/distribution/pull/4205 we added labels to GHA config, we forgot to add the actual action doing the labelling 🤦‍♂️ 

We are also adding a label for `area/cache`

This PR fixes that. PTAL @thaJeztah