### PR TITLE
Load libtrust KeyIDs from token certificate bundle

### DIFF
--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -346,6 +346,9 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 		if key := GetRFC7638Thumbprint(rootCert.PublicKey); key != "" {
 			trustedKeys[key] = rootCert.PublicKey
 		}
+		if key := GetLibtrustKeyID(rootCert.PublicKey); key != "" {
+			trustedKeys[key] = rootCert.PublicKey
+		}
 	}
 
 	if jwks != nil {

--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -1,13 +1,17 @@
 package token
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base32"
 	"encoding/base64"
 	"fmt"
 	"math/big"
+	"strings"
 )
 
 // actionSet is a special type of stringSet.
@@ -83,4 +87,27 @@ func GetRFC7638Thumbprint(publickey crypto.PublicKey) string {
 	}
 
 	return hashAndEncode(payload)
+}
+
+// Returns a libtrust-compatible Key ID, for backwards compatibility
+// with JWT headers expected by distribution/v2
+func GetLibtrustKeyID(publickey crypto.PublicKey) string {
+	keyBytes, err := x509.MarshalPKIXPublicKey(publickey)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha256.Sum256(keyBytes)
+	b64 := strings.TrimRight(base32.StdEncoding.EncodeToString(sum[:30]), "=")
+
+	var buf bytes.Buffer
+	var i int
+	for i = 0; i < len(b64)/4-1; i++ {
+		start := i * 4
+		end := start + 4
+		buf.WriteString(b64[start:end] + ":")
+	}
+	buf.WriteString(b64[i*4:])
+
+	return buf.String()
 }


### PR DESCRIPTION
Resolves issue where legacy Key IDs were not loaded from CA bundles, necessitating use of JWKS JSON

Fixes:
* https://github.com/distribution/distribution/issues/4470
* https://github.com/distribution/distribution/discussions/4487

Ref: https://github.com/docker/libtrust/blob/aabc10ec26b754e797f9028f4589c5b7bd90dc20/util.go#L181-L207