### PR TITLE
chore: Migrate PR labeler config to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,35 +1,61 @@
 area/api:
-  - registry/api
-  - registry/handlers
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/api/**/*
+      - registry/handlers/**/*
 area/auth:
-  - registry/auth
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/auth/**/*
 area/build:
-  - Makefile
-  - Dockerfile
-  - docker-bake.hcl
-  - dockerfiles/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - Makefile
+      - Dockerfile
+      - docker-bake.hcl
+      - dockerfiles/**/*
 area/cache:
-  - registry/storage/cache
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/storage/cache/**/*
 area/ci:
-  - .github/**/*
-  - tests
-  - testutil
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/**/*
+      - tests/**/*
+      - testutil/**/*
 area/config:
-  - configuration
+  - changed-files:
+    - any-glob-to-any-file:
+      - configuration/**/*
 area/docs:
-  - README.md
-  - docs/**/*.md
+  - changed-files:
+    - any-glob-to-any-file:
+      - README.md
+      - docs/**/*.md
 area/proxy:
-  - registry/proxy
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/proxy/**/*
 area/storage:
-  - registry/storage
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/storage/**/*
 area/storage/azure:
-  - registry/storage/azure
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/storage/driver/azure/**/*
 area/storage/gcs:
-  - registry/storage/gcs
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/storage/driver/gcs/**/*
 area/storage/s3:
-  - registry/storage/s3-aws
+  - changed-files:
+    - any-glob-to-any-file:
+      - registry/storage/driver/s3-aws/**/*
 dependencies:
-  - vendor/**/*
-  - go.mod
-  - go.sum
+  - changed-files:
+    - any-glob-to-any-file:
+      - vendor/**/*
+      - go.mod
+      - go.sum

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 area/api:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/api/**/*
+      - registry/api/**
       - registry/handlers/**/*
 area/auth:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,32 +2,32 @@ area/api:
   - changed-files:
     - any-glob-to-any-file:
       - registry/api/**
-      - registry/handlers/**/*
+      - registry/handlers/**
 area/auth:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/auth/**/*
+      - registry/auth/**
 area/build:
   - changed-files:
     - any-glob-to-any-file:
       - Makefile
       - Dockerfile
       - docker-bake.hcl
-      - dockerfiles/**/*
+      - dockerfiles/**
 area/cache:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/storage/cache/**/*
+      - registry/storage/cache/**
 area/ci:
   - changed-files:
     - any-glob-to-any-file:
-      - .github/**/*
-      - tests/**/*
-      - testutil/**/*
+      - .github/**
+      - tests/**
+      - testutil/**
 area/config:
   - changed-files:
     - any-glob-to-any-file:
-      - configuration/**/*
+      - configuration/**
 area/docs:
   - changed-files:
     - any-glob-to-any-file:
@@ -36,26 +36,26 @@ area/docs:
 area/proxy:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/proxy/**/*
+      - registry/proxy/**
 area/storage:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/storage/**/*
+      - registry/storage/**
 area/storage/azure:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/storage/driver/azure/**/*
+      - registry/storage/driver/azure/**
 area/storage/gcs:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/storage/driver/gcs/**/*
+      - registry/storage/driver/gcs/**
 area/storage/s3:
   - changed-files:
     - any-glob-to-any-file:
-      - registry/storage/driver/s3-aws/**/*
+      - registry/storage/driver/s3-aws/**
 dependencies:
   - changed-files:
     - any-glob-to-any-file:
-      - vendor/**/*
+      - vendor/**
       - go.mod
       - go.sum


### PR DESCRIPTION
The PR labeler workflow uses v5 of the action but with a v4 configuration so it fails.

This should fix it (I think), see https://github.com/actions/labeler/tree/17086b774338d2689ada0d8fcc8c51b5c9bc782a#breaking-changes-in-v5