### PR TITLE
chore: Remove `area/config` duplicate entry in `labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 area/config:
-  - charts/registry/config/**/*
+  - configuration
 
 area/docs:
   - README.md
@@ -41,9 +41,6 @@ area/auth:
 
 area/proxy:
   - registry/proxy
-
-area/config:
-  - configuration
 
 area/api:
   - registry/api

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,47 +1,35 @@
-area/config:
-  - configuration
-
-area/docs:
-  - README.md
-  - docs/**/*.md
-
+area/api:
+  - registry/api
+  - registry/handlers
+area/auth:
+  - registry/auth
 area/build:
   - Makefile
   - Dockerfile
   - docker-bake.hcl
   - dockerfiles/**/*
-
+area/cache:
+  - registry/storage/cache
 area/ci:
   - .github/**/*
   - tests
   - testutil
-
+area/config:
+  - configuration
+area/docs:
+  - README.md
+  - docs/**/*.md
+area/proxy:
+  - registry/proxy
+area/storage:
+  - registry/storage
+area/storage/azure:
+  - registry/storage/azure
+area/storage/gcs:
+  - registry/storage/gcs
+area/storage/s3:
+  - registry/storage/s3-aws
 dependencies:
   - vendor/**/*
   - go.mod
   - go.sum
-
-area/storage:
-  - registry/storage
-
-area/storage/s3:
-  - registry/storage/s3-aws
-
-area/storage/gcs:
-  - registry/storage/gcs
-
-area/storage/azure:
-  - registry/storage/azure
-
-area/cache:
-  - registry/storage/cache
-
-area/auth:
-  - registry/auth
-
-area/proxy:
-  - registry/proxy
-
-area/api:
-  - registry/api
-  - registry/handlers


### PR DESCRIPTION
Missed this in https://github.com/distribution/distribution/pull/4256

`charts/registry/config/**/*` doesn't exist so I'm assuming this should be only `configuration`. Kept the top entry so everything is nicely sorted