### PR TITLE
Access controller: allow claims with a global (*) repo scope

### DIFF
--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -57,6 +57,11 @@ func (s accessSet) contains(access auth.Access) bool {
 	if ok {
 		return actionSet.contains(access.Action)
 	}
+	for authResource, actionSet := range s {
+		if authResource.Name == "*" {
+			return actionSet.contains(access.Action)
+		}
+	}
 
 	return false
 }


### PR DESCRIPTION
Hello there ! 

I have a special case in which I would like to allow pulling from 'any' repo, by setting a claim's `access.name` setting to `*`.

Happy to discuss, update anything ! LMK what you think 😊 