### PR TITLE
fix(registry/storage/driver/s3-aws): use a consistent multipart chunk size

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -80,9 +80,6 @@ Amazon S3 or S3 compatible services for object storage.
 
 `loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
 
-**NOTE:** Currently the S3 storage driver only supports S3 API compatible storage that
-allows parts of a multipart upload to vary in size. [Cloudflare R2 is not supported.](https://developers.cloudflare.com/r2/objects/multipart-objects/#limitations)
-
 ## S3 permission scopes
 
 The following AWS policy is required by the registry for push and pull. Make sure to replace `S3_BUCKET_NAME` with the name of your bucket.

--- a/registry/storage/driver/s3-aws/s3_32bit.go
+++ b/registry/storage/driver/s3-aws/s3_32bit.go
@@ -1,0 +1,10 @@
+//go:build arm
+
+package s3
+
+import "math"
+
+// maxChunkSize defines the maximum multipart upload chunk size allowed by S3.
+// S3 API requires max upload chunk to be 5GB, but this overflows on 32-bit
+// platforms.
+const maxChunkSize = math.MaxInt32

--- a/registry/storage/driver/s3-aws/s3_64bit.go
+++ b/registry/storage/driver/s3-aws/s3_64bit.go
@@ -1,0 +1,7 @@
+//go:build !arm
+
+package s3
+
+// maxChunkSize defines the maximum multipart upload chunk size allowed by S3.
+// S3 API requires max upload chunk to be 5GB.
+const maxChunkSize = 5 * 1024 * 1024 * 1024

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -101,30 +101,34 @@ func init() {
 			}
 		}
 
+		if objectACL == "" {
+			objectACL = s3.ObjectCannedACLPrivate
+		}
+
 		parameters := DriverParameters{
-			accessKey,
-			secretKey,
-			bucket,
-			region,
-			regionEndpoint,
-			forcePathStyleBool,
-			encryptBool,
-			keyID,
-			secureBool,
-			skipVerifyBool,
-			v4Bool,
-			minChunkSize,
-			defaultMultipartCopyChunkSize,
-			defaultMultipartCopyMaxConcurrency,
-			defaultMultipartCopyThresholdSize,
-			rootDirectory,
-			storageClass,
-			driverName + "-test",
-			objectACL,
-			sessionToken,
-			useDualStackBool,
-			accelerateBool,
-			getS3LogLevelFromParam(logLevel),
+			AccessKey:                   accessKey,
+			SecretKey:                   secretKey,
+			Bucket:                      bucket,
+			Region:                      region,
+			RegionEndpoint:              regionEndpoint,
+			ForcePathStyle:              forcePathStyleBool,
+			Encrypt:                     encryptBool,
+			KeyID:                       keyID,
+			Secure:                      secureBool,
+			SkipVerify:                  skipVerifyBool,
+			V4Auth:                      v4Bool,
+			ChunkSize:                   minChunkSize,
+			MultipartCopyChunkSize:      defaultMultipartCopyChunkSize,
+			MultipartCopyMaxConcurrency: defaultMultipartCopyMaxConcurrency,
+			MultipartCopyThresholdSize:  defaultMultipartCopyThresholdSize,
+			RootDirectory:               rootDirectory,
+			StorageClass:                storageClass,
+			UserAgent:                   driverName + "-test",
+			ObjectACL:                   objectACL,
+			SessionToken:                sessionToken,
+			UseDualStack:                useDualStackBool,
+			Accelerate:                  accelerateBool,
+			LogLevel:                    getS3LogLevelFromParam(logLevel),
 		}
 
 		return New(context.Background(), parameters)


### PR DESCRIPTION
Some S3 compatible object storage systems like R2 require that all multipart chunks are the same size. This was mostly true before, except the final chunk was larger than the requested chunk size which causes uploads to fail.

In addition, the two byte slices have been replaced with a single *bytes.Buffer and the surrounding code simplified significantly.

Fixes: #3873