### PR TITLE
Build artifacts and images for linux/riscv64

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,7 +61,8 @@ target "artifact-all" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
-    "linux/s390x"
+    "linux/s390x",
+    "linux/riscv64"
   ]
 }
 
@@ -87,7 +88,8 @@ target "image-all" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
-    "linux/s390x"
+    "linux/s390x",
+    "linux/riscv64"
   ]
 }
 


### PR DESCRIPTION
As part of the effort to be able to build `moby/moby` in Docker-in-Docker fashion for `linux/riscv64` natively, it requires this image to be build so as well.

Dependency from https://github.com/moby/moby/blob/master/Dockerfile#L95

I've been able to build and do a basic run of the binary in my riscv64 host:
```
user@bananapif3:~/Projects/distribution$ file bin/registry
bin/registry: ELF 64-bit LSB pie executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=3997fd5e706d3525b975f50f4badaa70e515c348, for GNU/Linux 4.15.0, stripped

user@bananapif3:~/Projects/distribution$ ./bin/registry --version
./bin/registry github.com/distribution/distribution/v3 v3.0.0-beta.1.m+unknown

user@bananapif3:~/Projects/distribution$ ./bin/registry serve cmd/registry/config-dev.yml
DEBU[0000] using "text" logging formatter
WARN[0000] No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable.  environment=development go.version=go1.22.6 instance.id=dc6db002-071b-403c-8ae9-998ecfec42db service=registry version=v3.0.0-beta.1.m+unknown
INFO[0000] redis not configured                          environment=development go.version=go1.22.6 instance.id=dc6db002-071b-403c-8ae9-998ecfec42db service=registry version=v3.0.0-beta.1.m+unknown
INFO[0000] using inmemory blob descriptor cache          environment=development go.version=go1.22.6 instance.id=dc6db002-071b-403c-8ae9-998ecfec42db service=registry version=v3.0.0-beta.1.m+unknown
INFO[0000] providing prometheus metrics on /metrics
INFO[0000] listening on [::]:5000                        environment=development go.version=go1.22.6 instance.id=dc6db002-071b-403c-8ae9-998ecfec42db service=registry version=v3.0.0-beta.1.m+unknown
INFO[0000] debug server listening :5001
```