### PR TITLE
ci: update bake-action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,11 +67,6 @@ jobs:
       - test
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -118,7 +113,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build artifacts
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: artifact-all
       -
@@ -146,11 +141,11 @@ jobs:
           if-no-files-found: error
       -
         name: Build image
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            cwd://${{ steps.meta.outputs.bake-file }}
           targets: image-all
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       -

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -16,13 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Build image
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: image-local
       -

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ on:
       - dockerfiles/docs.Dockerfile
       - docs/**
   workflow_dispatch:
+  pull_request:
 
 jobs:
   # Build job
@@ -22,28 +23,28 @@ jobs:
       contents: read
     # Build the site and upload artifacts using actions/upload-pages-artifact
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build docs
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
-          files: |
-            docker-bake.hcl
           targets: docs-export
           provenance: false
           set: |
             *.cache-from=type=gha,scope=docs
             *.cache-to=type=gha,scope=docs,mode=max
+
       - name: Fix permissions
         run: |
           chmod -c -R +rX "./build/docs" | while read line; do
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -51,6 +52,7 @@ jobs:
 
   # Deploy job
   deploy:
+    if: github.event_name != 'pull_request'
     # Add a dependency to the build job
     needs: build
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,9 @@ jobs:
           fetch-depth: 0
       -
         name: Build image
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           targets: image-local
       -
         name: Start distribution server


### PR DESCRIPTION
closes #4552 

Update bake-action to v6 with slight changes to take default to Git context into account. Made also a small change to the docs workflow so it builds on PR to make sure there is no regression.