### PR TITLE
test: Skip init if GCS envs are missing

### DIFF
--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -34,6 +34,10 @@ func init() {
 		}
 	}
 
+	if bucket == "" || credentials == "" {
+		return
+	}
+
 	jsonKey, err := os.ReadFile(credentials)
 	if err != nil {
 		panic(fmt.Sprintf("Error reading JSON key : %v", err))


### PR DESCRIPTION
This PR fixes the GCS storage tests to work on forked PRs and on environments that are not configured with GCS.

Looks like the intention of the tests is to skip them when the environment variables are missing, so we can't continue with the initialization.

Another way to do it is to extract the initialization code from `init` and call it after `skipCheck` is invoked