### PR TITLE
fix logic for handling regionEndpoint

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -223,12 +223,13 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 	}
 
 	regionName := parameters["region"]
-	if regionName == nil || fmt.Sprint(regionName) == "" {
-		return nil, fmt.Errorf("no region parameter provided")
-	}
 	region := fmt.Sprint(regionName)
+
 	// Don't check the region value if a custom endpoint is provided.
 	if regionEndpoint == "" {
+		if regionName == nil || region == "" {
+			return nil, fmt.Errorf("no region parameter provided")
+		}
 		if _, ok := validRegions[region]; !ok {
 			return nil, fmt.Errorf("invalid region provided: %v", region)
 		}


### PR DESCRIPTION
The current logic only checks the region and returns if it's empty; however, we are not validating the regionEndpoint parameter. Therefore, if the user provides only the regionEndpoint without any region, this will not be evaluated.