### PR TITLE
Do not write manifests on HEAD requests

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -212,6 +212,11 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Length", fmt.Sprint(len(p)))
 	w.Header().Set("Docker-Content-Digest", imh.Digest.String())
 	w.Header().Set("Etag", fmt.Sprintf(`"%s"`, imh.Digest))
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
 	if _, err := w.Write(p); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
The `GetManifest` handler is used for both `HEAD` and `GET` requests. For `HEAD` requests, the handler also calls `w.Write()` on the response writer.

This is not needed as HEAD requests should not include a response body. Most clients will actually just ignore the body, for example `curl` does this and simply skips it.

This PR adds a check to the `GetManifest` handler to return early when the request method is a `HEAD`. This would prevent wasting  resources writing to the response writer.

The `ServeBlob` method of the `blobServer` uses the standard library `http.ServeContent` [which internally has a check ](https://github.com/golang/go/blob/master/src/net/http/fs.go#L382) to only copy the result if the request method is not `HEAD`. So this change will follow the same approach as the blobs handler.

The change has also been recently merged to GitLab's Container Registry via https://gitlab.com/gitlab-org/container-registry/-/merge_requests/1585.
