### PR TITLE
chore: use no-cache-filter for outdated stage

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -39,11 +39,7 @@ target "update-vendor" {
 target "mod-outdated" {
   dockerfile = "./dockerfiles/vendor.Dockerfile"
   target = "outdated"
-  args = {
-    // used to invalidate cache for outdated run stage
-    // can be dropped when https://github.com/moby/buildkit/issues/1213 fixed
-    _RANDOM = uuidv4()
-  }
+  no-cache-filter = ["outdated"]
   output = ["type=cacheonly"]
 }
 

--- a/dockerfiles/vendor.Dockerfile
+++ b/dockerfiles/vendor.Dockerfile
@@ -40,7 +40,6 @@ EOT
 
 FROM psampaz/go-mod-outdated:${MODOUTDATED_VERSION} AS go-mod-outdated
 FROM base AS outdated
-ARG _RANDOM
 RUN --mount=target=.,ro \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=from=go-mod-outdated,source=/home/go-mod-outdated,target=/usr/bin/go-mod-outdated \


### PR DESCRIPTION
Since Buildx 0.8.0 we can use the `no-cache-filter` opt.