### PR TITLE
docs: removed description of ELB as an example of an not sophisticated Load Balancer

### DIFF
--- a/docs/content/about/deploying.md
+++ b/docs/content/about/deploying.md
@@ -377,9 +377,9 @@ or a token service. If the load balancer has health checks, it is recommended
 to configure it to consider a 401 response as healthy and any other as down.
 This secures your registry by ensuring that configuration problems with
 authentication don't accidentally expose an unprotected registry. If you're
-using a less sophisticated load balancer, such as Amazon's Elastic Load
-Balancer, that doesn't allow one to change the healthy response code, health
-checks can be directed at "/", which always returns a `200 OK` response.
+using a less sophisticated load balancer that doesn't allow one to change
+the healthy response code, health checks can be directed at "/", which always
+returns a `200 OK` response.
 
 ## Restricting access
 


### PR DESCRIPTION
The documentation stated that ELB couldn't change the healthy response code. However, since both NLB and ALB now support 4xx codes, I've removed this example from the description.

### ALB

> https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html
> Matcher: If the protocol version is HTTP/1.1 or HTTP/2, the possible values are from 200 to 499.

### NLB

> https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html
> Matcher: [HTTP/HTTPS health checks] The HTTP codes to use when checking for a successful response from a target. The range is 200 to 599. The default is 200-399.

NLB support for this feature was added in November 2022

> https://aws.amazon.com/about-aws/whats-new/2022/11/elastic-load-balancing-capabilities-application-availability/
> Network Load Balancer (NLB) Health Check Improvements: NLB allows customers to define health check intervals, specify HTTP response codes that determine target health, and configure the number of consecutive health check responses before a target is either health or unhealthy. For details, see the NLB health check documentation here.

