### PR TITLE
build(deps): bump docker/bake-action from 2 to 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       -
         name: Build artifacts
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v4
         with:
           targets: artifact-all
       -
@@ -130,7 +130,7 @@ jobs:
           if-no-files-found: error
       -
         name: Build image
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v4
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       -
         name: Log in to GitHub Container registry
         if: github.event_name != 'pull_request'
@@ -111,16 +110,27 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       -
         name: Build artifacts
         uses: docker/bake-action@v4
         with:
           targets: artifact-all
       -
-        name: Move artifacts
+        name: Rename provenance
+        run: |
+          for pdir in ./bin/*/; do
+            (
+              cd "$pdir"
+              binname=$(find . -name '*.tar.gz')
+              filename=$(basename "${binname%.tar.gz}")
+              mv "provenance.json" "${filename}.provenance.json"
+            )
+          done
+      -
+        name: Move and list artifacts
         run: |
           mv ./bin/**/* ./bin/
+          tree -nh ./bin
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -145,6 +155,7 @@ jobs:
           draft: true
           files: |
             bin/*.tar.gz
+            bin/*.provenance.json
             bin/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       -
         name: Build image
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v4
         with:
           targets: image-local
       -

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build docs
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@v4
         with:
           files: |
             docker-bake.hcl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
           files: |
             docker-bake.hcl
           targets: docs-export
+          provenance: false
           set: |
             *.cache-from=type=gha,scope=docs
             *.cache-to=type=gha,scope=docs,mode=max

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       -
         name: Build image
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v4
         with:
           targets: image-local
       -


### PR DESCRIPTION
carry and closes #4233 

This handles provenance for built artifacts and disable provenance when generating docs.

See https://github.com/distribution/distribution/actions/runs/7501643046/job/20422754661?pr=4253#step:9:40