### PR TITLE
Initialize proxy prometheus counters values to 0

### DIFF
--- a/registry/proxy/proxymetrics.go
+++ b/registry/proxy/proxymetrics.go
@@ -62,6 +62,16 @@ func init() {
 	}))
 
 	metrics.Register(prometheus.ProxyNamespace)
+	initPrometheusMetrics("blob")
+	initPrometheusMetrics("manifest")
+}
+
+func initPrometheusMetrics(value string) {
+	requests.WithValues(value).Inc(0)
+	hits.WithValues(value).Inc(0)
+	misses.WithValues(value).Inc(0)
+	pulledBytes.WithValues(value).Inc(0)
+	pushedBytes.WithValues(value).Inc(0)
 }
 
 // BlobPull tracks metrics about blobs pulled into the cache


### PR DESCRIPTION
Proxy prometheus metrics introduced in #4047 uses labeled counters.
With this PR, counters values are initialized to 0 to mitigate the issue of missing metrics after a registry restart, as recommended [here](https://github.com/prometheus/client_python/discussions/952#discussioncomment-6972244).

For more details related to the issue see [Created Timestamps](https://github.com/prometheus/proposals/blob/main/proposals/2023-06-13_created-timestamp.md) proposal.
