### PR TITLE
Fix doc about config path when overriding

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -67,7 +67,7 @@ specify it in the `docker run` command:
 
 ```bash
 $ docker run -d -p 5000:5000 --restart=always --name registry \
-             -v `pwd`/config.yml:/etc/distribution/config.yml \
+             -v `pwd`/config.yml:/etc/docker/registry/config.yml \
              registry:2
 ```
 


### PR DESCRIPTION
I've made a small change in the docs regarding how to override the entire configuration via a .yml file. Apparently the path /etc/distribution/config.yml is not being picked up by the app when starting up.