### PR TITLE
remove deprecated ReadSeekCloser interfaces

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -140,12 +140,6 @@ type BlobDescriptorServiceFactory interface {
 	BlobAccessController(svc BlobDescriptorService) BlobDescriptorService
 }
 
-// ReadSeekCloser is the primary reader type for blob data, combining
-// io.ReadSeeker with io.Closer.
-//
-// Deprecated: use [io.ReadSeekCloser].
-type ReadSeekCloser = io.ReadSeekCloser
-
 // BlobProvider describes operations for getting blob data.
 type BlobProvider interface {
 	// Get returns the entire blob identified by digest along with the descriptor.

--- a/internal/client/transport/http_reader.go
+++ b/internal/client/transport/http_reader.go
@@ -26,11 +26,6 @@ var (
 	ErrWrongCodeForByteRange = errors.New("expected HTTP 206 from byte range request")
 )
 
-// ReadSeekCloser combines io.ReadSeeker with io.Closer.
-//
-// Deprecated: use [io.ReadSeekCloser].
-type ReadSeekCloser = io.ReadSeekCloser
-
 // NewHTTPReadSeeker handles reading from an HTTP endpoint using a GET
 // request. When seeking and starting a read from a non-zero offset
 // the a "Range" header will be added which sets the offset.


### PR DESCRIPTION
- follow-up to https://github.com/distribution/distribution/pull/3788
- relates to / depends on https://github.com/distribution/distribution/pull/4244


These were deprecated in 019ead86f5603e5b1b3a7afd4bb7cbcdab2613e9 and d71ad5b3a6be14e002d130db9b9703732eee42e8, and are no longer in use in our code.