### PR TITLE
Fix golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,5 @@ linters-settings:
         disabled: true
 
 issues:
-  deadline: 2m
-  exlude-dirs:
+  exclude-dirs:
     - vendor

--- a/dockerfiles/lint.Dockerfile
+++ b/dockerfiles/lint.Dockerfile
@@ -18,4 +18,5 @@ ARG BUILDTAGS
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
-      golangci-lint --timeout "${TIMEOUT}" --build-tags "${BUILDTAGS}" run
+    golangci-lint config verify && \
+    golangci-lint --timeout "${TIMEOUT}" --build-tags "${BUILDTAGS}" run


### PR DESCRIPTION
There was a typo and non-existent config option in the linter config.

Because we don't verify the config it's easy to miss it:
```
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additional properties 'exlude-dirs' not allowed
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additional properties 'deadline' not allowed
Failed executing command with error: the configuration contains invalid elements
```

This PR both fixes the config and adds a command which verifies it before we run the linter.

PTAL @thaJeztah 