### PR TITLE
JWKS section to docs

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -168,6 +168,7 @@ auth:
     service: token-service
     issuer: registry-token-issuer
     rootcertbundle: /root/certs/bundle
+    jwks: /path/to/jwks
   htpasswd:
     realm: basic-realm
     path: /path/to/htpasswd
@@ -572,6 +573,7 @@ auth:
     service: token-service
     issuer: registry-token-issuer
     rootcertbundle: /root/certs/bundle
+    jwks: /path/to/jwks
   htpasswd:
     realm: basic-realm
     path: /path/to/htpasswd
@@ -615,6 +617,7 @@ security.
 | `rootcertbundle` | yes | The absolute path to the root certificate bundle. This bundle contains the public part of the certificates used to sign authentication tokens. |
 | `autoredirect`   | no      | When set to `true`, `realm` will automatically be set using the Host header of the request as the domain and a path of `/auth/token/`(or specified by `autoredirectpath`), the `realm` URL Scheme will use `X-Forwarded-Proto` header if set, otherwise it will be set to `https`. |
 | `autoredirectpath`   | no      | The path to redirect to if `autoredirect` is set to `true`, default: `/auth/token/`. |
+| `jwks`    | no       | The absolute path to the JSON Web Key Set (JWKS) file. The JWKS file contains the trusted keys used to verify the signature of authentication tokens. |
 
 
 For more information about Token based authentication configuration, see the


### PR DESCRIPTION
Currently, the documentation lacks information about the `jwks` parameter added  by https://github.com/distribution/distribution/pull/4096

This PR attempts to append the documentation.

Note: 
Appending the [token](https://github.com/distribution/distribution/blob/main/docs/content/spec/auth/token.md) or [jwt](https://github.com/distribution/distribution/blob/main/docs/content/spec/auth/jwt.md) docs with an in-depth explanation of how the `jwks` parameter will affect the authentication process would probably be helpful. 
