### PR TITLE
[release/2.8 backport] Don't try to parse error responses with no body

### DIFF
--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -46,8 +46,14 @@ func parseHTTPErrorResponse(resp *http.Response) error {
 	}
 
 	statusCode := resp.StatusCode
-	ctHeader := resp.Header.Get("Content-Type")
 
+	// A HEAD request for example validly does not contain any body, while
+	// still returning a JSON content-type.
+	if len(body) == 0 {
+		return makeError(statusCode, "")
+	}
+
+	ctHeader := resp.Header.Get("Content-Type")
 	if ctHeader == "" {
 		return makeError(statusCode, string(body))
 	}

--- a/registry/client/errors_test.go
+++ b/registry/client/errors_test.go
@@ -46,6 +46,22 @@ func TestHandleErrorResponse401WithInvalidBody(t *testing.T) {
 	}
 }
 
+func TestHandleHTTPResponseError401WithNoBody(t *testing.T) {
+	json := ""
+	response := &http.Response{
+		Status:     "401 Unauthorized",
+		StatusCode: 401,
+		Body:       nopCloser{bytes.NewBufferString(json)},
+		Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+	}
+	err := HandleHTTPResponseError(response)
+
+	expectedMsg := "unauthorized: "
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Expected %q, got: %q", expectedMsg, err.Error())
+	}
+}
+
 func TestHandleErrorResponseExpectedStatusCode400ValidBody(t *testing.T) {
 	json := `{"errors":[{"code":"DIGEST_INVALID","message":"provided digest does not match"}]}`
 	response := &http.Response{


### PR DESCRIPTION
Backport of https://github.com/distribution/distribution/pull/4307