### PR TITLE
Opt: refector tag list pagination support (stage 1)

### DIFF
--- a/internal/client/repository.go
+++ b/internal/client/repository.go
@@ -349,6 +349,10 @@ func (t *tags) Lookup(ctx context.Context, digest distribution.Descriptor) ([]st
 	panic("not implemented")
 }
 
+func (t *tags) List(ctx context.Context, limit int, last string) ([]string, error) {
+	panic("not implemented")
+}
+
 func (t *tags) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
 	panic("not implemented")
 }

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -563,9 +563,11 @@ func TestTagsAPI(t *testing.T) {
 			queryParams:        url.Values{"last": []string{"does-not-exist"}, "n": []string{"3"}},
 			expectedStatusCode: http.StatusOK,
 			expectedBody: tagsAPIResponse{Name: imageName.Name(), Tags: []string{
+				"jyi7b",
 				"kb0j5",
 				"sb71y",
 			}},
+			expectedLinkHeader: `</v2/test/tags/list?last=sb71y&n=3>; rel="next"`,
 		},
 	}
 

--- a/registry/proxy/proxytagservice.go
+++ b/registry/proxy/proxytagservice.go
@@ -64,3 +64,7 @@ func (pt proxyTagService) All(ctx context.Context) ([]string, error) {
 func (pt proxyTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
 	return []string{}, distribution.ErrUnsupported
 }
+
+func (pt proxyTagService) List(ctx context.Context, limit int, last string) ([]string, error) {
+	return []string{}, distribution.ErrUnsupported
+}

--- a/registry/proxy/proxytagservice_test.go
+++ b/registry/proxy/proxytagservice_test.go
@@ -57,6 +57,13 @@ func (m *mockTagStore) All(ctx context.Context) ([]string, error) {
 	return tags, nil
 }
 
+func (m *mockTagStore) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	panic("not implemented")
+}
+
+func (m *mockTagStore) List(ctx context.Context, limit int, last string) ([]string, error) {
+	panic("not implemented")
+}
 func testProxyTagService(local, remote map[string]distribution.Descriptor) *proxyTagService {
 	if local == nil {
 		local = make(map[string]distribution.Descriptor)

--- a/tags.go
+++ b/tags.go
@@ -26,6 +26,9 @@ type TagService interface {
 
 	// Lookup returns the set of tags referencing the given digest.
 	Lookup(ctx context.Context, digest Descriptor) ([]string, error)
+
+	// List returns the set of tags after last managed by this tag service
+	List(ctx context.Context, limit int, last string) ([]string, error)
 }
 
 // TagManifestsProvider provides method to retrieve the digests of manifests that a tag historically


### PR DESCRIPTION
Stage 1 for this [PR](https://github.com/distribution/distribution/pull/4353)：

- Use `storagedriver.WithStartAfterHint` to optimize the current tags list API implementation. When specifying paging parameters, there is no need to load all tags in the repository into memory.