### PR TITLE
Fix broken signing algorithm configuration for token authentication

### DIFF
--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -306,11 +306,11 @@ func getJwks(path string) (*jose.JSONWebKeySet, error) {
 func getSigningAlgorithms(algos []string) ([]jose.SignatureAlgorithm, error) {
 	signAlgVals := make([]jose.SignatureAlgorithm, 0, len(algos))
 	for _, alg := range algos {
-		alg, ok := signingAlgorithms[alg]
+		signAlg, ok := signingAlgorithms[alg]
 		if !ok {
 			return nil, fmt.Errorf("unsupported signing algorithm: %s", alg)
 		}
-		signAlgVals = append(signAlgVals, alg)
+		signAlgVals = append(signAlgVals, signAlg)
 	}
 	return signAlgVals, nil
 }

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -228,11 +228,19 @@ func checkOptions(options map[string]interface{}) (tokenAccessOptions, error) {
 
 	signingAlgos, ok := options["signingalgorithms"]
 	if ok {
-		signingAlgorithmsVals, ok := signingAlgos.([]string)
+		signingAlgorithmsVals, ok := signingAlgos.([]interface{})
 		if !ok {
 			return opts, errors.New("signingalgorithms must be a list of signing algorithms")
 		}
-		opts.signingAlgorithms = signingAlgorithmsVals
+
+		for _, signingAlgorithmVal := range signingAlgorithmsVals {
+			signingAlgorithm, ok := signingAlgorithmVal.(string)
+			if !ok {
+				return opts, errors.New("signingalgorithms must be a list of signing algorithms")
+			}
+
+			opts.signingAlgorithms = append(opts.signingAlgorithms, signingAlgorithm)
+		}
 	}
 
 	return opts, nil


### PR DESCRIPTION
Fixes https://github.com/distribution/distribution/issues/4577

Specifically, this seems to something funky when unmarshalling a YAML file containing a list/slice into an `interface{}` type, and then using a type assertion to directly convert the field into the slice of the desired type.
A related issue is https://github.com/go-yaml/yaml/issues/282.

This can be fixed by first converting the value to a `[]interface{}`, then looping over it and converting each element into a `string` separately.

Also included is a fix for the error message shown when you supply an unsupported signing algorithm, which doesn't currently show which algorithm was invalid, like so:
```
panic: unable to configure authorization (token): unsupported signing algorithm:
```