### PR TITLE
Upgrade Scorecard Action version to fix error 

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # tag=v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
It seems the new version of Scorecard fixed this error. It seems it was caused by a infrastructure change on Sigstore Cosign used by Scorecard to sign the result artifact before publishing.

Thanks for pinging me!

> @joycebrum this has started failing in this repo and I've no idea why. The verbosity of the log is pretty wild. Mind having a look?

_Originally posted by @milosgajdos in https://github.com/distribution/distribution/issues/3740#issuecomment-2018801221_
            