### PR TITLE
fix nil pointer in s3 list api

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -874,19 +874,19 @@ func (d *driver) List(ctx context.Context, opath string) ([]string, error) {
 			directories = append(directories, strings.Replace(commonPrefix[0:len(commonPrefix)-1], d.s3Path(""), prefix, 1))
 		}
 
-		if *resp.IsTruncated {
-			resp, err = d.S3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
-				Bucket:            aws.String(d.Bucket),
-				Prefix:            aws.String(d.s3Path(path)),
-				Delimiter:         aws.String("/"),
-				MaxKeys:           aws.Int64(listMax),
-				ContinuationToken: resp.NextContinuationToken,
-			})
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
 			break
+		}
+
+		resp, err = d.S3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(d.Bucket),
+			Prefix:            aws.String(d.s3Path(path)),
+			Delimiter:         aws.String("/"),
+			MaxKeys:           aws.Int64(listMax),
+			ContinuationToken: resp.NextContinuationToken,
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Fixes #4411
Ref: https://github.com/project-zot/zot/pull/2532

On other situations, a nil check is present. 

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L760

---

There are still some missing nil checks, not sure

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L740

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L727

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L794

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L778-L779

https://github.com/distribution/distribution/blob/252619876af36ec194d918b8fd87fba018c4971b/registry/storage/driver/s3-aws/s3.go#L682