### PR TITLE
Rebased + extended Support OCI Image Manifests+Index with artifactType and subject properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ that everyone is welcome to join and chat about development.
 
 ## Licenses
 
+
 The distribution codebase is released under the [Apache 2.0 license](LICENSE).
 The README.md file, and files in the "docs" folder are licensed under the
 Creative Commons Attribution 4.0 International License. You may obtain a

--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1140,8 +1140,9 @@ The error codes encountered via the API are enumerated in the following table:
  `BLOB_UPLOAD_INVALID` | blob upload invalid | The blob upload encountered an error and can no longer proceed.
  `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned.
  `DIGEST_INVALID` | provided digest did not match uploaded content | When a blob is uploaded, the registry will check that the content matches the digest provided by the client. The error may include a detail structure with the key "digest", including the invalid digest string. This error may also be returned when a manifest includes an invalid layer digest.
- `MANIFEST_BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a manifest blob is  unknown to the registry.
+ `MANIFEST_BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a manifest blob is unknown to the registry.
  `MANIFEST_INVALID` | manifest invalid | During upload, manifests undergo several checks ensuring validity. If those checks fail, this error may be returned, unless a more specific error is included. The detail will contain information the failed validation.
+ `MANIFEST_NOT_ACCEPTABLE` | manifest does not match Accept header | This is returned if the manifest known to the registry has a different mediaType then the client's Accept header.
  `MANIFEST_UNKNOWN` | manifest unknown | This error is returned when the manifest, identified by name and tag is unknown to the repository.
  `MANIFEST_UNVERIFIED` | manifest failed signature verification | During manifest upload, if the manifest fails signature verification, this error will be returned.
  `NAME_INVALID` | invalid repository name | Invalid repository name encountered either during manifest validation or any API operation.

--- a/manifest/ocischema/index_test.go
+++ b/manifest/ocischema/index_test.go
@@ -85,7 +85,7 @@ func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]v1.Descriptor, *De
 		"com.example.locale":           "en_GB",
 	}
 
-	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, annotations, mediaType)
+	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, nil, annotations, mediaType)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifestList: %v", err)
 	}

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -67,7 +67,7 @@ type Manifest struct {
 	Layers []v1.Descriptor `json:"layers"`
 
 	// Subject is the descriptor of a manifest referred to by this manifest.
-	Subject *distribution.Descriptor `json:"subject,omitempty"`
+	Subject *v1.Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the image manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -3,9 +3,10 @@ package ocischema
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/distribution/distribution/v3/manifest/schema2"
 	"reflect"
 	"testing"
+
+	"github.com/distribution/distribution/v3/manifest/schema2"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"

--- a/manifests.go
+++ b/manifests.go
@@ -27,6 +27,18 @@ type Manifest interface {
 	Payload() (mediaType string, payload []byte, err error)
 }
 
+// Referrer represents a Manifest which can refer to a subject.
+type Referrer interface {
+	// Subject returns a pointer to a Descriptor representing the manifest which
+	// this manifest refers to or nil if this manifest does not refer to a
+	// subject.
+	Subject() *Descriptor
+
+	// Type returns the type of the referrer if there is one, otherwise it
+	// returns empty string
+	Type() string
+}
+
 // ManifestService describes operations on manifests.
 type ManifestService interface {
 	// Exists returns true if the manifest exists.
@@ -66,6 +78,12 @@ func ManifestMediaTypes() (mediaTypes []string) {
 		}
 	}
 	return
+}
+
+// ManifestMediaTypeSupported returns true if the given mediaType is supported.
+func ManifestMediaTypeSupported(mediaType string) bool {
+	_, ok := mappings[mediaType]
+	return ok
 }
 
 // UnmarshalFunc implements manifest unmarshalling a given MediaType

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -178,7 +178,7 @@ var (
 	ErrorCodeManifestBlobUnknown = register(errGroup, ErrorDescriptor{
 		Value:   "MANIFEST_BLOB_UNKNOWN",
 		Message: "blob unknown to registry",
-		Description: `This error may be returned when a manifest blob is 
+		Description: `This error may be returned when a manifest blob is
 		unknown to the registry.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})
@@ -223,6 +223,16 @@ var (
 		to return) is not an integer, "n" is negative or "n" is bigger than
 		the maximum allowed.`,
 		HTTPStatusCode: http.StatusBadRequest,
+	})
+
+	// ErrorCodeManifestNotAcceptable is returned when the manifest found is not
+	// acceptable according to the client's Accept header
+	ErrorCodeManifestNotAcceptable = register(errGroup, ErrorDescriptor{
+		Value:   "MANIFEST_NOT_ACCEPTABLE",
+		Message: "manifest does not match Accept header",
+		Description: `This is returned if the manifest known to the registry
+		has a different mediaType then the client's Accept header.`,
+		HTTPStatusCode: http.StatusNotAcceptable,
 	})
 )
 

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/distribution/distribution/v3/manifest/ocischema"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +18,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/distribution/distribution/v3/manifest/ocischema"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/configuration"
@@ -2976,6 +2976,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to PUT manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusCreated {
 				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
 			}
@@ -3010,6 +3011,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusNotAcceptable {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotAcceptable)
 			}
@@ -3019,6 +3021,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusOK)
 			}
@@ -3052,6 +3055,7 @@ func TestArtifactManifest(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to DELETE subject: %s", err)
 				}
+				defer res.Body.Close()
 				if res.StatusCode != http.StatusAccepted {
 					t.Fatalf("Incorrect status code for subject DELETE: %s", err)
 				}
@@ -3080,6 +3084,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to DELETE manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusAccepted {
 				t.Fatalf("Incorrect status code for manifest DELETE: %d, expected: %d", res.StatusCode, http.StatusAccepted)
 			}
@@ -3093,6 +3098,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusNotFound {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotFound)
 			}
@@ -3174,6 +3180,7 @@ func TestDockerManifestWithSubject(t *testing.T) {
 	if res.StatusCode != http.StatusCreated {
 		t.Fatalf("Incorrect status code from manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
 	}
+	defer res.Body.Close()
 
 	// TODO(brackendawson): We should now try to get referrers for the subject
 	// (which should also eventually exist for that to work), but those APIs
@@ -3326,6 +3333,7 @@ func TestArtifactManifestValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to PUT manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != test.wantCode {
 				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, test.wantCode)
 			}

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -161,11 +161,11 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if manifestType == ociSchema && !supports[ociSchema] {
-		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestUnknown.WithMessage("OCI manifest found, but accept header does not support OCI manifests"))
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestNotAcceptable.WithMessage("OCI manifest found, but accept header does not support OCI manifests"))
 		return
 	}
 	if manifestType == ociImageIndexSchema && !supports[ociImageIndexSchema] {
-		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestUnknown.WithMessage("OCI index found, but accept header does not support OCI indexes"))
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestNotAcceptable.WithMessage("OCI index found, but accept header does not support OCI indexes"))
 		return
 	}
 

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -134,9 +134,9 @@ type FileWriter interface {
 // PathRegexp is the regular expression which each file path must match. A
 // file path is absolute, beginning with a slash and containing a positive
 // number of path components separated by slashes, where each component is
-// restricted to alphanumeric characters or a period, underscore, or
-// hyphen.
-var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+$`)
+// restricted to alphanumeric characters or a period, underscore, hyphen or
+// percent.
+var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._%-]+)+$`)
 
 // ErrUnsupportedMethod may be returned in the case where a StorageDriver implementation does not support an optional method.
 type ErrUnsupportedMethod struct {

--- a/registry/storage/ocimanifesthandler_test.go
+++ b/registry/storage/ocimanifesthandler_test.go
@@ -36,7 +36,7 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 	nonDistributableLayer := v1.Descriptor{
 		Digest:    "sha256:463435349086340864309863409683460843608348608934092322395278926a",
 		Size:      6323,
-		MediaType: v1.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // ignore A1019: v1.MediaTypeImageLayerNonDistributableGzip is deprecated: Non-distributable layers are deprecated, and not recommended for future use
+		MediaType: v1.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // Ignore SA1019 v1.MediaTypeImageLayerNonDistributable is deprecated, it is used for backwards compatibility
 	}
 
 	emptyLayer := v1.Descriptor{

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 
@@ -113,6 +114,10 @@ const (
 //	blobsPathSpec:                  <root>/v2/blobs/
 //	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
 //	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//
+//	Artifacts:
+//
+//	subjectReferrerPathSpec         <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<subject hex digest>/_referrers/_<artifactType>/<algorithm>/<referrer hex digest>/link
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -250,6 +255,19 @@ func pathFor(spec pathSpec) (string, error) {
 		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "hashstates", string(v.alg), offset)...), nil
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
+	case subjectReferrerLinkPathSpec:
+		manifestPath, err := pathFor(manifestRevisionPathSpec{name: v.name, revision: v.subject})
+		if err != nil {
+			return "", err
+		}
+
+		artifactType := "_" + url.QueryEscape(v.mediaType)
+		components, err := digestPathComponents(v.referrer, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(manifestPath, "_referrers", artifactType, path.Join(components...), "link"), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)
@@ -449,6 +467,17 @@ func (uploadHashStatePathSpec) pathSpec() {}
 type repositoriesRootPathSpec struct{}
 
 func (repositoriesRootPathSpec) pathSpec() {}
+
+// subjectReferrerLinkPathSpec returns the describes the link of a subject to
+// its referrers
+type subjectReferrerLinkPathSpec struct {
+	name      string
+	referrer  digest.Digest
+	subject   digest.Digest
+	mediaType string
+}
+
+func (subjectReferrerLinkPathSpec) pathSpec() {}
 
 // digestPathComponents provides a consistent path breakdown for a given
 // digest. For a generic digest, it will be as follows:

--- a/registry/storage/references.go
+++ b/registry/storage/references.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
+)
+
+// ReferenceService is a service to manage internal links from subjects back to
+// their referrers.
+type ReferenceService interface {
+	// Link creates a link from a subject back to a referrer
+	Link(ctx context.Context, mediaType string, referrer, subject digest.Digest) error
+}
+
+type referenceHandler struct {
+	*blobStore
+	repository distribution.Repository
+	pathFn     func(name, mediaType string, reference, artifact_subject_must_be_manifest digest.Digest) (string, error)
+}
+
+func (r *referenceHandler) Link(ctx context.Context, artifactType string, referrer, subject digest.Digest) error {
+	path, err := r.pathFn(r.repository.Named().Name(), artifactType, referrer, subject)
+	if err != nil {
+		return err
+	}
+
+	return r.blobStore.link(ctx, path, referrer)
+}
+
+// subjectReferrerLinkPath provides the path to the subject's referrer link
+func subjectReferrerLinkPath(name, mediaType string, referrer, subject digest.Digest) (string, error) {
+	return pathFor(subjectReferrerLinkPathSpec{name: name, mediaType: mediaType, referrer: referrer, subject: subject})
+}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -305,6 +305,11 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 			repository:   repo,
 			blobStore:    blobStore,
 			manifestURLs: repo.registry.manifestURLs,
+			references: &referenceHandler{
+				blobStore:  repo.blobStore,
+				repository: repo,
+				pathFn:     subjectReferrerLinkPath,
+			},
 		},
 		ocischemaIndexHandler: &ocischemaIndexHandler{
 			manifestListHandler: manifestListHandler,

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -114,3 +114,29 @@ func UploadBlobs(repository distribution.Repository, layers map[digest.Digest]io
 	}
 	return nil
 }
+
+// SeekerLen returns the apparent size of s
+func SeekerLen(s io.Seeker) (int64, error) {
+	offset, err := s.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read initial offset: %w", err)
+	}
+	size, err := s.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read size: %w", err)
+	}
+	_, err = s.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, fmt.Errorf("failed to restore initial offset: %w", err)
+	}
+	return size, nil
+}
+
+// MustSeekerLen returns the apparent size of s or panics
+func MustSeekerLen(s io.Seeker) int64 {
+	size, err := SeekerLen(s)
+	if err != nil {
+		panic(err)
+	}
+	return size
+}


### PR DESCRIPTION
This PR builds on the work of #3834 

First commit is the rebasing of the previous PR onto the latest commit.
Second commit extends this to also include support for oci image indexes

Thank you @brackendawson 

> This implements support for the previously ignored subject property on OCI Image manifests by creating a link to the referrer under the subject, which will be needed for the artifact listing API.
> 
> This pull request is based on https://github.com/distribution/distribution/pull/3833 which should be reviewed first and then this re-based.
> 
> Adresses https://github.com/distribution/distribution/issues/3716