### PR TITLE
fix: Broken /about links in distribution documentation.

### DIFF
--- a/docs/content/recipes/apache.md
+++ b/docs/content/recipes/apache.md
@@ -12,7 +12,7 @@ Usually, that includes enterprise setups using LDAP/AD on the backend and a SSO 
 
 ### Alternatives
 
-If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature](/about/deploying#native-basic-auth).
+If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature](../../about/deploying#native-basic-auth).
 
 ### Solution
 

--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -107,7 +107,7 @@ proxy:
 
 > **Warning**: For the scheduler to clean up old entries, `delete` must
 > be enabled in the registry configuration. See
-> [Registry Configuration](/about/configuration) for more details.
+> [Registry Configuration](../../about/configuration) for more details.
 
 ### Configure the Docker daemon
 

--- a/docs/content/recipes/nginx.md
+++ b/docs/content/recipes/nginx.md
@@ -17,7 +17,7 @@ mechanism fronting their internal http portal.
 
 If you just want authentication for your registry, and are happy maintaining
 users access separately, you should really consider sticking with the native
-[basic auth registry feature](/about/deploying#native-basic-auth).
+[basic auth registry feature](../../about/deploying#native-basic-auth).
 
 ### Solution
 

--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1088,7 +1088,7 @@ response will be issued instead.
 
     Accept: application/vnd.docker.distribution.manifest.v2+json
 
-> for more details, see: [compatibility](/about/compatibility#content-addressable-storage-cas)
+> for more details, see: [compatibility](../../about/compatibility#content-addressable-storage-cas)
 
 ## Detail
 


### PR DESCRIPTION
This isn't visible in a local hugo server, but the links were using absolute pathing, and in the prod deploy everything is prefixed with /distribution/ .

Overriding the hugo prefix for deploy is another option, but this repo uses relative pathing, so these were fixed accordingly.