### PR TITLE
Allow setting s3 forcepathstyle without regionendpoint

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -15,7 +15,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `secretkey`  | no   | Your AWS Secret Key. If you use [IAM roles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), omit to fetch temporary credentials from IAM. |
 | `region` |  yes  | The AWS region in which your bucket exists. |
 | `regionendpoint` | no | Endpoint for S3 compatible storage services (Minio, etc). |
-| `forcepathstyle` | no | To enable path-style addressing when the value is set to `true`. The default is `true`. |
+| `forcepathstyle` | no | To enable path-style addressing when the value is set to `true`. The default is `false`. |
 | `bucket`  | yes | The bucket name in which you want to store the registry's data. |
 | `encrypt`  | no | Specifies whether the registry stores the image in encrypted format or not. A boolean value. The default is `false`. |
 | `keyid`  | no | Optional KMS key ID to use for encryption (encrypt must be true, or this parameter is ignored). The default is `none`. |
@@ -43,7 +43,7 @@ Amazon S3 or S3 compatible services for object storage.
 
 `regionendpoint`: (optional) Endpoint URL for S3 compatible APIs. This should not be provided when using Amazon S3.
 
-`forcepathstyle`: (optional) The force path style for S3 compatible APIs. Some manufacturers only support force path style, while others only support DNS based bucket routing. Amazon S3 supports both.
+`forcepathstyle`: (optional) Force path style for S3 compatible APIs. Some manufacturers only support force path style, while others only support DNS based bucket routing. Amazon S3 supports both. The value of this parameter applies, regardless of the region settings.
 
 `bucket`: The name of your S3 bucket where you wish to store objects. The bucket must exist prior to the driver initialization.
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -205,7 +205,7 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 		regionEndpoint = ""
 	}
 
-	forcePathStyleBool := true
+	forcePathStyleBool := false
 	forcePathStyle := parameters["forcepathstyle"]
 	switch forcePathStyle := forcePathStyle.(type) {
 	case string:
@@ -529,9 +529,9 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 
 	if params.RegionEndpoint != "" {
 		awsConfig.WithEndpoint(params.RegionEndpoint)
-		awsConfig.WithS3ForcePathStyle(params.ForcePathStyle)
 	}
 
+	awsConfig.WithS3ForcePathStyle(params.ForcePathStyle)
 	awsConfig.WithS3UseAccelerate(params.Accelerate)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -80,7 +80,7 @@ func init() {
 				return nil, err
 			}
 		}
-		forcePathStyleBool := true
+		forcePathStyleBool := false
 		if forcePathStyle != "" {
 			forcePathStyleBool, err = strconv.ParseBool(forcePathStyle)
 			if err != nil {

--- a/tests/conf-e2e-cloud-storage.yml
+++ b/tests/conf-e2e-cloud-storage.yml
@@ -41,6 +41,7 @@ storage:
     bucket: images-local
     rootdirectory: /registry-v2
     regionendpoint: http://minio:9000
+    forcepathstyle: true
     encrypt: false
     secure: false
     chunksize: 33554432


### PR DESCRIPTION
Currently, the `forcepathstyle` parameter for the s3 storage driver is
considered only if the `regionendpoint` parameter is set. Since setting
a region endpoint explicitly is discouraged with AWS s3, it is not clear
how to enforce path style URLs with AWS s3.
This also means, that the default value (true) only applies if a region
endpoint is configured.

This change makes sure we always forward the `forcepathstyle` parameter
to the aws-sdk if present in the config. This is a breaking change where
a `regionendpoint` is configured but no explicit `forcepathstyle` value
is set.

Signed-off-by: Benjamin Schanzel <benjamin.schanzel@bmw.de>
