### PR TITLE
fix: ignore error of manifest tag path not found in gc

### DIFF
--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -73,7 +73,8 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 					// which means that we need check (and delete) those references when deleting manifest
 					allTags, err := repository.Tags(ctx).All(ctx)
 					if err != nil {
-						if _, ok := err.(distribution.ErrManifestUnknownRevision); !ok {
+						if _, ok := err.(distribution.ErrRepositoryUnknown); ok {
+							emit("manifest tags path of repository %s does not exist", repoName)
 							return nil
 						}
 						return fmt.Errorf("failed to retrieve tags %v", err)


### PR DESCRIPTION
it is reasonable to ignore the error that the manifest tag path does not exist when querying all tags of the specified repository when executing gc.

Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>