### PR TITLE
Include headers when serving blob through proxy

### DIFF
--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -448,10 +448,20 @@ func testProxyStoreServe(t *testing.T, te *testEnv, numClients int) {
 					return
 				}
 
-				bodyBytes := w.Body.Bytes()
+				resp := w.Result()
+				bodyBytes, err := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				if err != nil {
+					t.Errorf(err.Error())
+					return
+				}
 				localDigest := digest.FromBytes(bodyBytes)
 				if localDigest != remoteBlob.Digest {
 					t.Errorf("Mismatching blob fetch from proxy")
+					return
+				}
+				if resp.Header.Get("Docker-Content-Digest") != localDigest.String() {
+					t.Errorf("Mismatching digest in response header")
 					return
 				}
 


### PR DESCRIPTION
In commit 17952924f3 we updated ServeBlob() to use an io.MultiWriter to write simultaneously to the local store and the HTTP response.

However, copyContent was using a type assertion to only add headers if the io.Writer was a http.ResponseWriter. Therefore, this change caused us to stop sending the expected headers (i.e. Content-Length, Etag, etc.) on the first request for a blob.

Resolve the issue by explicitly passing in http.Header and setting it unconditionally.