### PR TITLE
build(deps): bump actions/upload-pages-artifact from 2 to 3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build/docs
 


### PR DESCRIPTION
Fixes artifact fetching failure by ensuring compatibility with actions/artifact@v4

https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
