### PR TITLE
Update S3 flush to not have last part greater than defined chunkSize

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1612,13 +1612,6 @@ func (w *writer) flush() error {
 	}
 
 	buf := bytes.NewBuffer(w.ready.data)
-	if w.pending.Len() > 0 && w.pending.Len() < int(w.driver.ChunkSize) {
-		if _, err := buf.Write(w.pending.data); err != nil {
-			return err
-		}
-		w.pending.Clear()
-	}
-
 	partSize := buf.Len()
 	partNumber := aws.Int64(int64(len(w.parts) + 1))
 
@@ -1643,5 +1636,9 @@ func (w *writer) flush() error {
 	w.ready.Clear()
 	w.ready, w.pending = w.pending, w.ready
 
+	// In case we have more data in the pending buffer (now ready), we need to flush it
+	if w.ready.Len() > 0 {
+		return w.flush()
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/distribution/distribution/issues/3873

The new implementation ensures no part size exceeds the defined Chunk size. In the screenshot shared, this is before the changes where the size of the last part was `6579438` which is more than the defined `5242880`

The following logic is removed which was responsible for adding the last part bytes into the `buf`
```
-	if w.pending.Len() > 0 && w.pending.Len() < int(w.driver.ChunkSize) {
-		if _, err := buf.Write(w.pending.data); err != nil {
-			return err
-		}
-		w.pending.Clear()
-	}
```

![Screenshot 2024-04-16 at 1 40 39 PM](https://github.com/distribution/distribution/assets/66587720/580600f8-779e-427a-a51c-0ed27a2c867a)
