### PR TITLE
New path for distribution config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ COPY --from=releaser /out /
 
 FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache ca-certificates
-COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+COPY cmd/registry/config-dev.yml /etc/distribution/config.yml
 COPY --from=binary /registry /bin/registry
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]
-CMD ["serve", "/etc/docker/registry/config.yml"]
+CMD ["serve", "/etc/distribution/config.yml"]

--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -50,7 +50,7 @@ specify it in the `docker run` command:
 
 ```bash
 $ docker run -d -p 5000:5000 --restart=always --name registry \
-             -v `pwd`/config.yml:/etc/docker/registry/config.yml \
+             -v `pwd`/config.yml:/etc/distribution/config.yml \
              registry:2
 ```
 

--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -72,7 +72,7 @@ be configured to use the `filesystem` driver for storage.
 
 The easiest way to run a registry as a pull through cache is to run the official
 Registry image.
-At least, you need to specify `proxy.remoteurl` within `/etc/docker/registry/config.yml`
+At least, you need to specify `proxy.remoteurl` within `/etc/distribution/config.yml`
 as described in the following subsection.
 
 Multiple registry caches can be deployed over the same back-end. A single

--- a/docs/dockerhub.md
+++ b/docs/dockerhub.md
@@ -44,7 +44,7 @@ docker run -d -p 5000:5000 $PWD/FS/PATH:/var/lib/registry --restart always --nam
 If you don't wan to use the default configuration file, you can supply
 your own custom configuration file as follows:
 ```
-docker run -d -p 5000:5000 $PWD/PATH/TO/config.yml:/etc/docker/registry/config.yml --restart always --name registry distribution/distribution:edge
+docker run -d -p 5000:5000 $PWD/PATH/TO/config.yml:/etc/distribution/config.yml --restart always --name registry distribution/distribution:edge
 ```
 
 ## Communication

--- a/tests/docker-compose-e2e-cloud-storage.yml
+++ b/tests/docker-compose-e2e-cloud-storage.yml
@@ -43,7 +43,7 @@ services:
       dockerfile: ./Dockerfile
     command:
       - "serve"
-      - "/etc/docker/registry/config-test.yml"
+      - "/etc/distribution/config-test.yml"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/debug/health"]
       interval: 5s
@@ -58,4 +58,4 @@ services:
       - "5000:5000"
       - "5001:5001"
     volumes:
-      - ./conf-e2e-cloud-storage.yml:/etc/docker/registry/config-test.yml
+      - ./conf-e2e-cloud-storage.yml:/etc/distribution/config-test.yml


### PR DESCRIPTION
The original path was referencing a docker directory which no longer makes much sense.

Closes https://github.com/distribution/distribution/issues/4357

Also see: https://github.com/distribution/distribution-library-image/pull/166