### PR TITLE
Update squizzi maintainer email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,7 +11,7 @@
 "heww","He Weiwei","hweiwei@vmware.com"
 "joaodrp","João Pereira","jpereira@gitlab.com"
 "justincormack","Justin Cormack","justin.cormack@docker.com"
-"squizzi","Kyle Squizzato","ksquizzato@mirantis.com"
+"squizzi","Kyle Squizzato","ksquizz@gmail.com"
 "milosgajdos","Milos Gajdos","milosthegajdos@gmail.com"
 "sargun","Sargun Dhillon","sargun@sargun.me"
 "wy65701436","Wang Yan","wangyan@vmware.com"


### PR DESCRIPTION
I no longer work at Mirantis, updating my maintainer email to my personal.