### PR TITLE
Correctly match environment variables to YAML-inlined structs in configuration

### DIFF
--- a/configuration/parser.go
+++ b/configuration/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -205,6 +206,25 @@ func (p *Parser) overwriteStruct(v reflect.Value, fullpath string, path []string
 	byUpperCase := make(map[string]int)
 	for i := 0; i < v.NumField(); i++ {
 		sf := v.Type().Field(i)
+
+		// For fields inlined in the YAML configuration file, the environment variables also need to be inlined
+		// Example struct tag for inlined field: `yaml:",inline"`
+		yamlTag := sf.Tag.Get("yaml")
+		split := strings.Split(yamlTag, ",")
+		// Skip the first entry, which is the field name
+		isInlined := slices.Contains(split[1:], "inline")
+
+		if isInlined && sf.Type.Kind() == reflect.Struct {
+			// Inlined struct, check whether the env variable corresponds to a field inside this struct
+			// Maps could also be inlined, but since we don't need it right now it is not supported
+			inlined := v.Field(i)
+			for j := 0; j < inlined.NumField(); j++ {
+				if strings.ToUpper(inlined.Type().Field(j).Name) == path[0] {
+					return p.overwriteFields(inlined, fullpath, path, payload)
+				}
+			}
+		}
+
 		upper := strings.ToUpper(sf.Name)
 		if _, present := byUpperCase[upper]; present {
 			panic(fmt.Sprintf("field name collision in configuration object: %s", sf.Name))


### PR DESCRIPTION
This is a quick and dirty fix for https://github.com/distribution/distribution/issues/4621. The underlying issue is as mentioned in https://github.com/distribution/distribution/issues/4621#issuecomment-2801461654.

This fixes it by checking for the `inline` directive inside YAML struct tags when parsing environment variables into the configuration struct. If it finds this directive, it will check if the environment variable corresponds to a field inside the inlined struct and overwrite that instead.

In order to keep things backward compatible for people using the workaround, the code will still accept an environment variable with the full inlined struct field name in it.
For example, for the Redis configuration, [which has an inline struct field named Options](https://github.com/distribution/distribution/blob/97495e53977ff5178fd5ca01608db1d71c9073d7/configuration/configuration.go#L956), both `REGISTRY_REDIS_OPTIONS_ADDRS` and `REGISTRY_REDIS_ADDRS` will point to the same struct field.

Feel free to close this if you'd like to see it handled differently; tying custom env variable parsing logic to the `yaml` struct tag is pretty janky, but it is a simple fix. A rewrite of the entire configuration package (maybe just using a third-party package that handles all of this) would be nice, but that would warrant some more discussion I'd guess.