### PR TITLE
chore: dependabot to keep gha up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
follow-up https://github.com/distribution/distribution/pull/4083#discussion_r1435612362

Adds dependabot to keep the github actions being used in our workflows up to date.