### PR TITLE
Support redirects in gcs storage with default credentials

### DIFF
--- a/docs/content/storage-drivers/gcs.md
+++ b/docs/content/storage-drivers/gcs.md
@@ -17,4 +17,8 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Goog
 
 {{< hint type=note >}}
 Instead of a key file you can use [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+
+To use redirects with default credentials assigned to a virtual machine you have to enable "IAM Service Account Credentials API" and grant `iam.serviceAccounts.signBlob` permission on the used service account.
+
+To use redirects with default credentials from Google Cloud CLI, in addition to the permissions mentioned above, you have to [impersonate the service account intended to be used by the registry](https://cloud.google.com/sdk/gcloud/reference#--impersonate-service-account).
 {{< /hint >}}

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -785,10 +785,6 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 // RedirectURL returns a URL which may be used to retrieve the content stored at
 // the given path, possibly using the given options.
 func (d *driver) RedirectURL(r *http.Request, path string) (string, error) {
-	if d.privateKey == nil {
-		return "", nil
-	}
-
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		return "", nil
 	}


### PR DESCRIPTION
Hi! GCS storage driver does not support redirect URLs _only_ when configured to use application default credentials. Supporting this case looks useful in general and makes GCS driver behaviour consistent (currently, changing the configuration from using service account key to using default credentials may have an unexpected effect of making registry forward data increasing its' load).

This PR adds support and documentation for using redirects with default credentials. Since it was a very small change I've created the PR directly.

Sadly adding this isn't backward compatible - if someone is running a registry on a vm with default credentials and has left 'redirect' unconfigured then this PR is going to break their setup - after an upgrade they would start receiving errors if required IAM permissions weren't configured. It's easy to fix (either by configuring IAM, or by disabling 'redirect' in registry configuration), so maybe it would be ok for a major release? To make this backward compatible we could add an additional configurtation parameter ([like this](https://github.com/RTBHOUSE/distribution/commit/585a968e52f6070f4e86e8617c01d096843d52a6))...

WDYT, does it look ok?