### PR TITLE
[release/2.8 backport] deprecate ReadSeekCloser in favor of io.ReadSeekCloser

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -142,20 +142,18 @@ type BlobDescriptorServiceFactory interface {
 
 // ReadSeekCloser is the primary reader type for blob data, combining
 // io.ReadSeeker with io.Closer.
-type ReadSeekCloser interface {
-	io.ReadSeeker
-	io.Closer
-}
+//
+// Deprecated: use [io.ReadSeekCloser].
+type ReadSeekCloser = io.ReadSeekCloser
 
 // BlobProvider describes operations for getting blob data.
 type BlobProvider interface {
 	// Get returns the entire blob identified by digest along with the descriptor.
 	Get(ctx context.Context, dgst digest.Digest) ([]byte, error)
 
-	// Open provides a ReadSeekCloser to the blob identified by the provided
-	// descriptor. If the blob is not known to the service, an error will be
-	// returned.
-	Open(ctx context.Context, dgst digest.Digest) (ReadSeekCloser, error)
+	// Open provides an [io.ReadSeekCloser] to the blob identified by the provided
+	// descriptor. If the blob is not known to the service, an error is returned.
+	Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error)
 }
 
 // BlobServer can serve blobs via http.

--- a/manifest/ocischema/builder_test.go
+++ b/manifest/ocischema/builder_test.go
@@ -12,6 +12,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -19,14 +20,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -37,14 +30,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestBuilder(t *testing.T) {

--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -17,6 +17,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -24,14 +25,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -42,14 +35,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestEmptyTar(t *testing.T) {

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -11,6 +11,7 @@ import (
 
 type mockBlobService struct {
 	descriptors map[digest.Digest]distribution.Descriptor
+	distribution.BlobService
 }
 
 func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -18,14 +19,6 @@ func (bs *mockBlobService) Stat(ctx context.Context, dgst digest.Digest) (distri
 		return descriptor, nil
 	}
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-func (bs *mockBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	panic("not implemented")
 }
 
 func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
@@ -36,14 +29,6 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil
-}
-
-func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
 }
 
 func TestBuilder(t *testing.T) {

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/docker/distribution"
@@ -147,7 +148,7 @@ func (bsl *blobServiceListener) Get(ctx context.Context, dgst digest.Digest) ([]
 	return p, err
 }
 
-func (bsl *blobServiceListener) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (bsl *blobServiceListener) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	rc, err := bsl.BlobStore.Open(ctx, dgst)
 	if err == nil {
 		if desc, err := bsl.Stat(ctx, dgst); err != nil {

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -135,16 +135,14 @@ func NewRepository(name reference.Named, baseURL string, transport http.RoundTri
 		return nil, err
 	}
 
-	client := &http.Client{
-		Transport:     transport,
-		CheckRedirect: checkHTTPRedirect,
-		// TODO(dmcgowan): create cookie jar
-	}
-
 	return &repository{
-		client: client,
-		ub:     ub,
-		name:   name,
+		client: &http.Client{
+			Transport:     transport,
+			CheckRedirect: checkHTTPRedirect,
+			// TODO(dmcgowan): create cookie jar
+		},
+		ub:   ub,
+		name: name,
 	}, nil
 }
 
@@ -159,16 +157,15 @@ func (r *repository) Named() reference.Named {
 }
 
 func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
-	statter := &blobStatter{
+	return &blobs{
 		name:   r.name,
 		ub:     r.ub,
 		client: r.client,
-	}
-	return &blobs{
-		name:    r.name,
-		ub:      r.ub,
-		client:  r.client,
-		statter: cache.NewCachedBlobStatter(memory.NewInMemoryBlobDescriptorCacheProvider(), statter),
+		statter: cache.NewCachedBlobStatter(memory.NewInMemoryBlobDescriptorCacheProvider(), &blobStatter{
+			name:   r.name,
+			ub:     r.ub,
+			client: r.client,
+		}),
 	}
 }
 

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -645,7 +645,7 @@ func (bs *blobs) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
 	return ioutil.ReadAll(reader)
 }
 
-func (bs *blobs) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (bs *blobs) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	ref, err := reference.WithDigest(bs.name, dgst)
 	if err != nil {
 		return nil, err
@@ -655,13 +655,12 @@ func (bs *blobs) Open(ctx context.Context, dgst digest.Digest) (distribution.Rea
 		return nil, err
 	}
 
-	return transport.NewHTTPReadSeeker(bs.client, blobURL,
-		func(resp *http.Response) error {
-			if resp.StatusCode == http.StatusNotFound {
-				return distribution.ErrBlobUnknown
-			}
-			return HandleErrorResponse(resp)
-		}), nil
+	return transport.NewHTTPReadSeeker(bs.client, blobURL, func(resp *http.Response) error {
+		if resp.StatusCode == http.StatusNotFound {
+			return distribution.ErrBlobUnknown
+		}
+		return HandleErrorResponse(resp)
+	}), nil
 }
 
 func (bs *blobs) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {

--- a/registry/client/transport/http_reader.go
+++ b/registry/client/transport/http_reader.go
@@ -19,24 +19,25 @@ var (
 )
 
 // ReadSeekCloser combines io.ReadSeeker with io.Closer.
-type ReadSeekCloser interface {
-	io.ReadSeeker
-	io.Closer
-}
+//
+// Deprecated: use [io.ReadSeekCloser].
+type ReadSeekCloser = io.ReadSeekCloser
 
 // NewHTTPReadSeeker handles reading from an HTTP endpoint using a GET
 // request. When seeking and starting a read from a non-zero offset
 // the a "Range" header will be added which sets the offset.
+//
 // TODO(dmcgowan): Move this into a separate utility package
-func NewHTTPReadSeeker(client *http.Client, url string, errorHandler func(*http.Response) error) ReadSeekCloser {
-	return &httpReadSeeker{
+func NewHTTPReadSeeker(client *http.Client, url string, errorHandler func(*http.Response) error) *HTTPReadSeeker {
+	return &HTTPReadSeeker{
 		client:       client,
 		url:          url,
 		errorHandler: errorHandler,
 	}
 }
 
-type httpReadSeeker struct {
+// HTTPReadSeeker implements an [io.ReadSeekCloser].
+type HTTPReadSeeker struct {
 	client *http.Client
 	url    string
 
@@ -60,7 +61,7 @@ type httpReadSeeker struct {
 	err        error
 }
 
-func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
+func (hrs *HTTPReadSeeker) Read(p []byte) (n int, err error) {
 	if hrs.err != nil {
 		return 0, hrs.err
 	}
@@ -89,7 +90,7 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
+func (hrs *HTTPReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if hrs.err != nil {
 		return 0, hrs.err
 	}
@@ -132,7 +133,7 @@ func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	return hrs.seekOffset, err
 }
 
-func (hrs *httpReadSeeker) Close() error {
+func (hrs *HTTPReadSeeker) Close() error {
 	if hrs.err != nil {
 		return hrs.err
 	}
@@ -149,7 +150,7 @@ func (hrs *httpReadSeeker) Close() error {
 	return nil
 }
 
-func (hrs *httpReadSeeker) reset() {
+func (hrs *HTTPReadSeeker) reset() {
 	if hrs.err != nil {
 		return
 	}
@@ -159,7 +160,7 @@ func (hrs *httpReadSeeker) reset() {
 	}
 }
 
-func (hrs *httpReadSeeker) reader() (io.Reader, error) {
+func (hrs *HTTPReadSeeker) reader() (io.Reader, error) {
 	if hrs.err != nil {
 		return nil, hrs.err
 	}

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -212,7 +212,7 @@ func (pbs *proxyBlobStore) Mount(ctx context.Context, sourceRepo reference.Named
 	return distribution.Descriptor{}, distribution.ErrUnsupported
 }
 
-func (pbs *proxyBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (pbs *proxyBlobStore) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	return nil, distribution.ErrUnsupported
 }
 

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -60,7 +61,7 @@ func (sbs statsBlobStore) Resume(ctx context.Context, id string) (distribution.B
 	return sbs.blobs.Resume(ctx, id)
 }
 
-func (sbs statsBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (sbs statsBlobStore) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	sbsMu.Lock()
 	sbs.stats["open"]++
 	sbsMu.Unlock()

--- a/registry/proxy/proxytagservice_test.go
+++ b/registry/proxy/proxytagservice_test.go
@@ -13,9 +13,8 @@ import (
 type mockTagStore struct {
 	mapping map[string]distribution.Descriptor
 	sync.Mutex
+	distribution.TagService
 }
-
-var _ distribution.TagService = &mockTagStore{}
 
 func (m *mockTagStore) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
 	m.Lock()
@@ -56,10 +55,6 @@ func (m *mockTagStore) All(ctx context.Context) ([]string, error) {
 	}
 
 	return tags, nil
-}
-
-func (m *mockTagStore) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
-	panic("not implemented")
 }
 
 func testProxyTagService(local, remote map[string]distribution.Descriptor) *proxyTagService {

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"io"
 	"path"
 
 	"github.com/docker/distribution"
@@ -41,7 +42,7 @@ func (bs *blobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error
 	return p, nil
 }
 
-func (bs *blobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (bs *blobStore) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	desc, err := bs.statter.Stat(ctx, dgst)
 	if err != nil {
 		return nil, err

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"time"
@@ -59,7 +60,7 @@ func (lbs *linkedBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte
 	return lbs.blobStore.Get(ctx, canonical.Digest)
 }
 
-func (lbs *linkedBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+func (lbs *linkedBlobStore) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error) {
 	canonical, err := lbs.Stat(ctx, dgst) // access check
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
backport of:

- https://github.com/distribution/distribution/pull/3787
- https://github.com/distribution/distribution/pull/3788

relates to:

- https://github.com/distribution/distribution/pull/4245

back porting these so that (if another 2.8.x patch release is done), we can give a warning out to users that this will be removed in v3