### PR TITLE
feat: Use regional endpoint for us-east-1 AWS region

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -524,6 +524,10 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		awsConfig.WithEndpoint(params.RegionEndpoint)
 	}
 
+	// Use regional endpoint for us-east-1 region
+	if params.RegionEndpoint == "" && params.Region == "us-east-1" {
+		awsConfig.WithS3UsEast1RegionalEndpoint(endpoints.RegionalS3UsEast1Endpoint)
+	}
 	awsConfig.WithS3ForcePathStyle(params.ForcePathStyle)
 	awsConfig.WithS3UseAccelerate(params.Accelerate)
 	awsConfig.WithRegion(params.Region)


### PR DESCRIPTION
Use regional S3 endpoint, instead global for buckets in us-east-1 AWS region, this change reduce cloud costs:

To test this changes - start registry with S3 bucket in us-east-1 region:
```bash
export REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io
export REGISTRY_STORAGE=s3
export REGISTRY_STORAGE_S3_BUCKET=test-bucket-for-test-distribution
export REGISTRY_STORAGE_S3_REGION=us-east-1
export REGISTRY_STORAGE_S3_LOGLEVEL=debug

go run ./cmd/registry serve ./cmd/registry/config-dev.yml
```
All requests to S3 use regional endpoint:
```
GET /?list-type=2&max-keys=1&prefix= HTTP/1.1
Host: test-bucket-for-test-distribution.s3.us-east-1.amazonaws.com
```

Closes: #4661 