### PR TITLE
ci: fix bake build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,11 @@ jobs:
       - test
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -115,6 +120,7 @@ jobs:
         name: Build artifacts
         uses: docker/bake-action@v6
         with:
+          source: .
           targets: artifact-all
       -
         name: Rename provenance
@@ -143,9 +149,10 @@ jobs:
         name: Build image
         uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             ./docker-bake.hcl
-            cwd://${{ steps.meta.outputs.bake-file }}
+            ${{ steps.meta.outputs.bake-file }}
           targets: image-all
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       -


### PR DESCRIPTION
similar to https://github.com/docker/compose/pull/12470

When building using git context, it does not fetch tags and therefore version would be broken in: https://github.com/distribution/distribution/blob/3270367d89f572883be9a3ac2c28dd4222df5bf7/Dockerfile#L18

Let's keep local context as before until we investigate this issue upstream.