### PR TITLE
fix: remove nested structs from configuration

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -23,31 +23,7 @@ type Configuration struct {
 
 	// Log supports setting various parameters related to the logging
 	// subsystem.
-	Log struct {
-		// AccessLog configures access logging.
-		AccessLog struct {
-			// Disabled disables access logging.
-			Disabled bool `yaml:"disabled,omitempty"`
-		} `yaml:"accesslog,omitempty"`
-
-		// Level is the granularity at which registry operations are logged.
-		Level Loglevel `yaml:"level,omitempty"`
-
-		// Formatter overrides the default formatter with another. Options
-		// include "text", "json" and "logstash".
-		Formatter string `yaml:"formatter,omitempty"`
-
-		// Fields allows users to specify static string fields to include in
-		// the logger context.
-		Fields map[string]interface{} `yaml:"fields,omitempty"`
-
-		// Hooks allows users to configure the log hooks, to enabling the
-		// sequent handling behavior, when defined levels of log message emit.
-		Hooks []LogHook `yaml:"hooks,omitempty"`
-
-		// ReportCaller allows user to configure the log to report the caller
-		ReportCaller bool `yaml:"reportcaller,omitempty"`
-	}
+	Log Log `yaml:"log"`
 
 	// Loglevel is the level at which registry operations are logged.
 	//
@@ -66,113 +42,7 @@ type Configuration struct {
 
 	// HTTP contains configuration parameters for the registry's http
 	// interface.
-	HTTP struct {
-		// Addr specifies the bind address for the registry instance.
-		Addr string `yaml:"addr,omitempty"`
-
-		// Net specifies the net portion of the bind address. A default empty value means tcp.
-		Net string `yaml:"net,omitempty"`
-
-		// Host specifies an externally-reachable address for the registry, as a fully
-		// qualified URL.
-		Host string `yaml:"host,omitempty"`
-
-		Prefix string `yaml:"prefix,omitempty"`
-
-		// Secret specifies the secret key which HMAC tokens are created with.
-		Secret string `yaml:"secret,omitempty"`
-
-		// RelativeURLs specifies that relative URLs should be returned in
-		// Location headers
-		RelativeURLs bool `yaml:"relativeurls,omitempty"`
-
-		// Amount of time to wait for connection to drain before shutting down when registry
-		// receives a stop signal
-		DrainTimeout time.Duration `yaml:"draintimeout,omitempty"`
-
-		// TLS instructs the http server to listen with a TLS configuration.
-		// This only support simple tls configuration with a cert and key.
-		// Mostly, this is useful for testing situations or simple deployments
-		// that require tls. If more complex configurations are required, use
-		// a proxy or make a proposal to add support here.
-		TLS struct {
-			// Certificate specifies the path to an x509 certificate file to
-			// be used for TLS.
-			Certificate string `yaml:"certificate,omitempty"`
-
-			// Key specifies the path to the x509 key file, which should
-			// contain the private portion for the file specified in
-			// Certificate.
-			Key string `yaml:"key,omitempty"`
-
-			// Specifies the CA certs for client authentication
-			// A file may contain multiple CA certificates encoded as PEM
-			ClientCAs []string `yaml:"clientcas,omitempty"`
-
-			// Client certificate authentication mode
-			// One of: request-client-cert, require-any-client-cert, verify-client-cert-if-given, require-and-verify-client-cert
-			ClientAuth ClientAuth `yaml:"clientauth,omitempty"`
-
-			// Specifies the lowest TLS version allowed
-			MinimumTLS string `yaml:"minimumtls,omitempty"`
-
-			// Specifies a list of cipher suites allowed
-			CipherSuites []string `yaml:"ciphersuites,omitempty"`
-
-			// LetsEncrypt is used to configuration setting up TLS through
-			// Let's Encrypt instead of manually specifying certificate and
-			// key. If a TLS certificate is specified, the Let's Encrypt
-			// section will not be used.
-			LetsEncrypt struct {
-				// CacheFile specifies cache file to use for lets encrypt
-				// certificates and keys.
-				CacheFile string `yaml:"cachefile,omitempty"`
-
-				// Email is the email to use during Let's Encrypt registration
-				Email string `yaml:"email,omitempty"`
-
-				// Hosts specifies the hosts which are allowed to obtain Let's
-				// Encrypt certificates.
-				Hosts []string `yaml:"hosts,omitempty"`
-
-				// DirectoryURL points to the CA directory endpoint.
-				// If empty, LetsEncrypt is used.
-				DirectoryURL string `yaml:"directoryurl,omitempty"`
-			} `yaml:"letsencrypt,omitempty"`
-		} `yaml:"tls,omitempty"`
-
-		// Headers is a set of headers to include in HTTP responses. A common
-		// use case for this would be security headers such as
-		// Strict-Transport-Security. The map keys are the header names, and
-		// the values are the associated header payloads.
-		Headers http.Header `yaml:"headers,omitempty"`
-
-		// Debug configures the http debug interface, if specified. This can
-		// include services such as pprof, expvar and other data that should
-		// not be exposed externally. Left disabled by default.
-		Debug struct {
-			// Addr specifies the bind address for the debug server.
-			Addr string `yaml:"addr,omitempty"`
-			// Prometheus configures the Prometheus telemetry endpoint.
-			Prometheus struct {
-				Enabled bool   `yaml:"enabled,omitempty"`
-				Path    string `yaml:"path,omitempty"`
-			} `yaml:"prometheus,omitempty"`
-		} `yaml:"debug,omitempty"`
-
-		// HTTP2 configuration options
-		HTTP2 struct {
-			// Specifies whether the registry should disallow clients attempting
-			// to connect via HTTP/2. If set to true, only HTTP/1.1 is supported.
-			Disabled bool `yaml:"disabled,omitempty"`
-		} `yaml:"http2,omitempty"`
-
-		H2C struct {
-			// Enables H2C (HTTP/2 Cleartext). Enable to support HTTP/2 without needing to configure TLS
-			// Useful when deploying the registry behind a load balancer (e.g. Cloud Run)
-			Enabled bool `yaml:"enabled,omitempty"`
-		} `yaml:"h2c,omitempty"`
-	} `yaml:"http,omitempty"`
+	HTTP HTTP `yaml:"http,omitempty"`
 
 	// Notifications specifies configuration about various endpoint to which
 	// registry events are dispatched.
@@ -181,36 +51,218 @@ type Configuration struct {
 	// Redis configures the redis pool available to the registry webapp.
 	Redis Redis `yaml:"redis,omitempty"`
 
-	Health  Health  `yaml:"health,omitempty"`
+	// Health provides the configuration section for health checks.
+	// It allows defining various checks to monitor the health of different subsystems.
+	Health Health `yaml:"health,omitempty"`
+
+	// Catalog is composed of MaxEntries.
+	// Catalog endpoint (/v2/_catalog) configuration, it provides the configuration
+	// options to control the maximum number of entries returned by the catalog endpoint.
 	Catalog Catalog `yaml:"catalog,omitempty"`
 
+	// Proxy defines the configuration options for using the registry as a pull-through cache.
 	Proxy Proxy `yaml:"proxy,omitempty"`
 
 	// Validation configures validation options for the registry.
 	Validation Validation `yaml:"validation,omitempty"`
 
 	// Policy configures registry policy options.
-	Policy struct {
-		// Repository configures policies for repositories
-		Repository struct {
-			// Classes is a list of repository classes which the
-			// registry allows content for. This class is matched
-			// against the configuration media type inside uploaded
-			// manifests. When non-empty, the registry will enforce
-			// the class in authorized resources.
-			Classes []string `yaml:"classes"`
-		} `yaml:"repository,omitempty"`
-	} `yaml:"policy,omitempty"`
+	Policy Policy `yaml:"policy,omitempty"`
 }
 
-// Catalog is composed of MaxEntries.
-// Catalog endpoint (/v2/_catalog) configuration, it provides the configuration
-// options to control the maximum number of entries returned by the catalog endpoint.
+// Policy defines configuration options for managing registry policies.
+type Policy struct {
+	// Repository configures policies for repositories
+	Repository Repository `yaml:"repository,omitempty"`
+}
+
+// Repository defines configuration options related to repository policies in the registry.
+type Repository struct {
+	// Classes is a list of repository classes that the registry allows content for.
+	// This value is matched against the media type in uploaded manifests.
+	// If this field is non-empty, the registry enforces that all uploaded
+	// content belongs to one of the specified classes.
+	Classes []string `yaml:"classes"`
+}
+
+// Catalog provides configuration options for the /v2/_catalog endpoint.
 type Catalog struct {
 	// Max number of entries returned by the catalog endpoint. Requesting n entries
 	// to the catalog endpoint will return at most MaxEntries entries.
 	// An empty or a negative value will set a default of 1000 maximum entries by default.
 	MaxEntries int `yaml:"maxentries,omitempty"`
+}
+
+// Log represents the configuration for logging within the application.
+type Log struct {
+	// AccessLog configures access logging.
+	AccessLog AccessLog `yaml:"accesslog,omitempty"`
+
+	// Level is the granularity at which registry operations are logged.
+	Level Loglevel `yaml:"level,omitempty"`
+
+	// Formatter overrides the default formatter with another. Options
+	// include "text", "json" and "logstash".
+	Formatter string `yaml:"formatter,omitempty"`
+
+	// Fields allows users to specify static string fields to include in
+	// the logger context.
+	Fields map[string]interface{} `yaml:"fields,omitempty"`
+
+	// Hooks allows users to configure the log hooks, to enabling the
+	// sequent handling behavior, when defined levels of log message emit.
+	Hooks []LogHook `yaml:"hooks,omitempty"`
+
+	// ReportCaller allows user to configure the log to report the caller
+	ReportCaller bool `yaml:"reportcaller,omitempty"`
+}
+
+// AccessLog configures options for access logging.
+type AccessLog struct {
+	// Disabled disables access logging.
+	Disabled bool `yaml:"disabled,omitempty"`
+}
+
+// HTTP defines configuration options for the HTTP interface of the registry.
+type HTTP struct {
+	// Addr specifies the bind address for the registry instance.
+	Addr string `yaml:"addr,omitempty"`
+
+	// Net specifies the net portion of the bind address. A default empty value means tcp.
+	Net string `yaml:"net,omitempty"`
+
+	// Host specifies an externally-reachable address for the registry, as a fully
+	// qualified URL.
+	Host string `yaml:"host,omitempty"`
+
+	// Prefix specifies a URL path prefix for the HTTP interface.
+	// This can be used to serve the registry under a specific path
+	// rather than at the root of the domain (e.g., "/registry").
+	Prefix string `yaml:"prefix,omitempty"`
+
+	// Secret specifies the secret key which HMAC tokens are created with.
+	Secret string `yaml:"secret,omitempty"`
+
+	// RelativeURLs specifies that relative URLs should be returned in
+	// Location headers
+	RelativeURLs bool `yaml:"relativeurls,omitempty"`
+
+	// Amount of time to wait for connection to drain before shutting down when registry
+	// receives a stop signal
+	DrainTimeout time.Duration `yaml:"draintimeout,omitempty"`
+
+	// TLS instructs the http server to listen with a TLS configuration.
+	// This only support simple tls configuration with a cert and key.
+	// Mostly, this is useful for testing situations or simple deployments
+	// that require tls. If more complex configurations are required, use
+	// a proxy or make a proposal to add support here.
+	TLS TLS `yaml:"tls,omitempty"`
+
+	// Headers is a set of headers to include in HTTP responses. A common
+	// use case for this would be security headers such as
+	// Strict-Transport-Security. The map keys are the header names, and
+	// the values are the associated header payloads.
+	Headers http.Header `yaml:"headers,omitempty"`
+
+	// Debug configures the http debug interface, if specified. This can
+	// include services such as pprof, expvar and other data that should
+	// not be exposed externally. Left disabled by default.
+	Debug Debug `yaml:"debug,omitempty"`
+
+	// HTTP2 configures options for HTTP/2 support.
+	HTTP2 HTTP2 `yaml:"http2,omitempty"`
+
+	// H2C configures support for HTTP/2 without requiring TLS (HTTP/2 Cleartext).
+	H2C H2C `yaml:"h2c,omitempty"`
+}
+
+// Debug defines the configuration options for the registry's debug interface.
+// It allows administrators to enable or disable the debug server and configure
+// telemetry and monitoring endpoints such as Prometheus.
+type Debug struct {
+	// Addr specifies the bind address for the debug server.
+	Addr string `yaml:"addr,omitempty"`
+
+	// Prometheus configures the Prometheus telemetry endpoint for monitoring purposes.
+	Prometheus Prometheus `yaml:"prometheus,omitempty"`
+}
+
+// Prometheus configures the Prometheus telemetry endpoint for the registry.
+// It allows administrators to enable Prometheus monitoring and customize
+// the scrape path for metric collection.
+type Prometheus struct {
+	// Enabled determines whether Prometheus telemetry is enabled or not.
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Path specifies the URL path where the Prometheus metrics are exposed.
+	// The default is "/metrics", but it can be customized here.
+	Path string `yaml:"path,omitempty"`
+}
+
+// HTTP2 configures options.
+type HTTP2 struct {
+	// Specifies whether the registry should disallow clients attempting
+	// to connect via HTTP/2. If set to true, only HTTP/1.1 is supported.
+	Disabled bool `yaml:"disabled,omitempty"`
+}
+
+// H2C configures support for HTTP/2 Cleartext.
+type H2C struct {
+	// Enables H2C (HTTP/2 Cleartext). Enable to support HTTP/2 without needing to configure TLS
+	// Useful when deploying the registry behind a load balancer (e.g. Cloud Run)
+	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+// TLS defines the configuration options for enabling and configuring TLS (Transport Layer Security)
+// for secure communication between the registry and clients. It allows the registry to listen for
+// HTTPS connections with a specified certificate, key, and optional client authentication settings.
+type TLS struct {
+	// Certificate specifies the path to an x509 certificate file to
+	// be used for TLS.
+	Certificate string `yaml:"certificate,omitempty"`
+
+	// Key specifies the path to the x509 key file, which should
+	// contain the private portion for the file specified in
+	// Certificate.
+	Key string `yaml:"key,omitempty"`
+
+	// Specifies the CA certs for client authentication
+	// A file may contain multiple CA certificates encoded as PEM
+	ClientCAs []string `yaml:"clientcas,omitempty"`
+
+	// Client certificate authentication mode
+	// One of: request-client-cert, require-any-client-cert, verify-client-cert-if-given, require-and-verify-client-cert
+	ClientAuth ClientAuth `yaml:"clientauth,omitempty"`
+
+	// Specifies the lowest TLS version allowed
+	MinimumTLS string `yaml:"minimumtls,omitempty"`
+
+	// Specifies a list of cipher suites allowed
+	CipherSuites []string `yaml:"ciphersuites,omitempty"`
+
+	// LetsEncrypt is used to configuration setting up TLS through
+	// Let's Encrypt instead of manually specifying certificate and
+	// key. If a TLS certificate is specified, the Let's Encrypt
+	// section will not be used.
+	LetsEncrypt LetsEncrypt `yaml:"letsencrypt,omitempty"`
+}
+
+// LetsEncrypt configures automatic TLS certificate provisioning using Let's Encrypt.
+type LetsEncrypt struct {
+	// CacheFile specifies cache file to use for lets encrypt
+	// certificates and keys.
+	CacheFile string `yaml:"cachefile,omitempty"`
+
+	// Email is the email to use during Let's Encrypt registration
+	Email string `yaml:"email,omitempty"`
+
+	// Hosts specifies the hosts which are allowed to obtain Let's
+	// Encrypt certificates.
+	Hosts []string `yaml:"hosts,omitempty"`
+
+	// DirectoryURL points to the CA directory endpoint.
+	// If empty, LetsEncrypt is used.
+	DirectoryURL string `yaml:"directoryurl,omitempty"`
 }
 
 // LogHook is composed of hook Level and Type.
@@ -233,19 +285,8 @@ type LogHook struct {
 
 // MailOptions provides the configuration sections to user, for specific handler.
 type MailOptions struct {
-	SMTP struct {
-		// Addr defines smtp host address
-		Addr string `yaml:"addr,omitempty"`
-
-		// Username defines user name to smtp host
-		Username string `yaml:"username,omitempty"`
-
-		// Password defines password of login user
-		Password string `yaml:"password,omitempty"`
-
-		// Insecure defines if smtp login skips the secure certification.
-		Insecure bool `yaml:"insecure,omitempty"`
-	} `yaml:"smtp,omitempty"`
+	// SMTP defines the configuration options for the SMTP server used for sending email notifications.
+	SMTP SMTP `yaml:"smtp,omitempty"`
 
 	// From defines mail sending address
 	From string `yaml:"from,omitempty"`
@@ -254,12 +295,31 @@ type MailOptions struct {
 	To []string `yaml:"to,omitempty"`
 }
 
+// SMTP represents the configuration for an SMTP (Simple Mail Transfer Protocol) server
+// used for sending emails. It includes settings for the SMTP server's address, authentication,
+// and other relevant configurations needed to connect and send emails.
+type SMTP struct {
+	// Addr defines smtp host address
+	Addr string `yaml:"addr,omitempty"`
+
+	// Username defines user name to smtp host
+	Username string `yaml:"username,omitempty"`
+
+	// Password defines password of login user
+	Password string `yaml:"password,omitempty"`
+
+	// Insecure defines if smtp login skips the secure certification.
+	Insecure bool `yaml:"insecure,omitempty"`
+}
+
 // FileChecker is a type of entry in the health section for checking files.
 type FileChecker struct {
 	// Interval is the duration in between checks
 	Interval time.Duration `yaml:"interval,omitempty"`
+
 	// File is the path to check
 	File string `yaml:"file,omitempty"`
+
 	// Threshold is the number of times a check must fail to trigger an
 	// unhealthy state
 	Threshold int `yaml:"threshold,omitempty"`
@@ -269,14 +329,19 @@ type FileChecker struct {
 type HTTPChecker struct {
 	// Timeout is the duration to wait before timing out the HTTP request
 	Timeout time.Duration `yaml:"timeout,omitempty"`
+
 	// StatusCode is the expected status code
 	StatusCode int
+
 	// Interval is the duration in between checks
 	Interval time.Duration `yaml:"interval,omitempty"`
+
 	// URI is the HTTP URI to check
 	URI string `yaml:"uri,omitempty"`
+
 	// Headers lists static headers that should be added to all requests
 	Headers http.Header `yaml:"headers"`
+
 	// Threshold is the number of times a check must fail to trigger an
 	// unhealthy state
 	Threshold int `yaml:"threshold,omitempty"`
@@ -286,10 +351,13 @@ type HTTPChecker struct {
 type TCPChecker struct {
 	// Timeout is the duration to wait before timing out the TCP connection
 	Timeout time.Duration `yaml:"timeout,omitempty"`
+
 	// Interval is the duration in between checks
 	Interval time.Duration `yaml:"interval,omitempty"`
+
 	// Addr is the TCP address to check
 	Addr string `yaml:"addr,omitempty"`
+
 	// Threshold is the number of times a check must fail to trigger an
 	// unhealthy state
 	Threshold int `yaml:"threshold,omitempty"`
@@ -299,26 +367,40 @@ type TCPChecker struct {
 type Health struct {
 	// FileCheckers is a list of paths to check
 	FileCheckers []FileChecker `yaml:"file,omitempty"`
+
 	// HTTPCheckers is a list of URIs to check
 	HTTPCheckers []HTTPChecker `yaml:"http,omitempty"`
+
 	// TCPCheckers is a list of URIs to check
 	TCPCheckers []TCPChecker `yaml:"tcp,omitempty"`
+
 	// StorageDriver configures a health check on the configured storage
 	// driver
-	StorageDriver struct {
-		// Enabled turns on the health check for the storage driver
-		Enabled bool `yaml:"enabled,omitempty"`
-		// Interval is the duration in between checks
-		Interval time.Duration `yaml:"interval,omitempty"`
-		// Threshold is the number of times a check must fail to trigger an
-		// unhealthy state
-		Threshold int `yaml:"threshold,omitempty"`
-	} `yaml:"storagedriver,omitempty"`
+	StorageDriver StorageDriver `yaml:"storagedriver,omitempty"`
 }
 
+// StorageDriver configures health checks specific to the storage driver.
+type StorageDriver struct {
+	// Enabled turns on the health check for the storage driver
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Interval is the duration in between checks
+	Interval time.Duration `yaml:"interval,omitempty"`
+
+	// Threshold is the number of times a check must fail to trigger an
+	// unhealthy state
+	Threshold int `yaml:"threshold,omitempty"`
+}
+
+// Platform specifies the characteristics of a computing environment
+// and allows registry administrators to define required platforms for image validation.
+// Administrators can select specific architectures and operating systems that must exist
+// in the registry. This ensures that all image indexes uploaded to the registry are valid
+// for the specified platforms.
 type Platform struct {
 	// Architecture is the architecture for this platform
 	Architecture string `yaml:"architecture,omitempty"`
+
 	// OS is the operating system for this platform
 	OS string `yaml:"os,omitempty"`
 }
@@ -614,6 +696,11 @@ type Proxy struct {
 	TTL *time.Duration `yaml:"ttl,omitempty"`
 }
 
+// ExecConfig defines the configuration for executing a command as a credential helper.
+// This allows the registry to authenticate against an upstream registry by executing a
+// specified command to obtain credentials. The command can be re-executed based on the
+// configured lifetime, enabling the registry to run as a pull-through cache that manages
+// its authentication dynamically.
 type ExecConfig struct {
 	// Command is the command to execute.
 	Command string `yaml:"command"`
@@ -626,33 +713,44 @@ type ExecConfig struct {
 	Lifetime *time.Duration `yaml:"lifetime,omitempty"`
 }
 
+// Validation configures validation options for the registry.
 type Validation struct {
 	// Enabled enables the other options in this section. This field is
 	// deprecated in favor of Disabled.
 	Enabled bool `yaml:"enabled,omitempty"`
+
 	// Disabled disables the other options in this section.
 	Disabled bool `yaml:"disabled,omitempty"`
+
 	// Manifests configures manifest validation.
 	Manifests ValidationManifests `yaml:"manifests,omitempty"`
 }
 
+// ValidationManifests configures validation rules for manifests pushed to the registry.
 type ValidationManifests struct {
 	// URLs configures validation for URLs in pushed manifests.
-	URLs struct {
-		// Allow specifies regular expressions (https://godoc.org/regexp/syntax)
-		// that URLs in pushed manifests must match.
-		Allow []string `yaml:"allow,omitempty"`
-		// Deny specifies regular expressions (https://godoc.org/regexp/syntax)
-		// that URLs in pushed manifests must not match.
-		Deny []string `yaml:"deny,omitempty"`
-	} `yaml:"urls,omitempty"`
+	URLs URLs `yaml:"urls,omitempty"`
+
 	// ImageIndexes configures validation of image indexes
 	Indexes ValidationIndexes `yaml:"indexes,omitempty"`
 }
 
+// URLs defines validation rules for URLs found in the manifests pushed to the registry.
+type URLs struct {
+	// Allow specifies regular expressions (https://godoc.org/regexp/syntax)
+	// that URLs in pushed manifests must match.
+	Allow []string `yaml:"allow,omitempty"`
+
+	// Deny specifies regular expressions (https://godoc.org/regexp/syntax)
+	// that URLs in pushed manifests must not match.
+	Deny []string `yaml:"deny,omitempty"`
+}
+
+// ValidationIndexes configures validation rules for image indexes within the manifest.
 type ValidationIndexes struct {
 	// Platforms configures the validation applies to the platform images included in an image index
 	Platforms Platforms `yaml:"platforms"`
+
 	// PlatformList filters the set of platforms to validate for image existence.
 	PlatformList []Platform `yaml:"platformlist,omitempty"`
 }
@@ -735,17 +833,38 @@ func Parse(rd io.Reader) (*Configuration, error) {
 	return config, nil
 }
 
+// RedisOptions represents the configuration options for Redis, which are
+// provided by the redis package. This struct can be used to configure the
+// connection to Redis in a universal (clustered or standalone) setup.
 type RedisOptions = redis.UniversalOptions
 
+// RedisTLSOptions configures the TLS (Transport Layer Security) settings for
+// Redis connections, allowing secure communication over the network.
 type RedisTLSOptions struct {
-	Certificate string   `yaml:"certificate,omitempty"`
-	Key         string   `yaml:"key,omitempty"`
-	ClientCAs   []string `yaml:"clientcas,omitempty"`
+	// Certificate specifies the path to the certificate file for TLS authentication.
+	// This certificate is used to establish a secure connection with the Redis server.
+	Certificate string `yaml:"certificate,omitempty"`
+
+	// Key specifies the path to the private key file associated with the certificate.
+	// This key is used to authenticate the client during the TLS handshake.
+	Key string `yaml:"key,omitempty"`
+
+	// ClientCAs specifies a list of certificates to be used to verify the server's
+	// certificate during the TLS handshake. This can be used for mutual TLS authentication.
+	ClientCAs []string `yaml:"clientcas,omitempty"`
 }
 
+// Redis represents the configuration for connecting to a Redis server. It includes
+// both the basic connection options and optional TLS settings to secure the connection.
 type Redis struct {
-	Options RedisOptions    `yaml:",inline"`
-	TLS     RedisTLSOptions `yaml:"tls,omitempty"`
+	// Options provides the configuration for connecting to Redis, including
+	// options for both clustered and standalone Redis setups. It is provided inline
+	// from the `redis.UniversalOptions` struct.
+	Options RedisOptions `yaml:",inline"`
+
+	// TLS contains the TLS settings for secure communication with the Redis server.
+	// If specified, these settings will enable encryption and authentication via TLS.
+	TLS RedisTLSOptions `yaml:"tls,omitempty"`
 }
 
 func (c Redis) MarshalYAML() (interface{}, error) {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -16,16 +16,7 @@ import (
 // configStruct is a canonical example configuration, which should map to configYamlV0_1
 var configStruct = Configuration{
 	Version: "0.1",
-	Log: struct {
-		AccessLog struct {
-			Disabled bool `yaml:"disabled,omitempty"`
-		} `yaml:"accesslog,omitempty"`
-		Level        Loglevel               `yaml:"level,omitempty"`
-		Formatter    string                 `yaml:"formatter,omitempty"`
-		Fields       map[string]interface{} `yaml:"fields,omitempty"`
-		Hooks        []LogHook              `yaml:"hooks,omitempty"`
-		ReportCaller bool                   `yaml:"reportcaller,omitempty"`
-	}{
+	Log: Log{
 		Level:  "info",
 		Fields: map[string]interface{}{"environment": "test"},
 	},
@@ -69,71 +60,18 @@ var configStruct = Configuration{
 	Catalog: Catalog{
 		MaxEntries: 1000,
 	},
-	HTTP: struct {
-		Addr         string        `yaml:"addr,omitempty"`
-		Net          string        `yaml:"net,omitempty"`
-		Host         string        `yaml:"host,omitempty"`
-		Prefix       string        `yaml:"prefix,omitempty"`
-		Secret       string        `yaml:"secret,omitempty"`
-		RelativeURLs bool          `yaml:"relativeurls,omitempty"`
-		DrainTimeout time.Duration `yaml:"draintimeout,omitempty"`
-		TLS          struct {
-			Certificate  string     `yaml:"certificate,omitempty"`
-			Key          string     `yaml:"key,omitempty"`
-			ClientCAs    []string   `yaml:"clientcas,omitempty"`
-			ClientAuth   ClientAuth `yaml:"clientauth,omitempty"`
-			MinimumTLS   string     `yaml:"minimumtls,omitempty"`
-			CipherSuites []string   `yaml:"ciphersuites,omitempty"`
-			LetsEncrypt  struct {
-				CacheFile    string   `yaml:"cachefile,omitempty"`
-				Email        string   `yaml:"email,omitempty"`
-				Hosts        []string `yaml:"hosts,omitempty"`
-				DirectoryURL string   `yaml:"directoryurl,omitempty"`
-			} `yaml:"letsencrypt,omitempty"`
-		} `yaml:"tls,omitempty"`
-		Headers http.Header `yaml:"headers,omitempty"`
-		Debug   struct {
-			Addr       string `yaml:"addr,omitempty"`
-			Prometheus struct {
-				Enabled bool   `yaml:"enabled,omitempty"`
-				Path    string `yaml:"path,omitempty"`
-			} `yaml:"prometheus,omitempty"`
-		} `yaml:"debug,omitempty"`
-		HTTP2 struct {
-			Disabled bool `yaml:"disabled,omitempty"`
-		} `yaml:"http2,omitempty"`
-		H2C struct {
-			Enabled bool `yaml:"enabled,omitempty"`
-		} `yaml:"h2c,omitempty"`
-	}{
-		TLS: struct {
-			Certificate  string     `yaml:"certificate,omitempty"`
-			Key          string     `yaml:"key,omitempty"`
-			ClientCAs    []string   `yaml:"clientcas,omitempty"`
-			ClientAuth   ClientAuth `yaml:"clientauth,omitempty"`
-			MinimumTLS   string     `yaml:"minimumtls,omitempty"`
-			CipherSuites []string   `yaml:"ciphersuites,omitempty"`
-			LetsEncrypt  struct {
-				CacheFile    string   `yaml:"cachefile,omitempty"`
-				Email        string   `yaml:"email,omitempty"`
-				Hosts        []string `yaml:"hosts,omitempty"`
-				DirectoryURL string   `yaml:"directoryurl,omitempty"`
-			} `yaml:"letsencrypt,omitempty"`
-		}{
+	HTTP: HTTP{
+		TLS: TLS{
 			ClientCAs:  []string{"/path/to/ca.pem"},
 			ClientAuth: ClientAuthVerifyClientCertIfGiven,
 		},
 		Headers: http.Header{
 			"X-Content-Type-Options": []string{"nosniff"},
 		},
-		HTTP2: struct {
-			Disabled bool `yaml:"disabled,omitempty"`
-		}{
+		HTTP2: HTTP2{
 			Disabled: false,
 		},
-		H2C: struct {
-			Enabled bool `yaml:"enabled,omitempty"`
-		}{
+		H2C: H2C{
 			Enabled: true,
 		},
 	},

--- a/configuration/parser_test.go
+++ b/configuration/parser_test.go
@@ -13,10 +13,6 @@ type localConfiguration struct {
 	Notifications []Notif `yaml:"notifications,omitempty"`
 }
 
-type Log struct {
-	Formatter string `yaml:"formatter,omitempty"`
-}
-
 type Notif struct {
 	Name string `yaml:"name"`
 }


### PR DESCRIPTION
Hi! I've started designing Kubernetes Operator for Distribution (see https://registry-operator.dev/latest/), and I noticed that handling the configuration structure from code is extremely cumbersome due to the nested structs. Simplest fix is to define few new structures, and unflatten the configuration.

Progress:
- [x] unflatten the code
- [x] godoc
- [ ] tests