### PR TITLE
Replace custom Redis config struct with go-redis UniversalOptions (adds sentinel & cluster support)

### DIFF
--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -20,11 +20,10 @@ http:
     headers:
         X-Content-Type-Options: [nosniff]
 redis:
-  addr: localhost:6379
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
+  addrs: [localhost:6379]
+  maxidleconns: 16
+  poolsize: 64
+  connmaxidletime: 300s
   dialtimeout: 10ms
   readtimeout: 10ms
   writetimeout: 10ms

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 // Configuration is a versioned registry configuration, intended to be provided by a yaml file, and
@@ -275,44 +277,6 @@ type FileChecker struct {
 	// Threshold is the number of times a check must fail to trigger an
 	// unhealthy state
 	Threshold int `yaml:"threshold,omitempty"`
-}
-
-// Redis configures the redis pool available to the registry webapp.
-type Redis struct {
-	// Addr specifies the redis instance available to the application.
-	Addr string `yaml:"addr,omitempty"`
-
-	// Usernames can be used as a finer-grained permission control since the introduction of the redis 6.0.
-	Username string `yaml:"username,omitempty"`
-
-	// Password string to use when making a connection.
-	Password string `yaml:"password,omitempty"`
-
-	// DB specifies the database to connect to on the redis instance.
-	DB int `yaml:"db,omitempty"`
-
-	// TLS configures settings for redis in-transit encryption
-	TLS struct {
-		Enabled bool `yaml:"enabled,omitempty"`
-	} `yaml:"tls,omitempty"`
-
-	DialTimeout  time.Duration `yaml:"dialtimeout,omitempty"`  // timeout for connect
-	ReadTimeout  time.Duration `yaml:"readtimeout,omitempty"`  // timeout for reads of data
-	WriteTimeout time.Duration `yaml:"writetimeout,omitempty"` // timeout for writes of data
-
-	// Pool configures the behavior of the redis connection pool.
-	Pool struct {
-		// MaxIdle sets the maximum number of idle connections.
-		MaxIdle int `yaml:"maxidle,omitempty"`
-
-		// MaxActive sets the maximum number of connections that should be
-		// opened before blocking a connection request.
-		MaxActive int `yaml:"maxactive,omitempty"`
-
-		// IdleTimeout sets the amount time to wait before closing
-		// inactive connections.
-		IdleTimeout time.Duration `yaml:"idletimeout,omitempty"`
-	} `yaml:"pool,omitempty"`
 }
 
 // HTTPChecker is a type of entry in the health section for checking HTTP URIs.
@@ -687,4 +651,125 @@ func Parse(rd io.Reader) (*Configuration, error) {
 	}
 
 	return config, nil
+}
+
+type Redis struct {
+	redis.UniversalOptions
+}
+
+func (c Redis) MarshalYAML() (interface{}, error) {
+	fields := make(map[string]interface{})
+
+	val := reflect.ValueOf(c.UniversalOptions)
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+
+		// ignore imports and funcs
+		if field.PkgPath != "" || fieldValue.Kind() == reflect.Func {
+			continue
+		}
+
+		fields[strings.ToLower(field.Name)] = fieldValue.Interface()
+	}
+
+	return fields, nil
+}
+
+func (c *Redis) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var fields map[string]interface{}
+	err := unmarshal(&fields)
+	if err != nil {
+		return err
+	}
+
+	val := reflect.ValueOf(&c.UniversalOptions).Elem()
+	typ := val.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		fieldName := strings.ToLower(field.Name)
+
+		if value, ok := fields[fieldName]; ok {
+			fieldValue := val.Field(i)
+			if fieldValue.CanSet() {
+				switch field.Type {
+				case reflect.TypeOf(time.Duration(0)):
+					durationStr, ok := value.(string)
+					if !ok {
+						return fmt.Errorf("invalid duration value for field: %s", fieldName)
+					}
+					duration, err := time.ParseDuration(durationStr)
+					if err != nil {
+						return fmt.Errorf("failed to parse duration for field: %s, error: %v", fieldName, err)
+					}
+					fieldValue.Set(reflect.ValueOf(duration))
+				default:
+					if err := setFieldValue(fieldValue, value); err != nil {
+						return fmt.Errorf("failed to set value for field: %s, error: %v", fieldName, err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func setFieldValue(field reflect.Value, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	switch field.Kind() {
+	case reflect.String:
+		stringValue, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("failed to convert value to string")
+		}
+		field.SetString(stringValue)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		intValue, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("failed to convert value to integer")
+		}
+		field.SetInt(int64(intValue))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		uintValue, ok := value.(uint)
+		if !ok {
+			return fmt.Errorf("failed to convert value to unsigned integer")
+		}
+		field.SetUint(uint64(uintValue))
+	case reflect.Float32, reflect.Float64:
+		floatValue, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("failed to convert value to float")
+		}
+		field.SetFloat(floatValue)
+	case reflect.Bool:
+		boolValue, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("failed to convert value to boolean")
+		}
+		field.SetBool(boolValue)
+	case reflect.Slice:
+		slice := reflect.MakeSlice(field.Type(), 0, 0)
+		valueSlice, ok := value.([]interface{})
+		if !ok {
+			return fmt.Errorf("failed to convert value to slice")
+		}
+		for _, item := range valueSlice {
+			sliceValue := reflect.New(field.Type().Elem()).Elem()
+			if err := setFieldValue(sliceValue, item); err != nil {
+				return err
+			}
+			slice = reflect.Append(slice, sliceValue)
+		}
+		field.Set(slice)
+	default:
+		return fmt.Errorf("unsupported field type: %v", field.Type())
+	}
+	return nil
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -653,19 +653,23 @@ func Parse(rd io.Reader) (*Configuration, error) {
 	return config, nil
 }
 
+type RedisOptions = redis.UniversalOptions
+
+type RedisTLSOptions struct {
+	Certificate string   `yaml:"certificate,omitempty"`
+	Key         string   `yaml:"key,omitempty"`
+	ClientCAs   []string `yaml:"clientcas,omitempty"`
+}
+
 type Redis struct {
-	redis.UniversalOptions `yaml:",inline"`
-	TLS                    struct {
-		Certificate string   `yaml:"certificate,omitempty"`
-		Key         string   `yaml:"key,omitempty"`
-		ClientCAs   []string `yaml:"clientcas,omitempty"`
-	} `yaml:"tls,omitempty"`
+	Options RedisOptions    `yaml:",inline"`
+	TLS     RedisTLSOptions `yaml:"tls,omitempty"`
 }
 
 func (c Redis) MarshalYAML() (interface{}, error) {
 	fields := make(map[string]interface{})
 
-	val := reflect.ValueOf(c.UniversalOptions)
+	val := reflect.ValueOf(c.Options)
 	typ := val.Type()
 
 	for i := 0; i < val.NumField(); i++ {
@@ -695,7 +699,7 @@ func (c *Redis) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	val := reflect.ValueOf(&c.UniversalOptions).Elem()
+	val := reflect.ValueOf(&c.Options).Elem()
 	typ := val.Type()
 
 	for i := 0; i < typ.NumField(); i++ {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -132,7 +132,7 @@ var configStruct = Configuration{
 		},
 	},
 	Redis: Redis{
-		UniversalOptions: redis.UniversalOptions{
+		Options: redis.UniversalOptions{
 			Addrs:           []string{"localhost:6379"},
 			Username:        "alice",
 			Password:        "123456",
@@ -144,11 +144,7 @@ var configStruct = Configuration{
 			ReadTimeout:     time.Millisecond * 10,
 			WriteTimeout:    time.Millisecond * 10,
 		},
-		TLS: struct {
-			Certificate string   `yaml:"certificate,omitempty"`
-			Key         string   `yaml:"key,omitempty"`
-			ClientCAs   []string `yaml:"clientcas,omitempty"`
-		}{
+		TLS: RedisTLSOptions{
 			Certificate: "/foo/cert.crt",
 			Key:         "/foo/key.pem",
 			ClientCAs:   []string{"/path/to/ca.pem"},

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v2"
 )
@@ -131,22 +132,18 @@ var configStruct = Configuration{
 		},
 	},
 	Redis: Redis{
-		Addr:     "localhost:6379",
-		Username: "alice",
-		Password: "123456",
-		DB:       1,
-		Pool: struct {
-			MaxIdle     int           `yaml:"maxidle,omitempty"`
-			MaxActive   int           `yaml:"maxactive,omitempty"`
-			IdleTimeout time.Duration `yaml:"idletimeout,omitempty"`
-		}{
-			MaxIdle:     16,
-			MaxActive:   64,
-			IdleTimeout: time.Second * 300,
+		redis.UniversalOptions{
+			Addrs:           []string{"localhost:6379"},
+			Username:        "alice",
+			Password:        "123456",
+			DB:              1,
+			MaxIdleConns:    16,
+			PoolSize:        64,
+			ConnMaxIdleTime: time.Second * 300,
+			DialTimeout:     time.Millisecond * 10,
+			ReadTimeout:     time.Millisecond * 10,
+			WriteTimeout:    time.Millisecond * 10,
 		},
-		DialTimeout:  time.Millisecond * 10,
-		ReadTimeout:  time.Millisecond * 10,
-		WriteTimeout: time.Millisecond * 10,
 	},
 }
 
@@ -190,14 +187,13 @@ http:
   headers:
     X-Content-Type-Options: [nosniff]
 redis:
-  addr: localhost:6379
+  addrs: [localhost:6379]
   username: alice
-  password: 123456
+  password: "123456"
   db: 1
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
+  maxidleconns: 16
+  poolsize: 64
+  connmaxidletime: 300s
   dialtimeout: 10ms
   readtimeout: 10ms
   writetimeout: 10ms

--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -241,6 +241,11 @@ notifications:
         actions:
            - pull
 redis:
+  tls:
+    certificate: /path/to/cert.crt
+    key: /path/to/key.pem
+    clientcas:
+      - /path/to/ca.pem
   addrs: [localhost:6379]
   password: asecret
   db: 0
@@ -959,12 +964,27 @@ how the registry connects to the `redis` instance.
 You should configure Redis with the **allkeys-lru** eviction policy, because the
 registry does not set an expiration value on keys.
 
-Under the hood distribution uses [`go-redis`](https://redis.uptrace.dev/) for
-redis connectivity and its [`UniversalOptions`](https://pkg.go.dev/github.com/redis/go-redis/v9#UniversalOptions)
+Under the hood distribution uses [`go-redis`](https://github.com/redis/go-redis) Go module for
+Redis connectivity and its [`UniversalOptions`](https://pkg.go.dev/github.com/redis/go-redis/v9#UniversalOptions)
 struct.
+
+You can optionally specify TLS configuration on top of the `UniversalOptions` settings.
+
+Use these settings to configure Redis TLS:
+
+| Parameter | Required | Description                                           |
+|-----------|----------|-------------------------------------------------------|
+| `certificate`  | yes  | Absolute path to the x509 certificate file.           |
+| `key`          | yes  | Absolute path to the x509 private key file.           |
+| `clientcas`    | no   | An array of absolute paths to x509 CA files.          |
 
 ```yaml
 redis:
+  tls:
+    certificate: /path/to/cert.crt
+    key: /path/to/key.pem
+    clientcas:
+      - /path/to/ca.pem
   addrs: [localhost:6379]
   password: asecret
   db: 0

--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -241,16 +241,15 @@ notifications:
         actions:
            - pull
 redis:
-  addr: localhost:6379
+  addrs: [localhost:6379]
   password: asecret
   db: 0
   dialtimeout: 10ms
   readtimeout: 10ms
   writetimeout: 10ms
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
+  maxidleconns: 16
+  poolsize: 64
+  connmaxidletime: 300s
   tls:
     enabled: false
 health:
@@ -952,71 +951,30 @@ The `events` structure configures the information provided in event notification
 
 ## `redis`
 
+Declare parameters for constructing the `redis` connections. Registry instances
+may use the Redis instance for several applications. Currently, it caches
+information about immutable blobs. Most of the `redis` options control
+how the registry connects to the `redis` instance.
+
+You should configure Redis with the **allkeys-lru** eviction policy, because the
+registry does not set an expiration value on keys.
+
+Under the hood distribution uses [`go-redis`](https://redis.uptrace.dev/) for
+redis connectivity and its [`UniversalOptions`](https://pkg.go.dev/github.com/redis/go-redis/v9#UniversalOptions)
+struct.
+
 ```yaml
 redis:
-  addr: localhost:6379
+  addrs: [localhost:6379]
   password: asecret
   db: 0
   dialtimeout: 10ms
   readtimeout: 10ms
   writetimeout: 10ms
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
-  tls:
-    enabled: false
+  maxidleconns: 16
+  poolsize: 64
+  connmaxidletime: 300s
 ```
-
-Declare parameters for constructing the `redis` connections. Registry instances
-may use the Redis instance for several applications. Currently, it caches
-information about immutable blobs. Most of the `redis` options control
-how the registry connects to the `redis` instance. You can control the pool's
-behavior with the [pool](#pool) subsection. Additionally, you can control
-TLS connection settings with the [tls](#tls) subsection (in-transit encryption).
-
-You should configure Redis with the **allkeys-lru** eviction policy, because the
-registry does not set an expiration value on keys.
-
-| Parameter | Required | Description                                           |
-|-----------|----------|-------------------------------------------------------|
-| `addr`    | yes      | The address (host and port) of the Redis instance.    |
-| `password`| no       | A password used to authenticate to the Redis instance.|
-| `db`      | no       | The name of the database to use for each connection.  |
-| `dialtimeout` | no   | The timeout for connecting to the Redis instance.     |
-| `readtimeout` | no   | The timeout for reading from the Redis instance.      |
-| `writetimeout` | no  | The timeout for writing to the Redis instance.        |
-
-### `pool`
-
-```yaml
-pool:
-  maxidle: 16
-  maxactive: 64
-  idletimeout: 300s
-```
-
-Use these settings to configure the behavior of the Redis connection pool.
-
-| Parameter | Required | Description                                           |
-|-----------|----------|-------------------------------------------------------|
-| `maxidle` | no       | The maximum number of idle connections in the pool.   |
-| `maxactive`| no      | The maximum number of connections which can be open before blocking a connection request. |
-| `idletimeout`| no    | How long to wait before closing inactive connections. |
-
-### `tls`
-
-```yaml
-tls:
-  enabled: false
-```
-
-Use these settings to configure Redis TLS.
-
-| Parameter | Required | Description                           |
-|-----------|----------|-------------------------------------- |
-| `enabled` | no       | Whether or not to use TLS in-transit. |
-
 
 ## `health`
 

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -489,7 +489,7 @@ func (app *App) configureEvents(configuration *configuration.Configuration) {
 }
 
 func (app *App) configureRedis(cfg *configuration.Configuration) {
-	if len(cfg.Redis.Addrs) == 0 {
+	if len(cfg.Redis.Options.Addrs) == 0 {
 		dcontext.GetLogger(app).Infof("redis not configured")
 		return
 	}
@@ -520,10 +520,10 @@ func (app *App) configureRedis(cfg *configuration.Configuration) {
 			tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
 			tlsConf.ClientCAs = pool
 		}
-		cfg.Redis.UniversalOptions.TLSConfig = tlsConf
+		cfg.Redis.Options.TLSConfig = tlsConf
 	}
 
-	app.redis = app.createPool(cfg.Redis.UniversalOptions)
+	app.redis = app.createPool(cfg.Redis.Options)
 
 	// Enable metrics instrumentation.
 	if err := redisotel.InstrumentMetrics(app.redis); err != nil {

--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -25,7 +25,7 @@ import (
 // Note that there is no implied relationship between these two caches. The
 // layer may exist in one, both or none and the code must be written this way.
 type redisBlobDescriptorService struct {
-	pool *redis.Client
+	pool redis.UniversalClient
 
 	// TODO(stevvooe): We use a pool because we don't have great control over
 	// the cache lifecycle to manage connections. A new connection if fetched
@@ -37,7 +37,7 @@ var _ distribution.BlobDescriptorService = &redisBlobDescriptorService{}
 
 // NewRedisBlobDescriptorCacheProvider returns a new redis-based
 // BlobDescriptorCacheProvider using the provided redis connection pool.
-func NewRedisBlobDescriptorCacheProvider(pool *redis.Client) cache.BlobDescriptorCacheProvider {
+func NewRedisBlobDescriptorCacheProvider(pool redis.UniversalClient) cache.BlobDescriptorCacheProvider {
 	return metrics.NewPrometheusCacheProvider(
 		&redisBlobDescriptorService{
 			pool: pool,

--- a/tests/conf-e2e-cloud-storage.yml
+++ b/tests/conf-e2e-cloud-storage.yml
@@ -17,15 +17,14 @@ log:
     formatter: text
     level: debug
 redis:
-   addr: redis:6379
+   addrs: [redis:6379]
    db: 0
    dialtimeout: 5s
    readtimeout: 10ms
    writetimeout: 10ms
-   pool:
-     idletimeout: 60s
-     maxactive: 64
-     maxidle: 16
+   maxidleconns: 16
+   poolsize: 64
+   connmaxidletime: 300s
 storage:
   redirect:
     disable: true


### PR DESCRIPTION
Less code more features! :-D

This PR replaces the custom `Redis` config struct with `UniversalOptions` from `go-redis`, which implicitly adds support for both redis sentinel and redis clustering.

I have two failing tests that I can't quite figure out how to fix:
```
    --- FAIL: TestConfigSuite/TestMarshalRoundtrip (0.00s)
    --- FAIL: TestConfigSuite/TestParseInvalidVersion (0.00s)
```

<details><summary>Associated stack trace</summary>

```
    suite.go:87: test panicked: cannot marshal type: func(context.Context, string, string) (net.Conn, error)
        goroutine 18 [running]:
        runtime/debug.Stack()
        	/usr/lib/go-1.21/src/runtime/debug/stack.go:24 +0x5e
        github.com/stretchr/testify/suite.failOnPanic(0xc0002b8820, {0x8ebe40, 0xc0002c5850})
        	/home/aim/Workspace/forks/distribution/vendor/github.com/stretchr/testify/suite/suite.go:87 +0x39
        github.com/stretchr/testify/suite.Run.func1.1()
        	/home/aim/Workspace/forks/distribution/vendor/github.com/stretchr/testify/suite/suite.go:183 +0x24c
        panic({0x8ebe40?, 0xc0002c5850?})
        	/usr/lib/go-1.21/src/runtime/panic.go:914 +0x21f
        gopkg.in/yaml%2ev2.handleErr(0xc0001513c8)
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/yaml.go:249 +0x6d
        panic({0x8ebe40?, 0xc0002c5850?})
        	/usr/lib/go-1.21/src/runtime/panic.go:914 +0x21f
        gopkg.in/yaml%2ev2.(*encoder).marshal(0xc000220b00, {0x0, 0x0}, {0x913e00?, 0xc0002de618?, 0x0?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:183 +0xa34
        gopkg.in/yaml%2ev2.(*encoder).structv.func1()
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:226 +0x1fc
        gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc000220b00, {0x0?, 0x0}, 0xc000150c58)
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:256 +0x14a
        gopkg.in/yaml%2ev2.(*encoder).structv(0xc000220b00, {0x0, 0x0}, {0x9778a0?, 0xc0002de5e8?, 0xc0002de6c8?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:213 +0xe5
        gopkg.in/yaml%2ev2.(*encoder).marshal(0xc000220b00, {0x0, 0x0}, {0x9778a0?, 0xc0002de5e8?, 0x91b7e0?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:160 +0x945
        gopkg.in/yaml%2ev2.(*encoder).structv.func1()
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:226 +0x1fc
        gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc000220b00, {0x0?, 0x0}, 0xc00013d028)
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:256 +0x14a
        gopkg.in/yaml%2ev2.(*encoder).structv(0xc000220b00, {0x0, 0x0}, {0x96d600?, 0xc0002de400?, 0x18?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:213 +0xe5
        gopkg.in/yaml%2ev2.(*encoder).marshal(0xc000220b00, {0x0, 0x0}, {0x96d600?, 0xc0002de400?, 0x96d7c0?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:160 +0x945
        gopkg.in/yaml%2ev2.(*encoder).marshal(0xc000220b00, {0x0, 0x0}, {0x8dcb80?, 0xc0002de400?, 0xc00013d348?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:154 +0x74b
        gopkg.in/yaml%2ev2.(*encoder).marshalDoc(0xc000220b00, {0x0, 0x0}, {0x8dcb80?, 0xc0002de400?, 0xc00013d3c8?})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/encode.go:93 +0xcb
        gopkg.in/yaml%2ev2.Marshal({0x8dcb80, 0xc0002de400})
        	/home/aim/Workspace/forks/distribution/vendor/gopkg.in/yaml.v2/yaml.go:203 +0x319
        github.com/distribution/distribution/v3/configuration.(*ConfigSuite).TestParseInvalidVersion(0xc00007e4b0)
        	/home/aim/Workspace/forks/distribution/configuration/configuration_test.go:397 +0xfa
        reflect.Value.call({0xc00007de80?, 0xc0000550b8?, 0x0?}, {0x99472c, 0x4}, {0xc000065e70, 0x1, 0xc000065d78?})
        	/usr/lib/go-1.21/src/reflect/value.go:596 +0xce7
        reflect.Value.Call({0xc00007de80?, 0xc0000550b8?, 0xc00007e4b0?}, {0xc000065e70?, 0x5214cd?, 0xc69e78?})
        	/usr/lib/go-1.21/src/reflect/value.go:380 +0xb9
        github.com/stretchr/testify/suite.Run.func1(0xc0002b8820)
        	/home/aim/Workspace/forks/distribution/vendor/github.com/stretchr/testify/suite/suite.go:197 +0x467
        testing.tRunner(0xc0002b8820, 0xc00019c630)
        	/usr/lib/go-1.21/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 6
        	/usr/lib/go-1.21/src/testing/testing.go:1648 +0x3ad
```

</details>

As v3 is still in alpha I was hoping that there would still be time for this to make it into the release.