### PR TITLE
Standardize OTEL error logging format to match application logs

### DIFF
--- a/tracing/loggerwriter.go
+++ b/tracing/loggerwriter.go
@@ -1,0 +1,21 @@
+package tracing
+
+import "github.com/distribution/distribution/v3/internal/dcontext"
+
+// loggerWriter is a custom writer that implements the io.Writer interface.
+// It is designed to redirect log messages to the Logger interface, specifically
+// for use with OpenTelemetry's stdouttrace exporter.
+type loggerWriter struct {
+	logger dcontext.Logger // Use the Logger interface
+}
+
+// Write logs the data using the Debug level of the provided logger.
+func (lw *loggerWriter) Write(p []byte) (n int, err error) {
+	lw.logger.Debug(string(p))
+	return len(p), nil
+}
+
+// Handle logs the error using the Error level of the provided logger.
+func (lw *loggerWriter) Handle(err error) {
+	lw.logger.Error(err)
+}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -26,19 +26,6 @@ const (
 	AttributePrefix = "io.cncf.distribution."
 )
 
-// loggerWriter is a custom writer that implements the io.Writer interface.
-// It is designed to redirect log messages to the Logger interface, specifically
-// for use with OpenTelemetry's stdouttrace exporter.
-type loggerWriter struct {
-	logger dcontext.Logger // Use the Logger interface
-}
-
-// Write logs the data using the Debug level of the provided logger.
-func (lw *loggerWriter) Write(p []byte) (n int, err error) {
-	lw.logger.Debug(string(p))
-	return len(p), nil
-}
-
 // InitOpenTelemetry initializes OpenTelemetry for the application. This function sets up the
 // necessary components for collecting telemetry data, such as traces.
 func InitOpenTelemetry(ctx context.Context) error {
@@ -71,6 +58,7 @@ func InitOpenTelemetry(ctx context.Context) error {
 		sdktrace.WithSpanProcessor(sp),
 	)
 	otel.SetTracerProvider(provider)
+	otel.SetErrorHandler(lw)
 
 	pr := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 	otel.SetTextMapPropagator(pr)


### PR DESCRIPTION
Fixes #4275 

**Before**:
<img width="1405" alt="old" src="https://github.com/distribution/distribution/assets/4104908/20ad65a3-207f-4ba1-8187-8a0f64b03824">

**After**:
<img width="1407" alt="new" src="https://github.com/distribution/distribution/assets/4104908/ce070e9c-b901-4e92-b8f3-c0a3b433a8c6">

cc @corhere , @milosgajdos for review