### PR TITLE
Add a go.mod toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/distribution/distribution/v3
 
-go 1.21
+go 1.21.8
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
go 1.21 added toolchain support. We should now specify a toolchain version in go.mod.

https://go.dev/doc/toolchain