### PR TITLE
s3-aws: fix build for 386

### DIFF
--- a/registry/storage/driver/s3-aws/s3_32bit.go
+++ b/registry/storage/driver/s3-aws/s3_32bit.go
@@ -1,4 +1,4 @@
-//go:build arm
+//go:build arm || 386
 
 package s3
 

--- a/registry/storage/driver/s3-aws/s3_64bit.go
+++ b/registry/storage/driver/s3-aws/s3_64bit.go
@@ -1,4 +1,4 @@
-//go:build !arm
+//go:build !arm && !386
 
 package s3
 


### PR DESCRIPTION
When building for 386, we got the following build error:

  registry/storage/driver/s3-aws/s3.go:312:99: cannot use
  maxChunkSize (untyped int constant 5368709120) as int value
  in argument to getParameterAsInteger (overflows)

This is because the s3_64bit.go is used. Adjust the build tag matching in s3_32bit.go and s3_64bit.go to fix this issue.