### PR TITLE
docs: Add OpenTelemetry links to quickstart docs (#4270)

### DIFF
--- a/docs/content/about/deploying.md
+++ b/docs/content/about/deploying.md
@@ -30,6 +30,15 @@ The registry is now ready to use.
 > continue to the [configuration guide](configuration.md) to deploy a
 > production-ready registry.
 
+> **Note**: The [default configuration](https://github.com/distribution/distribution/blob/main/cmd/registry/config-dev.yml)
+> is designed for development. As such, the log level is set to `debug`. In
+> addition, the registry uses [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/)
+> for logs and trace. OpenTelemetry integration is configured using [standard
+> environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/),
+> and will by default attempt to export telemetry traces to an OTLP collector at
+> `localhost:4318`. If this is not desired, telemetry can be disabled by adding
+> `-e OTEL_TRACES_EXPORTER=none` to the `docker run` command above.
+
 ## Copy an image from Docker Hub to your registry
 
 You can pull an image from Docker Hub and push it to your registry. The


### PR DESCRIPTION
Does what it says on the tin. Documentation only. This is my first commit so please let me know if I've missed anything with respect to markdown linting or contribution guidelines.