### PR TITLE
Stop proxy scheduler on system exit

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -430,6 +430,14 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 	}
 }
 
+// Shutdown close the underlying registry
+func (app *App) Shutdown() error {
+	if r, ok := app.registry.(proxy.Closer); ok {
+		return r.Close()
+	}
+	return nil
+}
+
 // register a handler with the application, by route name. The handler will be
 // passed through the application filters and context will be constructed at
 // request time.

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -211,6 +211,15 @@ func (pr *proxyingRegistry) BlobStatter() distribution.BlobStatter {
 	return pr.embedded.BlobStatter()
 }
 
+type Closer interface {
+	// Close release all resources used by this object
+	Close() error
+}
+
+func (pr *proxyingRegistry) Close() error {
+	return pr.scheduler.Stop()
+}
+
 // authChallenger encapsulates a request to the upstream to establish credential challenges
 type authChallenger interface {
 	tryEstablishChallenges(context.Context) error

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -206,12 +206,13 @@ func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.
 }
 
 // Stop stops the scheduler.
-func (ttles *TTLExpirationScheduler) Stop() {
+func (ttles *TTLExpirationScheduler) Stop() error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
-	if err := ttles.writeState(); err != nil {
-		dcontext.GetLogger(ttles.ctx).Errorf("Error writing scheduler state: %s", err)
+	err := ttles.writeState()
+	if err != nil {
+		err = fmt.Errorf("error writing scheduler state: %w", err)
 	}
 
 	for _, entry := range ttles.entries {
@@ -221,6 +222,7 @@ func (ttles *TTLExpirationScheduler) Stop() {
 	close(ttles.doneChan)
 	ttles.saveTimer.Stop()
 	ttles.stopped = true
+	return err
 }
 
 func (ttles *TTLExpirationScheduler) writeState() error {

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -136,7 +136,12 @@ func TestRestoreOld(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error starting ttlExpirationScheduler: %s", err)
 	}
-	defer s.Stop()
+	defer func(s *TTLExpirationScheduler) {
+		err := s.Stop()
+		if err != nil {
+			t.Fatalf("Error stopping ttlExpirationScheduler: %s", err)
+		}
+	}(s)
 
 	wg.Wait()
 	mu.Lock()
@@ -177,7 +182,10 @@ func TestStopRestore(t *testing.T) {
 
 	// Start and stop before all operations complete
 	// state will be written to fs
-	s.Stop()
+	err = s.Stop()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	time.Sleep(10 * time.Millisecond)
 
 	// v2 will restore state from fs


### PR DESCRIPTION
For pull through cache registry with configured TTL, a scheduler responsible for blobs garbage collection is started here: [registry/proxy/proxyregistry.go#L109](https://github.com/distribution/distribution/blob/51a72c2aef976bd55de3a7b8b0120f97b4169476/registry/proxy/proxyregistry.go#L109), but its [Stop](https://github.com/distribution/distribution/blob/51a72c2aef976bd55de3a7b8b0120f97b4169476/registry/proxy/scheduler/scheduler.go#L208-L209) method is never invoked.

Scheduler state is written to `scheduler-state.json` if a state change is detected every 5 seconds.
When terminating the registry process, this can result in an inconsistent/corrupted `scheduler-state.json`:
- recent state changes are not saved at all
- `scheduler-state.json` has been truncated, but no new content has been written

This PR explicitly invokes scheduler Stop method on `SIGINT` & `SIGTERM` to ensure that scheduler state is preserved.

Fixes #2374 