### PR TITLE
docs: disable base element override

### DIFF
--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -26,4 +26,3 @@ params:
   geekdocContentLicense:
     name: CC BY 4.0
     link: https://creativecommons.org/licenses/by/4.0/
-  geekdocOverwriteHTMLBase: true


### PR DESCRIPTION
It seems like the `geekdocOverwriteHTMLBase` configuration option caused local links URL fragments to target the root URL of the site, rather than the current page.

Closes #4388
