### PR TITLE
Use `x.y.0` format for the go module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/distribution/distribution/v3
 
-go 1.22.5
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
Updating the `github.com/distribution/distribution/v3` dependency from `v3.0.0-alpha.1` to `v3.0.0-beta.1` the module version of the corresponding project gets updated automatically: see https://github.com/gardener/gardener/pull/10105/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R3-R5

We want to use the `x.y.0` format in the module version, see the motivation in https://github.com/gardener/gardener/pull/9564.

Other projects like [kubernetes](https://github.com/kubernetes/kubernetes/blob/a2106b5f73fe9352f7bc0520788855d57fc301e1/go.mod#L9) and [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/1ed345090869edc4bd94fe220386cb7fa5df745f/go.mod#L3) are using the same approach (the `x.y.0` format as their module version).