### PR TITLE
chore: generate authors and update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,32 +1,36 @@
-Stephen J Day <stephen.day@docker.com> Stephen Day <stevvooe@users.noreply.github.com>
-Stephen J Day <stephen.day@docker.com> Stephen Day <stevvooe@gmail.com>
-Olivier Gambier <olivier@docker.com> Olivier Gambier <dmp42@users.noreply.github.com>
-Brian Bland <brian.bland@docker.com> Brian Bland <r4nd0m1n4t0r@gmail.com>
-Brian Bland <brian.bland@docker.com> Brian Bland <brian.t.bland@gmail.com>
-Josh Hawn <josh.hawn@docker.com> Josh Hawn <jlhawn@berkeley.edu>
-Richard Scothern <richard.scothern@docker.com> Richard <richard.scothern@gmail.com>
-Richard Scothern <richard.scothern@docker.com> Richard Scothern <richard.scothern@gmail.com>
-Andrew Meredith <andymeredith@gmail.com> Andrew Meredith <kendru@users.noreply.github.com>
-harche <p.harshal@gmail.com> harche <harche@users.noreply.github.com>
-Jessie Frazelle <jessie@docker.com>  <jfrazelle@users.noreply.github.com>
-Sharif Nassar <sharif@mrwacky.com> Sharif Nassar <mrwacky42@users.noreply.github.com>
-Sven Dowideit <SvenDowideit@home.org.au> Sven Dowideit <SvenDowideit@users.noreply.github.com>
-Vincent Giersch <vincent.giersch@ovh.net> Vincent Giersch <vincent@giersch.fr>
-davidli <wenquan.li@hp.com> davidli <wenquan.li@hpe.com>
-Omer Cohen <git@omer.io> Omer Cohen <git@omerc.net>
-Eric Yang <windfarer@gmail.com> Eric Yang <Windfarer@users.noreply.github.com>
-Nikita Tarasov <nikita@mygento.ru> Nikita <luckyraul@users.noreply.github.com>
-Yu Wang <yuwa@microsoft.com> yuwaMSFT2 <yuwa@microsoft.com>
-Yu Wang <yuwa@microsoft.com> Yu Wang (UC) <yuwa@microsoft.com>
-Olivier Gambier <olivier@docker.com> dmp <dmp@loaner.local>
-Olivier Gambier <olivier@docker.com> Olivier <o+github@gambier.email>
-Olivier Gambier <olivier@docker.com> Olivier <dmp42@users.noreply.github.com>
-Elsan Li 李楠 <elsanli@tencent.com> elsanli(李楠) <elsanli@tencent.com>
-Rui Cao <ruicao@alauda.io> ruicao <ruicao@alauda.io>
-Gwendolynne Barr <gwendolynne.barr@docker.com> gbarr01 <gwendolynne.barr@docker.com>
-Haibing Zhou 周海兵 <zhouhaibing089@gmail.com> zhouhaibing089 <zhouhaibing089@gmail.com>
-Feng Honglin <tifayuki@gmail.com> tifayuki <tifayuki@gmail.com>
-Helen Xie <xieyulin821@harmonycloud.cn> Helen-xie <xieyulin821@harmonycloud.cn>
-Mike Brown <brownwm@us.ibm.com> Mike Brown <mikebrow@users.noreply.github.com>
-Manish Tomar <manish.tomar@docker.com> Manish Tomar <manishtomar@users.noreply.github.com>
-Sakeven Jiang <jc5930@sina.cn> sakeven <jc5930@sina.cn>
+Andrew Meredith <andymeredith@gmail.com>
+Andrew Meredith <andymeredith@gmail.com> <kendru@users.noreply.github.com>
+Brian Bland <brian.t.bland@gmail.com>
+Brian Bland <brian.t.bland@gmail.com> <brian.bland@docker.com>
+Brian Bland <brian.t.bland@gmail.com> <r4nd0m1n4t0r@gmail.com>
+davidli <wenquan.li@hp.com>
+davidli <wenquan.li@hp.com> <wenquan.li@hpe.com>
+Eric Yang <windfarer@gmail.com>
+Eric Yang <windfarer@gmail.com> <Windfarer@users.noreply.github.com>
+harche <p.harshal@gmail.com>
+harche <p.harshal@gmail.com> <harche@users.noreply.github.com>
+Jessie Frazelle <jessie@docker.com>
+Jessie Frazelle <jessie@docker.com> <jfrazelle@users.noreply.github.com>
+Josh Hawn <jlhawn@berkeley.edu>
+Josh Hawn <jlhawn@berkeley.edu> <josh.hawn@docker.com>
+Manish Tomar <manish.tomar@docker.com>
+Manish Tomar <manish.tomar@docker.com> <manishtomar@users.noreply.github.com>
+Mike Brown <brownwm@us.ibm.com>
+Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
+Nikita Tarasov <nikita@mygento.ru>
+Nikita Tarasov <nikita@mygento.ru> <luckyraul@users.noreply.github.com>
+Olivier Gambier <olivier@docker.com>
+Olivier Gambier <olivier@docker.com> <dmp42@users.noreply.github.com>
+Omer Cohen <git@omer.io>
+Omer Cohen <git@omer.io> <git@omerc.net>
+Richard Scothern <richard.scothern@gmail.com>
+Richard Scothern <richard.scothern@gmail.com> <richard.scothern@docker.com>
+Sharif Nassar <sharif@mrwacky.com>
+Sharif Nassar <sharif@mrwacky.com> <mrwacky42@users.noreply.github.com>
+Stephen J Day <stevvooe@gmail.com>
+Stephen J Day <stevvooe@gmail.com> <stephen.day@docker.com>
+Stephen J Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
+Sven Dowideit <SvenDowideit@home.org.au>
+Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@users.noreply.github.com>
+Vincent Giersch <vincent@giersch.fr>
+Vincent Giersch <vincent@giersch.fr> <vincent.giersch@ovh.net>

--- a/.mailmap
+++ b/.mailmap
@@ -1,36 +1,161 @@
+Aaron Lehmann <alehmann@netflix.com>
+Aaron Lehmann <alehmann@netflix.com> <aaron.lehmann@docker.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
+Alexander Morozov <lk4d4math@gmail.com>
+Alexander Morozov <lk4d4math@gmail.com> <lk4d4@docker.com>
 Andrew Meredith <andymeredith@gmail.com>
 Andrew Meredith <andymeredith@gmail.com> <kendru@users.noreply.github.com>
+Andrii Soldatenko <andrii.soldatenko@gmail.com>
+Andrii Soldatenko <andrii.soldatenko@gmail.com> <andrii.soldatenko@dynatrace.com>
+Antonio Murdaca <antonio.murdaca@gmail.com>
+Antonio Murdaca <antonio.murdaca@gmail.com> <amurdaca@redhat.com>
+Antonio Murdaca <antonio.murdaca@gmail.com> <me@runcom.ninja>
+Antonio Murdaca <antonio.murdaca@gmail.com> <runcom@linux.com>
+Antonio Murdaca <antonio.murdaca@gmail.com> <runcom@redhat.com>
+Antonio Murdaca <antonio.murdaca@gmail.com> <runcom@users.noreply.github.com>
+baojiangnan <baojiangnan@meituan.com>
+baojiangnan <baojiangnan@meituan.com> <baojn1998@163.com>
 Brian Bland <brian.t.bland@gmail.com>
 Brian Bland <brian.t.bland@gmail.com> <brian.bland@docker.com>
 Brian Bland <brian.t.bland@gmail.com> <r4nd0m1n4t0r@gmail.com>
-davidli <wenquan.li@hp.com>
-davidli <wenquan.li@hp.com> <wenquan.li@hpe.com>
+CrazyMax <github@crazymax.dev>
+CrazyMax <github@crazymax.dev> <1951866+crazy-max@users.noreply.github.com>
+CrazyMax <github@crazymax.dev> <crazy-max@users.noreply.github.com>
+Daniel Nephin <dnephin@gmail.com>
+Daniel Nephin <dnephin@gmail.com> <dnephin@docker.com>
+David Karlsson <david.karlsson@docker.com>
+David Karlsson <david.karlsson@docker.com> <35727626+dvdksn@users.noreply.github.com>
+David Wu <dwu7401@gmail.com>
+David Wu <dwu7401@gmail.com> <david.wu@docker.com>
+Derek McGowan <derek@mcg.dev>
+Derek McGowan <derek@mcg.dev> <derek@mcgstyle.net>
+Doug Davis <dug@us.ibm.com>
+Doug Davis <dug@us.ibm.com> <duglin@users.noreply.github.com>
 Eric Yang <windfarer@gmail.com>
+Eric Yang <windfarer@gmail.com> <qizhao.yang@daocloud.io>
 Eric Yang <windfarer@gmail.com> <Windfarer@users.noreply.github.com>
+Erica Windisch <erica@windisch.us>
+Erica Windisch <erica@windisch.us> <eric@windisch.us>
+Guillaume J. Charmes <charmes.guillaume@gmail.com>
+Guillaume J. Charmes <charmes.guillaume@gmail.com> <guillaume.charmes@dotcloud.com>
+Guillaume J. Charmes <charmes.guillaume@gmail.com> <guillaume@charmes.net>
+Guillaume J. Charmes <charmes.guillaume@gmail.com> <guillaume@docker.com>
+Guillaume J. Charmes <charmes.guillaume@gmail.com> <guillaume@dotcloud.com>
 harche <p.harshal@gmail.com>
 harche <p.harshal@gmail.com> <harche@users.noreply.github.com>
-Jessie Frazelle <jessie@docker.com>
-Jessie Frazelle <jessie@docker.com> <jfrazelle@users.noreply.github.com>
+Jessica Frazelle <jess@oxide.computer>
+Jessica Frazelle <jess@oxide.computer> <acidburn@docker.com>
+Jessica Frazelle <jess@oxide.computer> <acidburn@google.com>
+Jessica Frazelle <jess@oxide.computer> <acidburn@microsoft.com>
+Jessica Frazelle <jess@oxide.computer> <jess@docker.com>
+Jessica Frazelle <jess@oxide.computer> <jess@mesosphere.com>
+Jessica Frazelle <jess@oxide.computer> <jessfraz@google.com>
+Jessica Frazelle <jess@oxide.computer> <jfrazelle@users.noreply.github.com>
+Jessica Frazelle <jess@oxide.computer> <me@jessfraz.com>
+Jessica Frazelle <jess@oxide.computer> <princess@docker.com>
+Joao Fernandes <joaofnfernandes@gmail.com>
+Joao Fernandes <joaofnfernandes@gmail.com> <joao.fernandes@docker.com>
+Johan Euphrosine <proppy@google.com>
+Johan Euphrosine <proppy@google.com> <proppy@aminche.com>
+John Howard <github@lowenna.com>
+John Howard <github@lowenna.com> <jhoward@microsoft.com>
 Josh Hawn <jlhawn@berkeley.edu>
 Josh Hawn <jlhawn@berkeley.edu> <josh.hawn@docker.com>
+Joyce Brum <joycebrumu.u@gmail.com>
+Joyce Brum <joycebrumu.u@gmail.com> <joycebrum@google.com>
+Justin Cormack <justin.cormack@docker.com>
+Justin Cormack <justin.cormack@docker.com> <justin.cormack@unikernel.com>
+Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>
+Kirat Singh <kirat.singh@gmail.com>
+Kirat Singh <kirat.singh@gmail.com> <kirat.singh@beacon.io>
+Kirat Singh <kirat.singh@gmail.com> <kirat.singh@wsq.io>
+Luca Bruno <lucab@debian.org>
+Luca Bruno <lucab@debian.org> <luca.bruno@coreos.com>
 Manish Tomar <manish.tomar@docker.com>
 Manish Tomar <manish.tomar@docker.com> <manishtomar@users.noreply.github.com>
+Maria Bermudez <bermudez.mt@gmail.com>
+Maria Bermudez <bermudez.mt@gmail.com> <bermudezmt@users.noreply.github.com>
+Matt Linville <matt@linville.me>
+Matt Linville <matt@linville.me> <misty@apache.org>
+Matt Linville <matt@linville.me> <misty@docker.com>
+Michael Crosby <crosbymichael@gmail.com>
+Michael Crosby <crosbymichael@gmail.com> <crosby.michael@gmail.com>
+Michael Crosby <crosbymichael@gmail.com> <michael@crosbymichael.com>
+Michael Crosby <crosbymichael@gmail.com> <michael@docker.com>
+Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
+Michal Minar <miminar@redhat.com>
+Michal Minar <miminar@redhat.com> Michal Minář <miminar@redhat.com>
 Mike Brown <brownwm@us.ibm.com>
 Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
+Milos Gajdos <milosthegajdos@gmail.com>
+Milos Gajdos <milosthegajdos@gmail.com> <1392526+milosgajdos@users.noreply.github.com>
+Milos Gajdos <milosthegajdos@gmail.com> <milosgajdos83@gmail.com>
 Nikita Tarasov <nikita@mygento.ru>
 Nikita Tarasov <nikita@mygento.ru> <luckyraul@users.noreply.github.com>
+Oleg Bulatov <oleg@bulatov.me>
+Oleg Bulatov <oleg@bulatov.me> <obulatov@redhat.com>
 Olivier Gambier <olivier@docker.com>
 Olivier Gambier <olivier@docker.com> <dmp42@users.noreply.github.com>
 Omer Cohen <git@omer.io>
 Omer Cohen <git@omer.io> <git@omerc.net>
+Per Lundberg <perlun@gmail.com>
+Per Lundberg <perlun@gmail.com> <per.lundberg@ecraft.com>
+Peter Dave Hello <hsu@peterdavehello.org>
+Peter Dave Hello <hsu@peterdavehello.org> <PeterDaveHello@users.noreply.github.com>
+Phil Estes <estesp@gmail.com>
+Phil Estes <estesp@gmail.com> <estesp@amazon.com>
+Phil Estes <estesp@gmail.com> <estesp@linux.vnet.ibm.com>
 Richard Scothern <richard.scothern@gmail.com>
 Richard Scothern <richard.scothern@gmail.com> <richard.scothern@docker.com>
+Rober Morales-Chaparro <rober.morales@rstor.io>
+Rober Morales-Chaparro <rober.morales@rstor.io> <rober@rstor.io>
 Sharif Nassar <sharif@mrwacky.com>
 Sharif Nassar <sharif@mrwacky.com> <mrwacky42@users.noreply.github.com>
-Stephen J Day <stevvooe@gmail.com>
-Stephen J Day <stevvooe@gmail.com> <stephen.day@docker.com>
-Stephen J Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
+Sebastiaan van Stijn <github@gone.nl>
+Sebastiaan van Stijn <github@gone.nl> <moby@example.com>
+Sebastiaan van Stijn <github@gone.nl> <sebastiaan@ws-key-sebas3.dpi1.dpi>
+Sebastiaan van Stijn <github@gone.nl> <thaJeztah@users.noreply.github.com>
+Joffrey F <joffrey@docker.com>
+Joffrey F <joffrey@docker.com> <f.joffrey@gmail.com>
+Joffrey F <joffrey@docker.com> <joffrey@dotcloud.com>
+Solomon Hykes <solomon@dagger.io>
+Solomon Hykes <solomon@dagger.io> <s@docker.com>
+Solomon Hykes <solomon@dagger.io> <solomon.hykes@dotcloud.com>
+Solomon Hykes <solomon@dagger.io> <solomon@docker.com>
+Solomon Hykes <solomon@dagger.io> <solomon@dotcloud.com>
+Stephen Day <stevvooe@gmail.com>
+Stephen Day <stevvooe@gmail.com> <stephen.day@docker.com>
+Stephen Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
 Sven Dowideit <SvenDowideit@home.org.au>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@users.noreply.github.com>
+Tibor Vass <teabee89@gmail.com>
+Tibor Vass <teabee89@gmail.com> <tibor@docker.com>
+Tibor Vass <teabee89@gmail.com> <tiborvass@users.noreply.github.com>
+Cristian Staretu <cristian.staretu@gmail.com>
+Cristian Staretu <cristian.staretu@gmail.com> <unclejack@users.noreply.github.com>
+Cristian Staretu <cristian.staretu@gmail.com> <unclejacksons@gmail.com>
+Victor Vieux <victorvieux@gmail.com>
+Victor Vieux <victorvieux@gmail.com> <dev@vvieux.com>
+Victor Vieux <victorvieux@gmail.com> <victor.vieux@docker.com>
+Victor Vieux <victorvieux@gmail.com> <victor.vieux@dotcloud.com>
+Victor Vieux <victorvieux@gmail.com> <victor@docker.com>
+Victor Vieux <victorvieux@gmail.com> <victor@dotcloud.com>
+Victor Vieux <victorvieux@gmail.com> <victorvieux@gmail.com>
+Victor Vieux <victorvieux@gmail.com> <vieux@docker.com>
+Victoria Bialas <victoria.bialas@docker.com>
+Victoria Bialas <victoria.bialas@docker.com> <londoncalling@users.noreply.github.com>
+Vincent Batts <vbatts@redhat.com>
+Vincent Batts <vbatts@redhat.com> <vbatts@hashbangbash.com>
+Vincent Demeester <vincent.demeester@docker.com>
+Vincent Demeester <vincent.demeester@docker.com> <vincent+github@demeester.fr>
+Vincent Demeester <vincent.demeester@docker.com> <vincent@demeester.fr>
+Vincent Demeester <vincent.demeester@docker.com> <vincent@sbr.pm>
 Vincent Giersch <vincent@giersch.fr>
 Vincent Giersch <vincent@giersch.fr> <vincent.giersch@ovh.net>
+Wen-Quan Li <legendarilylwq@gmail.com>
+Wen-Quan Li <legendarilylwq@gmail.com> <wenquan.li@hp.com>
+Wen-Quan Li <legendarilylwq@gmail.com> <wenquan.li@hpe.com>
+Yu Wang <yuwa@microsoft.com>
+Yu Wang <yuwa@microsoft.com> Yu Wang (UC) <yuwa@microsoft.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,530 @@
+# This file lists all individuals having contributed content to the repository.
+# For how it is generated, see dockerfiles/authors.Dockerfile.
+
+a-palchikov <deemok@gmail.com>
+Aaron Lehmann <alehmann@netflix.com>
+Aaron Schlesinger <aschlesinger@deis.com>
+Aaron Vinson <avinson.public@gmail.com>
+Adam Dobrawy <ad-m@users.noreply.github.com>
+Adam Duke <adam.v.duke@gmail.com>
+Adam Enger <adamenger@gmail.com>
+Adam Kaplan <adam.kaplan@redhat.com>
+Adam Wolfe Gordon <awg@digitalocean.com>
+AdamKorcz <adam@adalogics.com>
+Adrian Mouat <adrian.mouat@gmail.com>
+Adrian Plata <adrian.plata@docker.com>
+Adrien Duermael <adrien@duermael.com>
+Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
+Aidan Hobson Sayers <aidanhs@cantab.net>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Aleksejs Sinicins <monder@monder.cc>
+Alex <aleksandrosansan@gmail.com>
+Alex Chan <alex.chan@metaswitch.com>
+Alex Elman <aelman@indeed.com>
+Alex Laties <agl@tumblr.com>
+Alexander Larsson <alexl@redhat.com>
+Alexander Morozov <lk4d4math@gmail.com>
+Alexey Gladkov <gladkov.alexey@gmail.com>
+Alfonso Acosta <fons@syntacticsugar.consulting>
+allencloud <allen.sun@daocloud.io>
+Alvin Feng <alvin4feng@yahoo.com>
+amitshukla <ashukla73@hotmail.com>
+Amy Lindburg <amy.lindburg@docker.com>
+Andreas Hassing <andreas@famhassing.dk>
+Andrew Bulford <andrew.bulford@redmatter.com>
+Andrew Hsu <andrewhsu@acm.org>
+Andrew Lavery <laverya@umich.edu>
+Andrew Leung <anwleung@gmail.com>
+Andrew Lively <andrew.lively2@gmail.com>
+Andrew Meredith <andymeredith@gmail.com>
+Andrew T Nguyen <andrew.nguyen@docker.com>
+Andrews Medina <andrewsmedina@gmail.com>
+Andrey Kostov <kostov.andrey@gmail.com>
+Andrii Soldatenko <andrii.soldatenko@gmail.com>
+Andy Goldstein <agoldste@redhat.com>
+andyzhangx <xiazhang@microsoft.com>
+Anian Z <ziegler@sicony.de>
+Anil Belur <askb23@gmail.com>
+Anis Elleuch <vadmeste@gmail.com>
+Ankush Agarwal <ankushagarwal11@gmail.com>
+Anne Henmi <41210220+ahh-docker@users.noreply.github.com>
+Anton Tiurin <noxiouz@yandex.ru>
+Antonio Mercado <amercado@thinknode.com>
+Antonio Murdaca <antonio.murdaca@gmail.com>
+Antonio Ojea <antonio.ojea.garcia@gmail.com>
+Anusha Ragunathan <anusha@docker.com>
+Arien Holthuizen <aholthuizen@schubergphilis.com>
+Arko Dasgupta <arkodg@users.noreply.github.com>
+Arnaud Porterie <arnaud.porterie@docker.com>
+Arthur Baars <arthur@semmle.com>
+Arthur Gautier <baloo@gandi.net>
+Asuka Suzuki <hello@tanksuzuki.com>
+Avi Miller <avi.miller@oracle.com>
+Aviral Takkar <aviral26@users.noreply.github.com>
+Ayose Cazorla <ayosec@gmail.com>
+BadZen <dave.trombley@gmail.com>
+baojiangnan <baojiangnan@meituan.com>
+Ben Bodenmiller <bbodenmiller@hotmail.com>
+Ben De St Paer-Gotch <bende@outlook.com>
+Ben Emamian <ben@ictace.com>
+Ben Firshman <ben@firshman.co.uk>
+Ben Kochie <superq@gmail.com>
+Ben Manuel <ben.manuel@procore.com>
+Bhavin Gandhi <bhavin192@users.noreply.github.com>
+Bill <NonCreature0714@users.noreply.github.com>
+bin liu <liubin0329@gmail.com>
+Bouke van der Bijl <me@bou.ke>
+Bracken Dawson <abdawson@gmail.com>
+Brandon Mitchell <git@bmitch.net>
+Brandon Philips <brandon@ifup.co>
+Brett Higgins <brhiggins@arbor.net>
+Brian Bland <brian.t.bland@gmail.com>
+Brian Goff <cpuguy83@gmail.com>
+burnettk <burnettk@gmail.com>
+Caleb Spare <cespare@gmail.com>
+Carson A <ca@carsonoid.net>
+Cezar Sa Espinola <cezarsa@gmail.com>
+Chad Faragher <wyckster@hotmail.com>
+Chaos John <chaosjohn.yjh@icloud.com>
+Charles Smith <charles.smith@docker.com>
+Cheng Zheng <chengzheng.apply@gmail.com>
+chlins <chenyuzh@vmware.com>
+Chris Aniszczyk <caniszczyk@gmail.com>
+Chris Dillon <squarism@gmail.com>
+Chris K. Wong <chriskw.xyz@gmail.com>
+Chris Patterson <chrispat@github.com>
+Christopher Yeleighton <ne01026@shark.2a.pl>
+Christy Perez <christy@linux.vnet.ibm.com>
+Chuanying Du <cydu@google.com>
+Clayton Coleman <ccoleman@redhat.com>
+Collin Shoop <cshoop@digitalocean.com>
+Corey Quon <corey.quon@gmail.com>
+Cory Snider <csnider@mirantis.com>
+CrazyMax <github@crazymax.dev>
+cressie176 <github@stephen-cresswell.net>
+Cristian Staretu <cristian.staretu@gmail.com>
+cui fliter <imcusg@gmail.com>
+cuiwei13 <cuiwei13@pku.edu.cn>
+cyli <cyli@twistedmatrix.com>
+Daehyeok Mun <daehyeok@gmail.com>
+Daisuke Fujita <dtanshi45@gmail.com>
+Damien Mathieu <dmathieu@salesforce.com>
+Dan Fredell <furtchet@gmail.com>
+Dan Walsh <dwalsh@redhat.com>
+Daniel Helfand <helfand.4@gmail.com>
+Daniel Huhn <daniel@danielhuhn.de>
+Daniel Menet <membership@sontags.ch>
+Daniel Mizyrycki <mzdaniel@glidelink.net>
+Daniel Nephin <dnephin@gmail.com>
+Daniel, Dao Quang Minh <dqminh89@gmail.com>
+Danila Fominykh <dancheg97@fmnx.su>
+Darren Shepherd <darren@rancher.com>
+Dave <david.warshaw@gmail.com>
+Dave Trombley <dave.trombley@gmail.com>
+Dave Tucker <dt@docker.com>
+David Calavera <david.calavera@gmail.com>
+David Justice <david@devigned.com>
+David Karlsson <david.karlsson@docker.com>
+David Lawrence <david.lawrence@docker.com>
+David Luu <david@davidluu.info>
+David Mackey <tdmackey@booleanhaiku.com>
+David van der Spek <vanderspek.david@gmail.com>
+David Verhasselt <david@crowdway.com>
+David Wu <dwu7401@gmail.com>
+David Xia <dxia@spotify.com>
+Dawn W Docker <dawn.wood@users.noreply.github.com>
+ddelange <14880945+ddelange@users.noreply.github.com>
+Dejan Golja <dejan@golja.org>
+Denis Andrejew <da.colonel@gmail.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Derek <crq@kernel.org>
+Derek McGowan <derek@mcg.dev>
+Deshi Xiao <xiaods@gmail.com>
+Dimitar Kostadinov <dimitar.kostadinov@sap.com>
+Diogo Mónica <diogo.monica@gmail.com>
+DJ Enriquez <dj.enriquez@infospace.com>
+Djibril Koné <kone.djibril@gmail.com>
+dmp <dmp@loaner.local>
+Don Bowman <don@agilicus.com>
+Don Kjer <don.kjer@gmail.com>
+Donald Huang <don.hcd@gmail.com>
+Doug Davis <dug@us.ibm.com>
+drornir <drornir@users.noreply.github.com>
+duanhongyi <duanhongyi@doopai.com>
+ducksecops <daniel@ducksecops.uk>
+E. M. Bray <erik.m.bray@gmail.com>
+Edgar Lee <edgar.lee@docker.com>
+Elliot Pahl <elliot.pahl@gmail.com>
+elsanli(李楠) <elsanli@tencent.com>
+Elton Stoneman <elton@sixeyed.com>
+Emmanuel Briney <emmanuel.briney@docker.com>
+Eng Zer Jun <engzerjun@gmail.com>
+Eohyung Lee <liquidnuker@gmail.com>
+Eric Yang <windfarer@gmail.com>
+Erica Windisch <erica@windisch.us>
+Erik Hollensbe <github@hollensbe.org>
+Etki <etki@etki.me>
+Eugene Lubarsky <eug48@users.noreply.github.com>
+eyjhb <eyjhbb@gmail.com>
+eyjhbb@gmail.com <eyjhbb@gmail.com>
+Fabio Berchtold <jamesclonk@jamesclonk.ch>
+Fabio Falci <fabiofalci@gmail.com>
+Fabio Huser <fabio@fh1.ch>
+farmerworking <farmerworking@gmail.com>
+fate-grand-order <chenjg@harmonycloud.cn>
+Felix Bünemann <buenemann@louis.info>
+Felix Yan <felixonmars@archlinux.org>
+Feng Honglin <tifayuki@gmail.com>
+Fernando Mayo Fernandez <fernando@undefinedlabs.com>
+Flavian Missi <fmissi@redhat.com>
+Florentin Raud <florentin.raud@gmail.com>
+forkbomber <forkbomber@users.noreply.github.com>
+Frank Chen <frankchn@gmail.com>
+Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
+Gabor Nagy <mail@aigeruth.hu>
+gabriell nascimento <gabriell@bluesoft.com.br>
+Gaetan <gdevillele@gmail.com>
+gary schaetz <gary@schaetzkc.com>
+gbarr01 <gwendolynne.barr@docker.com>
+Geoffrey Hausheer <rc2012@pblue.org>
+ghodsizadeh <mehdi.ghodsizadeh@gmail.com>
+Giovanni Toraldo <giovanni.toraldo@eng.it>
+Gladkov Alexey <agladkov@redhat.com>
+Gleb M Borisov <borisov.gleb@gmail.com>
+Gleb Schukin <gschukin@ptsecurity.com>
+glefloch <glfloch@gmail.com>
+Glyn Owen Hanmer <1295698+glynternet@users.noreply.github.com>
+gotgelf <gotgelf@gmail.com>
+Grachev Mikhail <work@mgrachev.com>
+Grant Watters <grant.watters@docker.com>
+Greg Rebholz <gregrebholz@gmail.com>
+Guillaume J. Charmes <charmes.guillaume@gmail.com>
+Guillaume Rose <guillaume.rose@docker.com>
+Gábor Lipták <gliptak@gmail.com>
+harche <p.harshal@gmail.com>
+hasheddan <georgedanielmangum@gmail.com>
+Hayley Swimelar <hswimelar@gmail.com>
+Helen-xie <xieyulin821@harmonycloud.cn>
+Henri Gomez <henri.gomez@gmail.com>
+Honglin Feng <tifayuki@gmail.com>
+Hu Keping <hukeping@huawei.com>
+Hua Wang <wanghua.humble@gmail.com>
+HuKeping <hukeping@huawei.com>
+Huu Nguyen <whoshuu@gmail.com>
+ialidzhikov <i.alidjikov@gmail.com>
+Ian Babrou <ibobrik@gmail.com>
+iasoon <ilion.beyst@gmail.com>
+igayoso <igayoso@gmail.com>
+Igor Dolzhikov <bluesriverz@gmail.com>
+Igor Morozov <igmorv@gmail.com>
+Ihor Dvoretskyi <ihor@linux.com>
+Ilion Beyst <ilion.beyst@gmail.com>
+Ina Panova <ipanova@redhat.com>
+Irene Diez <idiez@redhat.com>
+Ismail Alidzhikov <i.alidjikov@gmail.com>
+Jack Baines <jack.baines@uk.ibm.com>
+Jack Griffin <jackpg14@gmail.com>
+Jacob Atzen <jatzen@gmail.com>
+Jake Moshenko <jake@devtable.com>
+Jakob Ackermann <das7pad@outlook.com>
+Jakub Mikulas <jakub@mikul.as>
+James Findley <jfindley@fastmail.com>
+James Hewitt <james.hewitt@uk.ibm.com>
+James Lal <james@lightsofapollo.com>
+Jason Freidman <jason.freidman@gmail.com>
+Jason Heiss <jheiss@aput.net>
+Javier Palomo Almena <javier.palomo.almena@gmail.com>
+jdolitsky <393494+jdolitsky@users.noreply.github.com>
+Jeff Nickoloff <jeff@allingeek.com>
+Jeffrey van Gogh <jvg@google.com>
+jerae-duffin <83294991+jerae-duffin@users.noreply.github.com>
+Jeremy THERIN <jtherin@scaleway.com>
+Jesse Brown <jabrown85@gmail.com>
+Jesse Haka <haka.jesse@gmail.com>
+Jessica Frazelle <jess@oxide.computer>
+jhaohai <jhaohai@foxmail.com>
+Jianqing Wang <tsing@jianqing.org>
+Jihoon Chung <jihoon@gmail.com>
+Jim Galasyn <jim.galasyn@docker.com>
+Joao Fernandes <joaofnfernandes@gmail.com>
+Joffrey F <joffrey@docker.com>
+Johan Euphrosine <proppy@google.com>
+John Howard <github@lowenna.com>
+John Mulhausen <john@docker.com>
+John Starks <jostarks@microsoft.com>
+Jon Johnson <jonjohnson@google.com>
+Jon Poler <jonathan.poler@apcera.com>
+Jonas Hecht <jonas.hecht@codecentric.de>
+Jonathan Boulle <jonathanboulle@gmail.com>
+Jonathan Lee <jonjohn1232009@gmail.com>
+Jonathan Rudenberg <jonathan@titanous.com>
+Jordan Liggitt <jliggitt@redhat.com>
+Jose D. Gomez R <jose.gomez@suse.com>
+Josh Chorlton <josh.chorlton@docker.com>
+Josh Dolitsky <josh@dolit.ski>
+Josh Hawn <jlhawn@berkeley.edu>
+Josiah Kiehl <jkiehl@riotgames.com>
+Joyce Brum <joycebrumu.u@gmail.com>
+João Pereira <484633+joaodrp@users.noreply.github.com>
+Julien Bordellier <1444415+jstoja@users.noreply.github.com>
+Julien Fernandez <julien.fernandez@gmail.com>
+Justas Brazauskas <brazauskasjustas@gmail.com>
+Justin Cormack <justin.cormack@docker.com>
+Justin I. Nevill <JustinINevill@users.noreply.github.com>
+Justin Santa Barbara <justin@fathomdb.com>
+kaiwentan <kaiwentan@harmonycloud.cn>
+Ke Xu <leonhartx.k@gmail.com>
+Keerthan Mala <kmala@engineyard.com>
+Kelsey Hightower <kelsey.hightower@gmail.com>
+Ken Cochrane <KenCochrane@gmail.com>
+Kenneth Lim <kennethlimcp@gmail.com>
+Kenny Leung <kleung@google.com>
+Kevin Lin <kevin@kelda.io>
+Kevin Robatel <kevinrob2@gmail.com>
+Kira <me@imkira.com>
+Kirat Singh <kirat.singh@gmail.com>
+L-Hudson <44844738+L-Hudson@users.noreply.github.com>
+Lachlan Cooper <lachlancooper@gmail.com>
+Laura Brehm <laurabrehm@hey.com>
+Lei Jitang <leijitang@huawei.com>
+Lenny Linux <tippexs91@googlemail.com>
+Leonardo Azize Martins <lazize@users.noreply.github.com>
+leonstrand <leonstrand@gmail.com>
+Li Yi <denverdino@gmail.com>
+Liam White <liamwhite@uk.ibm.com>
+libo.huang <huanglibo2010@gmail.com>
+LingFaKe <lingfake@huawei.com>
+Liron Levin <liron@twistlock.com>
+lisong <lisong@cdsunrise.net>
+Littlemoon917 <18084421+Littlemoon917@users.noreply.github.com>
+Liu Hua <sdu.liu@huawei.com>
+liuchang0812 <liuchang0812@gmail.com>
+liyongxin <yxli@alauda.io>
+Lloyd Ramey <lnr0626@gmail.com>
+lostsquirrel <lostsquirreli@hotmail.com>
+Louis Kottmann <louis.kottmann@gmail.com>
+Luca Bruno <lucab@debian.org>
+Lucas França de Oliveira <lucasfdo@palantir.com>
+Lucas Santos <lhs.santoss@gmail.com>
+Luis Lobo Borobia <luislobo@gmail.com>
+Luke Carpenter <x@rubynerd.net>
+Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>
+Makoto Oda <truth_jp_4133@yahoo.co.jp>
+mallchin <mallchin@mac.com>
+Manish Tomar <manish.tomar@docker.com>
+Marco Hennings <marco.hennings@freiheit.com>
+Marcus Martins <marcus@docker.com>
+Maria Bermudez <bermudez.mt@gmail.com>
+Mark Sagi-Kazar <mark.sagikazar@gmail.com>
+Mary Anthony <mary@docker.com>
+Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
+Matin Rahmanian <itsmatinx@gmail.com>
+MATSUMOTO TAKEAKI <takeaki.matsumoto@linecorp.com>
+Matt Bentley <mbentley@mbentley.net>
+Matt Duch <matt@learnmetrics.com>
+Matt Linville <matt@linville.me>
+Matt Moore <mattmoor@google.com>
+Matt Robenolt <matt@ydekproductions.com>
+Matt Tescher <matthew.tescher@docker.com>
+Matthew Balvanz <matthew.balvanz@workiva.com>
+Matthew Green <greenmr@live.co.uk>
+Matthew Riley <mattdr@google.com>
+Maurice Sotzny <ailuridae@users.noreply.github.com>
+Meaglith Ma <genedna@gmail.com>
+Michael Bonfils <bonfils.michael@protonmail.com>
+Michael Crosby <crosbymichael@gmail.com>
+Michael Prokop <mika@grml.org>
+Michael Vetter <jubalh@iodoru.org>
+Michal Fojtik <mfojtik@redhat.com>
+Michal Gebauer <mishak@mishak.net>
+Michal Guerquin <michalg@allenai.org>
+Michal Minar <miminar@redhat.com>
+Mike Brown <brownwm@us.ibm.com>
+Mike Lundy <mike@fluffypenguin.org>
+Mike Truman <miketruman42@gmail.com>
+Milos Gajdos <milosthegajdos@gmail.com>
+Miquel Sabaté <msabate@suse.com>
+mlmhl <409107750@qq.com>
+Monika Katiyar <monika@jeavio.com>
+Morgan Bauer <mbauer@us.ibm.com>
+moxiegirl <mary@docker.com>
+mqliang <mqliang.zju@gmail.com>
+Muesli <solom.emmanuel@gmail.com>
+Nan Monnand Deng <monnand@gmail.com>
+Nat Zimmermann <ntzm@users.noreply.github.com>
+Nathan Sullivan <nathan@nightsys.net>
+Naveed Jamil <naveed.jamil@tenpearl.com>
+Neil Wilson <neil@aldur.co.uk>
+nevermosby <robolwq@qq.com>
+Nghia Tran <tcnghia@gmail.com>
+Nicolas De Loof <nicolas.deloof@gmail.com>
+Nikita Tarasov <nikita@mygento.ru>
+ning xie <andy.xning@gmail.com>
+Nishant Totla <nishanttotla@gmail.com>
+Noah Treuhaft <noah.treuhaft@docker.com>
+Novak Ivanovski <novakivanovski@gmail.com>
+Nuutti Kotivuori <nuutti.kotivuori@poplatek.fi>
+Nycholas de Oliveira e Oliveira <nycholas@gmail.com>
+Oilbeater <liumengxinfly@gmail.com>
+Oleg Bulatov <oleg@bulatov.me>
+olegburov <oleg.burov@outlook.com>
+Olivier <o+github@gambier.email>
+Olivier Gambier <olivier@docker.com>
+Olivier Jacques <olivier.jacques@hp.com>
+ollypom <oppomeroy@gmail.com>
+Omer Cohen <git@omer.io>
+Oscar Caballero <ocaballero@opensistemas.com>
+Owen W. Taylor <otaylor@fishsoup.net>
+paigehargrave <Paige.hargrave@docker.com>
+Parth Mehrotra <parth@mehrotra.me>
+Pascal Borreli <pascal@borreli.com>
+Patrick Devine <patrick.devine@docker.com>
+Patrick Easters <peasters@redhat.com>
+Paul Cacheux <paul.cacheux@datadoghq.com>
+Pavel Antonov <ddc67cd@gmail.com>
+Paweł Gronowski <pawel.gronowski@docker.com>
+Per Lundberg <perlun@gmail.com>
+Peter Choi <reikani@Peters-MacBook-Pro.local>
+Peter Dave Hello <hsu@peterdavehello.org>
+Peter Kokot <peterkokot@gmail.com>
+Phil Estes <estesp@gmail.com>
+Philip Misiowiec <philip@atlashealth.com>
+Pierre-Yves Ritschard <pyr@spootnik.org>
+Pieter Scheffers <pieter.scheffers@gmail.com>
+Qiang Huang <h.huangqiang@huawei.com>
+Qiao Anran <qiaoanran@gmail.com>
+Radon Rosborough <radon.neon@gmail.com>
+Randy Barlow <randy@electronsweatshop.com>
+Raphaël Enrici <raphael@root-42.com>
+Ricardo Maraschini <ricardo.maraschini@gmail.com>
+Richard Scothern <richard.scothern@gmail.com>
+Rick Wieman <git@rickw.nl>
+Rik Nijessen <rik@keefo.nl>
+Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
+Rober Morales-Chaparro <rober.morales@rstor.io>
+Robert Kaussow <mail@geeklabor.de>
+Robert Steward <speaktorob@users.noreply.github.com>
+Roberto G. Hashioka <roberto.hashioka@docker.com>
+Rodolfo Carvalho <rhcarvalho@gmail.com>
+ROY <qqbuby@gmail.com>
+Rui Cao <ruicao@alauda.io>
+ruicao <ruicao@alauda.io>
+Rusty Conover <rusty@luckydinosaur.com>
+Ryan Abrams <rdabrams@gmail.com>
+Ryan Thomas <rthomas@atlassian.com>
+sakeven <jc5930@sina.cn>
+Sam Alba <sam.alba@gmail.com>
+Samuel Karp <skarp@amazon.com>
+sangluo <sangluo@pinduoduo.com>
+Santiago Torres <torresariass@gmail.com>
+Sargun Dhillon <sargun@sargun.me>
+sayboras <sayboras@yahoo.com>
+Sean Boran <Boran@users.noreply.github.com>
+Sean P. Kane <spkane00@gmail.com>
+Sebastiaan van Stijn <github@gone.nl>
+Sebastien Coavoux <s.coavoux@free.fr>
+Serge Dubrouski <sergeyfd@gmail.com>
+Sevki Hasirci <sevki@cloudflare.com>
+Sharif Nassar <sharif@mrwacky.com>
+Shawn Chen <chen8132@gmail.com>
+Shawn Falkner-Horine <dreadpirateshawn@gmail.com>
+Shawnpku <chen8132@gmail.com>
+Shengjing Zhu <zhsj@debian.org>
+Shiela M Parker <smp13@live.com>
+Shishir Mahajan <shishir.mahajan@redhat.com>
+Shreyas Karnik <karnik.shreyas@gmail.com>
+Silvin Lubecki <31478878+silvin-lubecki@users.noreply.github.com>
+Simon <crydotsnakegithub@gmail.com>
+Simon Thulbourn <simon+github@thulbourn.com>
+Simone Locci <simone.locci@eng.it>
+Smasherr <soundcracker@gmail.com>
+Solomon Hykes <solomon@dagger.io>
+Sora Morimoto <sora@morimoto.io>
+spacexnice <yaoyao.xyy@alibaba-inc.com>
+Spencer Rinehart <anubis@overthemonkey.com>
+srajmane <31947381+srajmane@users.noreply.github.com>
+Srini Brahmaroutu <srbrahma@us.ibm.com>
+Stan Hu <stanhu@gmail.com>
+Stefan Lörwald <10850250+stefanloerwald@users.noreply.github.com>
+Stefan Majewsky <stefan.majewsky@sap.com>
+Stefan Nica <snica@suse.com>
+Stefan Weil <sw@weilnetz.de>
+Stephen Day <stevvooe@gmail.com>
+Steve Lasker <stevenlasker@hotmail.com>
+Steven Hanna <stevenhanna6@gmail.com>
+Steven Kalt <SKalt@users.noreply.github.com>
+Steven Taylor <steven.taylor@me.com>
+stonezdj <stonezdj@gmail.com>
+sun jian <cnhttpd@gmail.com>
+Sungho Moon <sungho.moon@navercorp.com>
+Sven Dowideit <SvenDowideit@home.org.au>
+Sylvain Baubeau <sbaubeau@redhat.com>
+syntaxkim <40621244+syntaxkim@users.noreply.github.com>
+T N <tnir@users.noreply.github.com>
+t-eimizu <t-eimizu@aim.ac>
+Tariq Ibrahim <tariq181290@gmail.com>
+TaylorKanper <tony_kanper@hotmail.com>
+Ted Reed <ted.reed@gmail.com>
+Terin Stock <terinjokes@gmail.com>
+tgic <farmer1992@gmail.com>
+Thomas Berger <loki@lokis-chaos.de>
+Thomas Sjögren <konstruktoid@users.noreply.github.com>
+Tianon Gravi <admwiggin@gmail.com>
+Tibor Vass <teabee89@gmail.com>
+tifayuki <tifayuki@gmail.com>
+Tiger Kaovilai <tkaovila@redhat.com>
+Tobias Fuhrimann <mastertinner@users.noreply.github.com>
+Tobias Schwab <tobias.schwab@dynport.de>
+Tom Hayward <thayward@infoblox.com>
+Tom Hu <tomhu1096@gmail.com>
+Tonis Tiigi <tonistiigi@gmail.com>
+Tony Holdstock-Brown <tony@docker.com>
+Tosone <i@tosone.cn>
+Trapier Marshall <trapier@users.noreply.github.com>
+Trevor Pounds <trevor.pounds@gmail.com>
+Trevor Wood <Trevor.G.Wood@gmail.com>
+Troels Thomsen <troels@thomsen.io>
+uhayate <uhayate.gong@daocloud.io>
+Usha Mandya <47779042+usha-mandya@users.noreply.github.com>
+Usha Mandya <usha.mandya@docker.com>
+Vaidas Jablonskis <jablonskis@gmail.com>
+Vega Chou <VegeChou@users.noreply.github.com>
+Veres Lajos <vlajos@gmail.com>
+Victor Vieux <victorvieux@gmail.com>
+Victoria Bialas <victoria.bialas@docker.com>
+Vidar <vl@ez.no>
+Viktor Stanchev <me@viktorstanchev.com>
+Vincent Batts <vbatts@redhat.com>
+Vincent Demeester <vincent.demeester@docker.com>
+Vincent Giersch <vincent@giersch.fr>
+Vishesh Jindal <vishesh92@gmail.com>
+W. Trevor King <wking@tremily.us>
+Wang Jie <wangjie5@chinaskycloud.com>
+Wang Yan <wangyan@vmware.com>
+Wassim Dhif <wassimdhif@gmail.com>
+wayne <wayne.warren.s@gmail.com>
+Wei Fu <fuweid89@gmail.com>
+Wei Meng <wemeng@microsoft.com>
+weiyuan.yl <weiyuan.yl@alibaba-inc.com>
+Wen-Quan Li <legendarilylwq@gmail.com>
+Wenkai Yin <yinw@vmware.com>
+william wei <1342247033@qq.com>
+xg.song <xg.song@venusource.com>
+xiekeyang <xiekeyang@huawei.com>
+Xueshan Feng <xueshan.feng@gmail.com>
+Yann ROBERT <yann.robert@anantaplex.fr>
+Yannick Fricke <YannickFricke@users.noreply.github.com>
+yaoyao.xyy <yaoyao.xyy@alibaba-inc.com>
+yixi zhang <yixi@memsql.com>
+Yong Tang <yong.tang.github@outlook.com>
+Yong Wen Chua <lawliet89@users.noreply.github.com>
+Yongxin Li <yxli@alauda.io>
+Yu Wang <yuwa@microsoft.com>
+yuexiao-wang <wang.yuexiao@zte.com.cn>
+YuJie <390282283@qq.com>
+yuzou <zouyu7@huawei.com>
+Zhang Wei <zhangwei555@huawei.com>
+zhipengzuo <zuozhipeng@baidu.com>
+zhouhaibing089 <zhouhaibing089@gmail.com>
+zounengren <zounengren@cmss.chinamobile.com>
+姜继忠 <jizhong.jiangjz@alibaba-inc.com>

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BINARIES=$(addprefix bin/,$(COMMANDS))
 TESTFLAGS ?= -v $(TESTFLAGS_RACE)
 TESTFLAGS_PARALLEL ?= 8
 
-.PHONY: all build binaries clean test test-race test-full integration test-coverage validate lint validate-git validate-vendor vendor mod-outdated image
+.PHONY: all build binaries clean test test-race test-full integration test-coverage validate lint validate-git validate-vendor vendor mod-outdated image validate-authors authors
 .DEFAULT: all
 
 .PHONY: FORCE
@@ -84,6 +84,9 @@ vendor: ## update vendor
 	rm -rf $($@_TMP_OUT)/*
 
 mod-outdated: ## check outdated dependencies
+	docker buildx bake $@
+
+authors: ## generate authors
 	docker buildx bake $@
 
 ##@ Test
@@ -170,6 +173,9 @@ validate-git: ## validate git
 	docker buildx bake $@
 
 validate-vendor: ## validate vendor
+	docker buildx bake $@
+
+validate-authors: ## validate authors
 	docker buildx bake $@
 
 .PHONY: help

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -124,3 +124,15 @@ target "docs-test" {
   target = "test"
   output = ["type=cacheonly"]
 }
+
+target "authors" {
+  dockerfile = "./dockerfiles/authors.Dockerfile"
+  target = "update"
+  output = ["."]
+}
+
+target "validate-authors" {
+  dockerfile = "./dockerfiles/authors.Dockerfile"
+  target = "validate"
+  output = ["type=cacheonly"]
+}

--- a/dockerfiles/authors.Dockerfile
+++ b/dockerfiles/authors.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+ARG ALPINE_VERSION=3.19
+
+FROM alpine:${ALPINE_VERSION} AS gen
+RUN apk add --no-cache git
+WORKDIR /src
+RUN --mount=type=bind,target=. <<EOT
+  set -e
+  mkdir /out
+  # see also ".mailmap" for how email addresses and names are deduplicated
+  {
+    echo "# This file lists all individuals having contributed content to the repository."
+    echo "# For how it is generated, see dockerfiles/authors.Dockerfile."
+    echo
+    git log --format='%aN <%aE>' | LC_ALL=C.UTF-8 sort -uf
+  } > /out/AUTHORS
+  cat /out/AUTHORS
+EOT
+
+FROM scratch AS update
+COPY --from=gen /out /
+
+FROM gen AS validate
+RUN --mount=type=bind,target=.,rw <<EOT
+  set -e
+  git add -A
+  cp -rf /out/* .
+  if [ -n "$(git status --porcelain -- AUTHORS)" ]; then
+    echo >&2 'ERROR: Authors result differs. Please update with "make authors"'
+    git status --porcelain -- AUTHORS
+    exit 1
+  fi
+EOT


### PR DESCRIPTION
Generate authors and update mailmap. As best effort I took linked authors from https://github.com/moby/moby/blob/master/.mailmap and https://github.com/containerd/containerd/blob/main/.mailmap