### PR TITLE
Enable MD5 check on GCS driver

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -14,6 +14,7 @@ package gcs
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -425,6 +426,10 @@ func (d *driver) putContent(ctx context.Context, obj *storage.ObjectHandle, cont
 	if _, err := bytes.NewReader(content).WriteTo(wc); err != nil {
 		return err
 	}
+	h := md5.New()
+	h.Write(content)
+	wc.MD5 = h.Sum(nil)
+
 	return wc.Close()
 }
 

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -426,6 +426,10 @@ func (d *driver) putContent(ctx context.Context, obj *storage.ObjectHandle, cont
 	if _, err := bytes.NewReader(content).WriteTo(wc); err != nil {
 		return err
 	}
+	// NOTE(milosgajdos): Apparently it's posisble to to upload 0-byte content to GCS.
+	// Setting MD5 on the Writer helps to prevent presisting that data.
+	// If set, the uploaded data is rejected if its MD5 hash does not match this field.
+	// See: https://pkg.go.dev/cloud.google.com/go/storage#ObjectAttrs
 	h := md5.New()
 	h.Write(content)
 	wc.MD5 = h.Sum(nil)


### PR DESCRIPTION
Apparently, you can upload 0-size content without GCS reporting any errors back to you. Registry operations fail in these situations

This is something a lot of our users experienced and reported. See here for at least one example:
https://github.com/distribution/distribution/issues/3018

This PR sets the MD5 sum on the uploaded content which should rectify things according to the docs:
https://pkg.go.dev/cloud.google.com/go/storage#ObjectAttrs

The alternative would be to set `CRC32C` but that's not been verified unlike the MD5 which is used by GitLab in their registry.

Closes: https://github.com/distribution/distribution/issues/3018