### PR TITLE
chore: fix typo in rewrite storage middleware init

### DIFF
--- a/registry/storage/driver/middleware/rewrite/middleware.go
+++ b/registry/storage/driver/middleware/rewrite/middleware.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	if err := storagemiddleware.Register("rewrite", newRewriteStorageMiddleware); err != nil {
-		logrus.Errorf("failed to register redirect storage middleware: %v", err)
+		logrus.Errorf("failed to register rewrite storage middleware: %v", err)
 	}
 }
 


### PR DESCRIPTION
https://github.com/distribution/distribution/pull/4146 introduced a new rewrite storage middleware but somehow missed updating the init logging message. 

This PR fixes that.