### PR TITLE
Chore: merge multiple "Accept"" headers into a single comma-separated string

### DIFF
--- a/internal/client/repository.go
+++ b/internal/client/repository.go
@@ -311,8 +311,9 @@ func (t *tags) Get(ctx context.Context, tag string) (v1.Descriptor, error) {
 			return nil, err
 		}
 
-		for _, t := range distribution.ManifestMediaTypes() {
-			req.Header.Add("Accept", t)
+		mediaTypes := distribution.ManifestMediaTypes()
+		if len(mediaTypes) > 0 {
+			req.Header.Add("Accept", strings.Join(mediaTypes, ", "))
 		}
 		resp, err := t.client.Do(req)
 		return resp, err
@@ -498,8 +499,8 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		return nil, err
 	}
 
-	for _, t := range mediaTypes {
-		req.Header.Add("Accept", t)
+	if len(mediaTypes) > 0 {
+		req.Header.Add("Accept", strings.Join(mediaTypes, ", "))
 	}
 
 	if _, ok := ms.etags[digestOrTag]; ok {

--- a/internal/client/repository_test.go
+++ b/internal/client/repository_test.go
@@ -1220,7 +1220,8 @@ func TestManifestFetchWithAccept(t *testing.T) {
 		// This test is about checking if the Accept headers are returned as expected.
 		// nolint:errcheck
 		ms.Get(ctx, dgst, distribution.WithManifestMediaTypes(testCase.mediaTypes))
-		actual := <-headers
+		actualHeaders := <-headers
+		actual := strings.Split(strings.Join(actualHeaders, ", "), ", ")
 		if testCase.sort {
 			sort.Strings(actual)
 			sort.Strings(testCase.expect)


### PR DESCRIPTION
When using the Accept header in HTTP requests, combining multiple content types into a single header rather than splitting them into multiple headers is recommended based on the following points:


- According to [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2), the Accept header field is used to specify the list of media types that the client can accept. The specification clearly states that these values should be separated by commas within a single header field.
` Accept = #( media-range [ accept-params ] )`

- In real-world development, sending multiple Accept headers can cause problems，Certain middleware or proxy servers might truncate or mishandle the request.