### PR TITLE
Prep for v3 release

### DIFF
--- a/releases/v3.0.0.toml
+++ b/releases/v3.0.0.toml
@@ -7,7 +7,7 @@ github_repo = "distribution/distribution"
 # previous release
 previous = "v3.0.0-rc.4"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 registry 3.0.0

--- a/releases/v3.0.0.toml
+++ b/releases/v3.0.0.toml
@@ -1,0 +1,58 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "registry"
+github_repo = "distribution/distribution"
+
+# previous release
+previous = "v3.0.0-rc.4"
+
+pre_release = true
+
+preface = """\
+registry 3.0.0
+
+Welcome to the v3.0.0 release of registry!
+
+*This is a stable releasese*
+
+registry 3.0.0
+
+Please try out the release binaries and report any issues at
+https://github.com/distribution/distribution/issues.
+
+### Contributors
+
+* Milos Gajdos
+
+### Changes
+<details><summary>7 commits</summary>
+<p>
+  * [`2e63da99`](https://github.com/distribution/distribution/commit/2e63da99776be71a17be3f79f60e4c3f485b87e1) Fix golangci-lint config (#4612)
+  * [`fd14cf19`](https://github.com/distribution/distribution/commit/fd14cf193339eb2300828363560884f4ccbadba3) Vrify the linter config first before running it
+  * [`3a33ba12`](https://github.com/distribution/distribution/commit/3a33ba12ad9a436792c1e89a3732f8600940f6e6) Fix golangci-lint config
+  * [`75f32197`](https://github.com/distribution/distribution/commit/75f32197b6f180518d17210195ae0d3eb3885ce5) Bump Azure deps (#4611)
+  * [`52f0f6c4`](https://github.com/distribution/distribution/commit/52f0f6c45d5397ebff48778b7c5c8b1dec89e572) Bump Azure deps
+  * [`ef21149b`](https://github.com/distribution/distribution/commit/ef21149b4999ac0be22fe292640491b55cac9d9b) build(deps): bump github.com/golang-jwt/jwt/v5 from 5.2.1 to 5.2.2 in the go_modules group across 1 directory (#4608)
+  * [`05b308bc`](https://github.com/distribution/distribution/commit/05b308bc42519068f6157747301f5e68ef01b9af) build(deps): bump github.com/golang-jwt/jwt/v5
+</p>
+</details>
+
+### Dependency Changes
+
+* **github.com/Azure/azure-sdk-for-go/sdk/azcore**                v1.11.1 -> v1.17.1
+* **github.com/Azure/azure-sdk-for-go/sdk/azidentity**            v1.6.0 -> v1.8.2
+* **github.com/Azure/azure-sdk-for-go/sdk/internal**              v1.8.0 -> v1.10.0
+* **github.com/Azure/azure-sdk-for-go/sdk/storage/azblob**        v1.0.0 -> v1.6.0
+* **github.com/AzureAD/microsoft-authentication-library-for-go**  v1.2.2 -> v1.3.3
+* **github.com/golang-jwt/jwt/v5**                                v5.2.1 -> v5.2.2
+* **github.com/redis/go-redis/v9**                                v9.1.0 -> v9.7.3
+* **golang.org/x/crypto**                                         v0.35.0 -> v0.36.0
+* **golang.org/x/net**                                            v0.36.0 -> v0.37.0
+* **golang.org/x/oauth2**                                         v0.23.0 -> v0.28.0
+* **golang.org/x/sync**                                           v0.11.0 -> v0.12.0
+* **golang.org/x/sys**                                            v0.30.0 -> v0.31.0
+* **golang.org/x/text**                                           v0.22.0 -> v0.23.0
+
+Previous release can be found at [v3.0.0-rc.4](https://github.com/distribution/distribution/releases/tag/v3.0.0-rc.4)
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ var mainpkg = "github.com/distribution/distribution/v3"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var version = "v3.0.0-rc.4+unknown"
+var version = "v3.0.0+unknown"
 
 // revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.


### PR DESCRIPTION
This is a prep for the first stable v3 release of registry! The time has come to get it out!

Let's get the stable release out in time for [KubeCon Europe](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/)

The only delta in comparison to the recent rc-4 release is Azure and some other security dependency bumps.

Once this is out and the DOI is built, we must not forget to merge https://github.com/distribution/distribution/pull/4373

Let's go!