### PR TITLE
fix: documentation broken links in production.

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -436,15 +436,15 @@ returns an error. You can choose any of these backend storage drivers:
 
 | Storage driver      | Description                                                                                                                                                                                                                                                                              |
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `filesystem`        | Uses the local disk to store registry files. It is ideal for development and may be appropriate for some small-scale production applications. See the [driver's reference documentation](/storage-drivers/filesystem). |
-| `azure`             | Uses Microsoft Azure Blob Storage. See the [driver's reference documentation](/storage-drivers/azure).                                                                                                               |
-| `gcs`               | Uses Google Cloud Storage. See the [driver's reference documentation](/storage-drivers/gcs).                                                                                                                           |
-| `s3`                | Uses Amazon Simple Storage Service (S3) and compatible Storage Services. See the [driver's reference documentation](/storage-drivers/s3).                                                                            |
+| `filesystem`        | Uses the local disk to store registry files. It is ideal for development and may be appropriate for some small-scale production applications. See the [driver's reference documentation]({{< ref "/storage-drivers/filesystem" >}})/. |
+| `azure`             | Uses Microsoft Azure Blob Storage. See the [driver's reference documentation]({{< ref "/storage-drivers/azure" >}})/.                                                                                                               |
+| `gcs`               | Uses Google Cloud Storage. See the [driver's reference documentation]({{< ref "/storage-drivers/gcs" >}})/.                                                                                                                           |
+| `s3`                | Uses Amazon Simple Storage Service (S3) and compatible Storage Services. See the [driver's reference documentation]({{< ref "/storage-drivers/s3" >}})/.                                                                            |
 
 For testing only, you can use the [`inmemory` storage
-driver](/storage-drivers/inmemory).
+driver]({{< ref "/storage-drivers/inmemory" >}})/.
 If you would like to run a registry from volatile memory, use the
-[`filesystem` driver](/storage-drivers/filesystem)
+[`filesystem` driver]({{< ref "/storage-drivers/filesystem" >}})/
 on a ramdisk.
 
 If you are deploying a registry on Windows, a Windows volume mounted from the
@@ -593,7 +593,7 @@ security.
 
 
 For more information about Token based authentication configuration, see the
-[specification](/spec/auth/token).
+[specification]({{< ref "/spec/auth/token" >}})/.
 
 ### `htpasswd`
 
@@ -1100,7 +1100,7 @@ proxy:
 
 The `proxy` structure allows a registry to be configured as a pull-through cache
 to Docker Hub. See
-[mirror](/recipes/mirror)
+[mirror]({{< ref "/recipes/mirror" >}})/
 for more information. Pushing to a registry configured as a pull-through cache
 is unsupported.
 

--- a/docs/content/about/deploying.md
+++ b/docs/content/about/deploying.md
@@ -166,7 +166,7 @@ $ docker run -d \
 By default, the registry stores its data on the local filesystem, whether you
 use a bind mount or a volume. You can store the registry data in an Amazon S3
 bucket, Google Cloud Platform, or on another storage back-end by using
-[storage drivers](/storage-drivers). For more information, see
+[storage drivers]({{< ref "/storage-drivers" >}})/. For more information, see
 [storage configuration options](../configuration#storage).
 
 ## Run an externally-accessible registry
@@ -468,13 +468,13 @@ See [run an insecure registry](../insecure).
 ### More advanced authentication
 
 You may want to leverage more advanced basic auth implementations by using a
-proxy in front of the registry. See the [recipes list](/recipes/).
+proxy in front of the registry. See the [recipes list]({{< ref "/recipes/" >}})/.
 
 The registry also supports delegated authentication which redirects users to a
 specific trusted token server. This approach is more complicated to set up, and
 only makes sense if you need to fully configure ACLs and need more control over
 the registry's integration into your global authorization and authentication
-systems. Refer to the following [background information](/spec/auth/token) and
+systems. Refer to the following [background information]({{< ref "/spec/auth/token" >}})/ and
 [configuration information here](../configuration#auth).
 
 This approach requires you to implement your own authentication system or
@@ -574,7 +574,7 @@ More specific and advanced information is available in the following sections:
 
 - [Configuration reference](../configuration)
 - [Working with notifications](../notifications)
-- [Advanced "recipes"](/recipes)
-- [Registry API](/spec/api)
-- [Storage driver model](/storage-drivers)
-- [Token authentication](/spec/auth/token)
+- [Advanced "recipes"]({{< ref "/recipes" >}})/
+- [Registry API]({{< ref "/spec/api" >}})/
+- [Storage driver model]({{< ref "/storage-drivers" >}})/
+- [Token authentication]({{< ref "/spec/auth/token" >}})/

--- a/docs/content/about/garbage-collection.md
+++ b/docs/content/about/garbage-collection.md
@@ -28,8 +28,8 @@ to the layer. As long as a layer is referenced by one manifest, it cannot be gar
 collected.
 
 Manifests and layers can be `deleted` with the registry API (refer to the API
-documentation [here](/spec/api#deleting-a-layer) and
-[here](/spec/api#deleting-an-image) for details). This API removes references
+documentation [here]({{< ref "/spec/api#deleting-a-layer" >}})/ and
+[here]({{< ref "/spec/api#deleting-an-image" >}})/ for details). This API removes references
 to the target and makes them eligible for garbage collection. It also makes them
 unable to be read via the API.
 

--- a/docs/content/recipes/apache.md
+++ b/docs/content/recipes/apache.md
@@ -12,7 +12,7 @@ Usually, that includes enterprise setups using LDAP/AD on the backend and a SSO 
 
 ### Alternatives
 
-If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature](/about/deploying#native-basic-auth).
+If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature]({{< ref "/about/deploying#native-basic-auth" >}})/.
 
 ### Solution
 

--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -107,7 +107,7 @@ proxy:
 
 > **Warning**: For the scheduler to clean up old entries, `delete` must
 > be enabled in the registry configuration. See
-> [Registry Configuration](/about/configuration) for more details.
+> [Registry Configuration]({{< ref "/about/configuration" >}})/ for more details.
 
 ### Configure the Docker daemon
 

--- a/docs/content/recipes/nginx.md
+++ b/docs/content/recipes/nginx.md
@@ -17,7 +17,7 @@ mechanism fronting their internal http portal.
 
 If you just want authentication for your registry, and are happy maintaining
 users access separately, you should really consider sticking with the native
-[basic auth registry feature](/about/deploying#native-basic-auth).
+[basic auth registry feature]({{< ref "/about/deploying#native-basic-auth" >}})/.
 
 ### Solution
 

--- a/docs/content/spec/_index.md
+++ b/docs/content/spec/_index.md
@@ -7,6 +7,6 @@ keywords: registry, service, images, repository,  json
 # Docker Registry Reference
 
 * [HTTP API V2](api)
-* [Storage Driver](/storage-drivers/)
+* [Storage Driver]({{< ref "/storage-drivers/" >}})/
 * [Token Authentication Specification](auth/token)
 * [Token Authentication Implementation](auth/jwt)

--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1088,7 +1088,7 @@ response will be issued instead.
 
     Accept: application/vnd.docker.distribution.manifest.v2+json
 
-> for more details, see: [compatibility](/about/compatibility#content-addressable-storage-cas)
+> for more details, see: [compatibility]({{< ref "/about/compatibility#content-addressable-storage-cas" >}})/
 
 ## Detail
 


### PR DESCRIPTION
These paths are using hardcoded absolute paths; this works in a local `hugo serve`, but will not work in `hugo server --baseURL <host>/distribution/`, which is how the actual production docs are deployed.

Either you convert all of these to relative- which means hugo still can't flag broken links like these- or you use the rel tag to have hugo render it.

The benefit of rel is it makes the content prefix movable, and hugo will break the build if you refer to something internal that doesn't exist.

Either way, this fixes the broken documentation; storage links, about links, etc.

For further commentary, see discussion thread in PR #4238.

For auditing/repro, this change was generated via:
```
grep -r '(/'  . -l | xargs -n1 sed -i -re 's:\(/([^)]+)\):({{< ref "/\1" >}})/:'
```

From there, a hugo build was ran to verify the changes didn't introduce broken intra-links.