### PR TITLE
chore: Remove duplicate `area/ci` entry in PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,3 @@
-area/ci:
-  - .github/**/*
-
 area/config:
   - charts/registry/config/**/*
 


### PR DESCRIPTION
Fixes https://github.com/distribution/distribution/actions/runs/7542009683/job/20529895576?pr=4248

From my PR here https://github.com/distribution/distribution/pull/4248