### PR TITLE
fix: Add the token's rootcert public key to the list of known keys

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -666,6 +666,11 @@ Default `signingalgorithms`:
 - PS384
 - PS512
 
+Additional notes on `rootcertbundle`:
+
+- The public key of this certificate will be automatically added to the list of known keys.
+- The public key will be identified by it's [RFC7638 Thumbprint](https://datatracker.ietf.org/doc/html/rfc7638).
+
 For more information about Token based authentication configuration, see the
 [specification](../spec/auth/token.md).
 

--- a/docs/content/spec/auth/token.md
+++ b/docs/content/spec/auth/token.md
@@ -16,7 +16,8 @@ This document outlines the v2 Distribution registry authentication scheme:
 3. The registry client makes a request to the authorization service for a
    Bearer token.
 4. The authorization service returns an opaque Bearer token representing the
-   client's authorized access.
+   client's authorized access. The token must comply with the structure
+   described in the [Token Authentication Implementation page](./jwt.md).
 5. The client retries the original request with the Bearer token embedded in
    the request's Authorization header.
 6. The Registry authorizes the client by validating the Bearer token and the

--- a/registry/auth/token/accesscontroller_test.go
+++ b/registry/auth/token/accesscontroller_test.go
@@ -1,9 +1,16 @@
 package token
 
 import (
+	"testing"
+
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+
 	"net/http"
 	"net/http/httptest"
-	"testing"
+
+	"github.com/go-jose/go-jose/v4"
 )
 
 func TestBuildAutoRedirectURL(t *testing.T) {
@@ -85,5 +92,88 @@ func TestCheckOptions(t *testing.T) {
 	}
 	if ta.autoRedirectPath != "/auth/token" {
 		t.Fatal("autoredirectpath should be /auth/token")
+	}
+}
+
+func mockGetRootCerts(path string) ([]*x509.Certificate, error) {
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 1024) // not to slow down the test that much
+	if err != nil {
+		return nil, err
+	}
+
+	ca := &x509.Certificate{
+		PublicKey: &caPrivKey.PublicKey,
+	}
+
+	return []*x509.Certificate{ca}, nil
+}
+
+func mockGetJwks(path string) (*jose.JSONWebKeySet, error) {
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				KeyID: "sample-key-id",
+			},
+		},
+	}, nil
+}
+
+func TestRootCertIncludedInTrustedKeys(t *testing.T) {
+	old := rootCertFetcher
+	rootCertFetcher = mockGetRootCerts
+	defer func() { rootCertFetcher = old }()
+
+	realm := "https://auth.example.com/token/"
+	issuer := "test-issuer.example.com"
+	service := "test-service.example.com"
+
+	options := map[string]interface{}{
+		"realm":            realm,
+		"issuer":           issuer,
+		"service":          service,
+		"rootcertbundle":   "something-to-trigger-our-mock",
+		"autoredirect":     true,
+		"autoredirectpath": "/auth",
+	}
+
+	ac, err := newAccessController(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// newAccessController return type is an interface built from
+	// accessController struct. The type check can be safely ignored.
+	ac2, _ := ac.(*accessController)
+	if got := len(ac2.trustedKeys); got != 1 {
+		t.Fatalf("Unexpected number of trusted keys, expected 1 got: %d", got)
+	}
+}
+
+func TestJWKSIncludedInTrustedKeys(t *testing.T) {
+	old := jwkFetcher
+	jwkFetcher = mockGetJwks
+	defer func() { jwkFetcher = old }()
+
+	realm := "https://auth.example.com/token/"
+	issuer := "test-issuer.example.com"
+	service := "test-service.example.com"
+
+	options := map[string]interface{}{
+		"realm":            realm,
+		"issuer":           issuer,
+		"service":          service,
+		"jwks":             "something-to-trigger-our-mock",
+		"autoredirect":     true,
+		"autoredirectpath": "/auth",
+	}
+
+	ac, err := newAccessController(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// newAccessController return type is an interface built from
+	// accessController struct. The type check can be safely ignored.
+	ac2, _ := ac.(*accessController)
+	if got := len(ac2.trustedKeys); got != 1 {
+		t.Fatalf("Unexpected number of trusted keys, expected 1 got: %d", got)
 	}
 }

--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -1,5 +1,15 @@
 package token
 
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+)
+
 // actionSet is a special type of stringSet.
 type actionSet struct {
 	stringSet
@@ -35,4 +45,42 @@ func containsAny(ss []string, q []string) bool {
 	}
 
 	return false
+}
+
+// NOTE: RFC7638 does not prescribe which hashing function to use, but suggests
+// sha256 as a sane default as of time of writing
+func hashAndEncode(payload string) string {
+	shasum := sha256.Sum256([]byte(payload))
+	return base64.RawURLEncoding.EncodeToString(shasum[:])
+}
+
+// RFC7638 states in section 3 sub 1 that the keys in the JSON object payload
+// are required to be ordered lexicographical order. Golang does not guarantee
+// order of keys[0]
+// [0]: https://groups.google.com/g/golang-dev/c/zBQwhm3VfvU
+//
+// The payloads are small enough to create the JSON strings manually
+func GetRFC7638Thumbprint(publickey crypto.PublicKey) string {
+	var payload string
+
+	switch pubkey := publickey.(type) {
+	case *rsa.PublicKey:
+		e_big := big.NewInt(int64(pubkey.E)).Bytes()
+
+		e := base64.RawURLEncoding.EncodeToString(e_big)
+		n := base64.RawURLEncoding.EncodeToString(pubkey.N.Bytes())
+
+		payload = fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, e, n)
+	case *ecdsa.PublicKey:
+		params := pubkey.Params()
+		crv := params.Name
+		x := base64.RawURLEncoding.EncodeToString(params.Gx.Bytes())
+		y := base64.RawURLEncoding.EncodeToString(params.Gy.Bytes())
+
+		payload = fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`, crv, x, y)
+	default:
+		return ""
+	}
+
+	return hashAndEncode(payload)
 }


### PR DESCRIPTION
- Borrowed two functions from docker/libtrust to generate the key ID from the certificate bundle in the same fashion as v2.8.3.

Addresses: distribution/distribution#4470