### PR TITLE
feat(proxy): LRU eviction policy for pull through cache

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/auth/silly"
 	_ "github.com/distribution/distribution/v3/registry/auth/token"
 	_ "github.com/distribution/distribution/v3/registry/proxy"
+	_ "github.com/distribution/distribution/v3/registry/proxy/lru"
 	_ "github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/auth/silly"
 	_ "github.com/distribution/distribution/v3/registry/auth/token"
 	_ "github.com/distribution/distribution/v3/registry/proxy"
+	_ "github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/gcs"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -708,10 +708,14 @@ type Proxy struct {
 	// If set, Username and Password are ignored.
 	Exec *ExecConfig `yaml:"exec,omitempty"`
 
+	// EvictionPolicy specifies the eviction policy of the cache. Unset means no eviction at all.
+	EvictionPolicy *EvictionPolicy `yaml:"evictionpolicy,omitempty"`
+
+	// This field is kept for backwards compatibility. EvictionPolicy should be used instead.
 	// TTL is the expiry time of the content and will be cleaned up when it expires
 	// if not set, defaults to 7 * 24 hours
 	// If set to zero, will never expire cache
-	TTL *time.Duration `yaml:"ttl,omitempty"`
+	TTL string `yaml:"ttl,omitempty"`
 
 	// CacheWriteTimeout is the maximum duration allowed for cache write operations
 	// to complete when pulling blobs from the remote registry. This timeout ensures
@@ -735,6 +739,52 @@ type ExecConfig struct {
 	// If set to zero, the command will be executed for every request.
 	// If not set, the command will only be executed once.
 	Lifetime *time.Duration `yaml:"lifetime,omitempty"`
+}
+
+// EvictionPolicy defines the configuration for the registry proxy eviction policy
+type EvictionPolicy map[string]Parameters
+
+// Type returns the eviction policy type, such as ttl
+func (ep EvictionPolicy) Type() string {
+	// Return only key in this map
+	for k := range ep {
+		return k
+	}
+	return ""
+}
+
+// Parameters returns the Parameters map for an EvictionPolicy configuration
+func (ep EvictionPolicy) Parameters() Parameters {
+	return ep[ep.Type()]
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+// Unmarshals a single item map into a EvictionPolicy or a string into a EvictionPolicy type with no parameters
+func (ep *EvictionPolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var m map[string]Parameters
+	err := unmarshal(&m)
+	if err != nil {
+		return err
+	}
+	if len(m) > 1 {
+		types := make([]string, 0, len(m))
+		for k := range m {
+			types = append(types, k)
+		}
+
+		return fmt.Errorf("must provide exactly one type. Provided: %v", types)
+
+	}
+	*ep = m
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (ep EvictionPolicy) MarshalYAML() (interface{}, error) {
+	if ep.Parameters() == nil {
+		return ep.Type(), nil
+	}
+	return map[string]Parameters(ep), nil
 }
 
 // Validation configures validation options for the registry.

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -208,6 +208,46 @@ validation:
       platforms: none
 `
 
+// proxyConfigYamlV0_1 is a Version 0.1 yaml document specifying a registry
+// configured as a pull through cache and using an in memory driver
+const proxyConfigYamlV0_1 = `
+version: 0.1
+log:
+  level: info
+storage: inmemory
+auth:
+  silly:
+    realm: silly
+    service: silly
+notifications:
+  endpoints:
+    - name: endpoint-1
+      url:  http://example.com
+      headers:
+        Authorization: [Bearer <example>]
+      ignoredmediatypes:
+        - application/octet-stream
+      ignore:
+        mediatypes:
+           - application/octet-stream
+        actions:
+           - pull
+http:
+  headers:
+    X-Content-Type-Options: [nosniff]
+validation:
+  manifests:
+    indexes:
+      platforms: none
+proxy:
+  remoteurl: https://registry.example.com
+  username: "username"
+  password: "password"
+  evictionpolicy:
+    ttl:
+      ttl: 168h
+`
+
 type ConfigSuite struct {
 	suite.Suite
 	expectedConfig *Configuration
@@ -250,6 +290,30 @@ func (suite *ConfigSuite) TestParseInmemory() {
 	suite.expectedConfig.Redis = Redis{}
 
 	config, err := Parse(bytes.NewReader([]byte(inmemoryConfigYamlV0_1)))
+	suite.Require().NoError(err)
+	suite.Require().Equal(suite.expectedConfig, config)
+}
+
+// TestParseProxy validates that configuration yaml with pull-through cache
+// configured can be parsed into a Configuration struct
+func (suite *ConfigSuite) TestParseProxy() {
+	suite.expectedConfig.Storage = Storage{"inmemory": Parameters{}}
+	suite.expectedConfig.Log.Fields = nil
+	suite.expectedConfig.HTTP.TLS.ClientCAs = nil
+	suite.expectedConfig.HTTP.TLS.ClientAuth = ""
+	suite.expectedConfig.Redis = Redis{}
+	suite.expectedConfig.Proxy = Proxy{
+		RemoteURL: "https://registry.example.com",
+		Username:  "username",
+		Password:  "password",
+		EvictionPolicy: &EvictionPolicy{
+			"ttl": Parameters{
+				"ttl": "168h",
+			},
+		},
+	}
+
+	config, err := Parse(bytes.NewReader([]byte(proxyConfigYamlV0_1)))
 	suite.Require().NoError(err)
 	suite.Require().Equal(suite.expectedConfig, config)
 }

--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -318,7 +318,9 @@ proxy:
   exec:
     command: docker-credential-helper
     lifetime: 1h
-  ttl: 168h
+  evictionpolicy:
+    ttl:
+      ttl: 168h
 validation:
   manifests:
     urls:
@@ -1230,7 +1232,9 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: [username]
   password: [password]
-  ttl: 168h
+  evictionpolicy:
+    ttl:
+      ttl: 168h
 ```
 
 The `proxy` structure allows a registry to be configured as a pull-through cache
@@ -1242,7 +1246,6 @@ is unsupported.
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
 | `remoteurl`| yes     | The URL for the repository on Docker Hub.             |
-| `ttl`      | no      | Expire proxy cache configured in "storage" after this time. Cache 168h(7 days) by default, set to 0 to disable cache expiration, The suffix is one of `ns`, `us`, `ms`, `s`, `m`, or `h`. If you specify a value but omit the suffix, the value is interpreted as a number of nanoseconds. |
 
 To enable pulling private repositories (e.g. `batman/robin`), specify one of the
 following authentication methods for the pull-through cache to authenticate with
@@ -1263,6 +1266,20 @@ to retrieve the credentials to authenticate with the upstream registry.
 |-----------|----------|-------------------------------------------------------|
 | `command` | yes      | The command to execute.                               |
 | `lifetime`| no       | The expiry period of the credentials. The credentials returned by the command is reused through the configured lifetime, then the command will be re-executed to retrieve new credentials. If set to zero, the command will be executed for every request. If not set, the command will only be executed once. |
+
+### `evictionpolicy`
+
+The eviction policy to use when removing cached data from the pull-through cache.
+Only one eviction policy can be specified. If `evictionpolicy` is not specified,
+no data will be evicted from the pull-through cache.
+
+#### `ttl`
+
+A time-to-live eviction policy where cached entries are expired after some time.
+
+| Parameter | Required | Description                                           |
+|-----------|----------|-------------------------------------------------------|
+| `ttl`     | yes      | Expire proxy cache configured in "storage" after this time. The suffix is one of `ns`, `us`, `ms`, `s`, `m`, or `h`. If you specify a value but omit the suffix, the value is interpreted as a number of nanoseconds. The value must be positive. |
 
 
 > **Note**: These private repositories are stored in the proxy cache's storage.

--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -321,6 +321,8 @@ proxy:
   evictionpolicy:
     ttl:
       ttl: 168h
+    lru:
+      limit: 128gb
 validation:
   manifests:
     urls:
@@ -1235,6 +1237,8 @@ proxy:
   evictionpolicy:
     ttl:
       ttl: 168h
+    lru:
+      limit: 128gb
 ```
 
 The `proxy` structure allows a registry to be configured as a pull-through cache
@@ -1281,6 +1285,16 @@ A time-to-live eviction policy where cached entries are expired after some time.
 |-----------|----------|-------------------------------------------------------|
 | `ttl`     | yes      | Expire proxy cache configured in "storage" after this time. The suffix is one of `ns`, `us`, `ms`, `s`, `m`, or `h`. If you specify a value but omit the suffix, the value is interpreted as a number of nanoseconds. The value must be positive. |
 
+#### `lru`
+
+A least recently used eviction policy where cached entries that are least recently
+used are evicted when storage usage is above the `limit`. Note this should be set
+to a lower number than the real limit, since eviction happens after the limit is
+surpassed, not before.
+
+| Parameter | Required | Description                                           |
+|-----------|----------|-------------------------------------------------------|
+| `limit`     | yes      | Remove proxy cache configured in "storage" until storage is below this size. The suffix is one of `b`, `kb`, `mb`, `gb`, `tb`, `tb`, `pb`, `eb`. If you specify a value but omit the suffix, the value is interpreted as a number of bytes. The value must be positive. |
 
 > **Note**: These private repositories are stored in the proxy cache's storage.
 > Take appropriate measures to protect access to the proxy cache.

--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -99,7 +99,9 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: [username]
   password: [password]
-  ttl: 168h
+  evictionpolicy:
+    ttl:
+      ttl: 168h
 ```
 
 > **Warning**: If you specify a username and password, it's very important to

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bshuster-repo/logrus-logstash-hook v1.1.0
+	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker-credential-helpers v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdb
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 h1:6lhrsTEnloDPXyeZBvSYvQf8u86jbKehZPVDDlkgDl4=
+github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/registry/proxy/lru/lru.go
+++ b/registry/proxy/lru/lru.go
@@ -1,0 +1,459 @@
+package lru
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/registry/proxy"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/reference"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	entryTypeBlob = iota
+	entryTypeManifest
+	entryTypeMetadata
+	indexSaveFrequency = 5 * time.Second
+	entryNameHead      = "HEAD"
+	entryNameTail      = "TAIL"
+)
+
+var _ proxy.EvictionController = &LRUEvictionController{}
+
+// init registers the LRU eviction backend.
+func init() {
+	if err := proxy.Register("lru", proxy.InitFunc(new)); err != nil {
+		logrus.Errorf("failed to register LRU eviction controller: %v", err)
+	}
+}
+
+// lruEntry represents an entry in the LRU cache
+// it differs from schedulerEntry in that the CanonicalReference is split between `Key` and `References`.
+// `References` contain the Named portion of the CanonicalReference(s) and is necessary to delete every link in the LinkedBlobstore.
+// `Key` contains the Digest, which used to deduplicate images that share a base layer (useful for `touch`).
+// since a `Digest` is of form (digest-algorithm ":" digest-hex), they will not collided with the special entries for head and tail.
+// `Prev` and `Next` are `Key`s for the underlying doubly linked list structure used in insertion and eviction.
+type lruEntry struct {
+	Key        string   `json:"Key"`
+	EntryType  int      `json:"EntryType"`
+	References []string `json:"References"`
+	Prev       string   `json:"Prev"`
+	Next       string   `json:"Next"`
+}
+
+// EvictionQueue is the underlying data structure for the LRU: a hash map + doubly linked list. Consider the following example.
+//
+// HEAD <-> Entry1 <-> Entry2 <-> TAIL
+//
+// The HEAD and TAIL entries are special entries to maintain the structure and should always exist.
+// The entry after HEAD should be the least recently used and the the entry before TAIL the most recently used.
+// If a new entry `Entry3` is `add`ed, then, it will be between `Entry2` and TAIL.
+// If `Entry1` is used again, it will be `touch`ed and moved to the end of the eviction queue (i.e. right before TAIL).
+//
+// It might benefit to factor out the linked list operations to this type in the future for better testing and isolation.
+type EvictionQueue map[string]*lruEntry
+
+// new returns a new instance of the LRU eviction controller
+func new(ctx context.Context, driver driver.StorageDriver, path string, options map[string]interface{}) (proxy.EvictionController, error) {
+	limitOpt, present := options["limit"]
+	if !present {
+		return nil, fmt.Errorf(`"limit" must be set for LRU eviction policy`)
+	}
+	limitStr, ok := limitOpt.(string)
+	if !ok {
+		return nil, fmt.Errorf(`"limit" must be a valid positive size capacity value, given %v`, limitOpt)
+	}
+	limit, err := datasize.ParseString(limitStr)
+	if err != nil || limit <= 0 {
+		return nil, fmt.Errorf(`"limit" must be a valid positive size capacity value, given %v, with error: %v`, limit, err)
+	}
+
+	// special head and tail entries are exported to simplify using the doubly linked list
+	headEntry := lruEntry{
+		Key:       entryNameHead,
+		EntryType: entryTypeMetadata,
+		Prev:      entryNameHead,
+		Next:      entryNameTail,
+	}
+	tailEntry := lruEntry{
+		Key:       entryNameTail,
+		EntryType: entryTypeMetadata,
+		Prev:      entryNameHead,
+		Next:      entryNameTail,
+	}
+
+	lruec := LRUEvictionController{
+		entries: EvictionQueue{
+			entryNameHead: &headEntry,
+			entryNameTail: &tailEntry,
+		},
+		head:            &headEntry,
+		tail:            &tailEntry,
+		driver:          driver,
+		pathToStateFile: path,
+		limit:           limit.Bytes(),
+		ctx:             ctx,
+		stopped:         true,
+		doneChan:        make(chan struct{}),
+		saveTimer:       time.NewTicker(indexSaveFrequency),
+	}
+
+	return &lruec, nil
+}
+
+// LRUEvictionController is an eviction controller used to perform actions
+// when the specified space limit is exceeded
+type LRUEvictionController struct {
+	sync.Mutex
+
+	entries EvictionQueue
+	head    *lruEntry
+	tail    *lruEntry
+
+	driver          driver.StorageDriver
+	ctx             context.Context
+	pathToStateFile string
+	limit           uint64
+
+	stopped bool
+
+	onBlobExpire     proxy.OnEvictFunc
+	onManifestExpire proxy.OnEvictFunc
+
+	indexDirty bool
+	saveTimer  *time.Ticker
+	doneChan   chan struct{}
+}
+
+// OnBlobEvict registers the callback function for when a cached blob is evicted
+func (lruec *LRUEvictionController) OnBlobEvict(f proxy.OnEvictFunc) {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	lruec.onBlobExpire = f
+}
+
+// OnManifestEvict registers the callback function for when a cached manifest is evicted
+func (lruec *LRUEvictionController) OnManifestEvict(f proxy.OnEvictFunc) {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	lruec.onManifestExpire = f
+}
+
+// AddBlob adds a blob to the LRU
+func (lruec *LRUEvictionController) AddBlob(blobRef reference.Canonical) error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	if lruec.stopped {
+		return fmt.Errorf("LRU eviction controller not started")
+	}
+
+	if err := lruec.add(blobRef, entryTypeBlob); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddManifest adds a manifest to the LRU
+func (lruec *LRUEvictionController) AddManifest(manifestRef reference.Canonical) error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	if lruec.stopped {
+		return fmt.Errorf("LRU eviction controller not started")
+	}
+
+	if err := lruec.add(manifestRef, entryTypeManifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TouchBlob touches the LRU entry from a cache hit
+func (lruec *LRUEvictionController) TouchBlob(blobRef reference.Canonical) error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	if lruec.stopped {
+		return fmt.Errorf("LRU eviction controller not started")
+	}
+
+	if err := lruec.touch(blobRef, entryTypeBlob); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TouchManifest touches the LRU entry from a cache hit
+func (lruec *LRUEvictionController) TouchManifest(manifestRef reference.Canonical) error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	if lruec.stopped {
+		return fmt.Errorf("LRU eviction controller not started")
+	}
+
+	if err := lruec.touch(manifestRef, entryTypeManifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Start starts the LRU eviction controller
+func (lruec *LRUEvictionController) Start() error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	if !lruec.stopped {
+		return fmt.Errorf("LRU eviction controller already started")
+	}
+
+	err := lruec.readState()
+	if err != nil {
+		return err
+	}
+
+	head, headOk := lruec.entries[entryNameHead]
+	tail, tailOk := lruec.entries[entryNameTail]
+	if !headOk || !tailOk {
+		return fmt.Errorf("lost head and/or tail entry when reading state")
+	}
+	lruec.head = head
+	lruec.tail = tail
+
+	dcontext.GetLogger(lruec.ctx).Infof("Starting cached object LRU eviction controller...")
+	lruec.stopped = false
+
+	// since we only checkpoint periodically, it is possible that we lose the latest state upon recovery if we encounter
+	// a non-graceful shutdown. If this becomes a problem, we maybe should change `add` and `touch` to not have a strong
+	// requirement on being consistent with the storage layer and instead just do `addOrTouch`.
+
+	// Start a ticker to periodically save the entries index
+	go func() {
+		for {
+			select {
+			case <-lruec.saveTimer.C:
+				lruec.Lock()
+				if !lruec.indexDirty {
+					lruec.Unlock()
+					continue
+				}
+
+				err := lruec.writeState()
+				if err != nil {
+					dcontext.GetLogger(lruec.ctx).Errorf("Error writing LRU state: %s", err)
+				} else {
+					lruec.indexDirty = false
+				}
+				lruec.Unlock()
+
+			case <-lruec.doneChan:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// mustGetEntry wraps around the map get for entries. It panics if entry is not found because this means a broken linked list
+func (lruec *LRUEvictionController) mustGetEntry(key string) *lruEntry {
+	entry, ok := lruec.entries[key]
+	if !ok {
+		panic("Unable to find entry %s, aborting due to broken linked list in LRU")
+	}
+	return entry
+}
+
+// add is the internal implementation called by AddBlob and AddManifest
+func (lruec *LRUEvictionController) add(r reference.Canonical, eType int) error {
+	entryKey := r.Digest().String()
+	_, ok := lruec.entries[entryKey]
+	if ok {
+		return fmt.Errorf("entry %s already exists in cache entries, inconsistency with storage", entryKey)
+	}
+
+	// Append entry back to tail of linked list
+	tail := lruec.tail
+	prev := lruec.mustGetEntry(tail.Prev)
+	entry := &lruEntry{
+		Key:        r.Digest().String(),
+		EntryType:  eType,
+		References: []string{r.Name()},
+		Prev:       prev.Key,
+		Next:       tail.Key,
+	}
+
+	dcontext.GetLogger(lruec.ctx).Infof("Adding lru entry for %s", entry.Key)
+	prev.Next = entryKey
+	tail.Prev = entryKey
+	lruec.entries[entry.Key] = entry
+	lruec.indexDirty = true
+
+	if err := lruec.evict(); err != nil {
+		return fmt.Errorf("error evicting entries after inserting %s: %v", entryKey, err)
+	}
+	return nil
+}
+
+// touch is the internal implementation called by TouchBlob and TouchManifest
+func (lruec *LRUEvictionController) touch(r reference.Canonical, eType int) error {
+	entryKey := r.Digest().String()
+	entry, ok := lruec.entries[entryKey]
+	if !ok {
+		return fmt.Errorf("entry %s does not exist in cache entries, inconsistency with storage", entryKey)
+	}
+	if entry.EntryType != eType {
+		return fmt.Errorf("entry %s is expected to have entry type %d, got %d", entryKey, entry.EntryType, eType)
+	}
+
+	if !slices.Contains(entry.References, r.Name()) {
+		entry.References = append(entry.References, r.Name())
+		lruec.indexDirty = true
+	}
+
+	// If the entry is already the last entry, no need to move to last
+	if entry.Next == entryNameTail {
+		return nil
+	}
+
+	tail := lruec.tail
+	prev := lruec.mustGetEntry(entry.Prev)
+	next := lruec.mustGetEntry(entry.Next)
+	newPrev := lruec.mustGetEntry(tail.Prev)
+
+	dcontext.GetLogger(lruec.ctx).Infof("Touching lru entry for %s", entry.Key)
+
+	// Remove entry's links in linked list
+	prev.Next = entry.Next
+	next.Prev = entry.Prev
+
+	// Append entry back to tail of linked list
+	entry.Prev = newPrev.Key
+	entry.Next = tail.Key
+	newPrev.Next = entryKey
+	tail.Prev = entryKey
+
+	lruec.indexDirty = true
+	return nil
+}
+
+// Evict removes entries until size of the storage backend is below the specified limit
+func (lruec *LRUEvictionController) evict() error {
+	head := lruec.head
+	tail := lruec.tail
+
+	for {
+		size, err := lruec.driver.Usage(lruec.ctx, "/")
+		if err != nil {
+			return fmt.Errorf("could not get storagedriver usage at \"/\": %s", err)
+		}
+
+		if size <= lruec.limit {
+			break
+		}
+		if head.Next == tail.Key {
+			return fmt.Errorf("cache eviction has evicted all entries but storage is still above limit")
+		}
+		entry := lruec.mustGetEntry(head.Next)
+
+		// Delete each reference to the entry in the storage backend
+		var f proxy.OnEvictFunc
+
+		switch entry.EntryType {
+		case entryTypeBlob:
+			f = lruec.onBlobExpire
+		case entryTypeManifest:
+			f = lruec.onManifestExpire
+		default:
+			f = func(reference.Reference) error {
+				return fmt.Errorf("lru entry type")
+			}
+		}
+		for _, ref := range entry.References {
+			// The left hand side is a Named reference, and the right hand side is the digest
+			canonical, err := reference.Parse(ref + "@" + entry.Key)
+			if err != nil {
+				return fmt.Errorf("error unpacking reference: %s", err)
+			}
+			// We've observed cases where the blob is already removed, we don't want to stop
+			// eviction because of this, so we continue.
+			if err := f(canonical); err != nil && !errors.Is(err, distribution.ErrBlobUnknown) {
+				return fmt.Errorf("eviction error returned from OnEvict(%s): %s", entry.Key, err)
+			}
+		}
+
+		next := lruec.mustGetEntry(entry.Next)
+
+		dcontext.GetLogger(lruec.ctx).Infof("Evicting lru entry: %s", entry.Key)
+		head.Next = entry.Next
+		next.Prev = entry.Prev
+		delete(lruec.entries, entry.Key)
+		lruec.indexDirty = true
+	}
+	return nil
+}
+
+// Stop stops the LRU eviction controller.
+func (lruec *LRUEvictionController) Stop() error {
+	lruec.Lock()
+	defer lruec.Unlock()
+
+	err := lruec.writeState()
+	if err != nil {
+		err = fmt.Errorf("error writing LRU state: %w", err)
+	}
+
+	close(lruec.doneChan)
+	lruec.saveTimer.Stop()
+	lruec.stopped = true
+	return err
+}
+
+func (lruec *LRUEvictionController) writeState() error {
+	jsonBytes, err := json.Marshal(lruec.entries)
+	if err != nil {
+		return err
+	}
+
+	err = lruec.driver.PutContent(lruec.ctx, lruec.pathToStateFile, jsonBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (lruec *LRUEvictionController) readState() error {
+	if _, err := lruec.driver.Stat(lruec.ctx, lruec.pathToStateFile); err != nil {
+		switch err := err.(type) {
+		case driver.PathNotFoundError:
+			return nil
+		default:
+			return err
+		}
+	}
+
+	bytes, err := lruec.driver.GetContent(lruec.ctx, lruec.pathToStateFile)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bytes, &lruec.entries)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/registry/proxy/lru/lru_test.go
+++ b/registry/proxy/lru/lru_test.go
@@ -1,0 +1,459 @@
+package lru
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
+	"github.com/distribution/reference"
+)
+
+var testData = [64]byte{}
+
+// testRefPath gives just the digest as a string
+func testRefPath(r reference.Reference) string {
+	return "/" + strings.Split(r.String(), ":")[1]
+}
+
+func testRefs(t *testing.T) (reference.Canonical, reference.Canonical, reference.Canonical) {
+	ref1, err := reference.Parse("testrepo@sha256:aaaaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatalf("could not parse reference: %v", err)
+	}
+	can1, ok := ref1.(reference.Canonical)
+	if !ok {
+		t.Fatalf("could not parse canonical reference: %v", ref1)
+	}
+
+	ref2, err := reference.Parse("testrepo@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatalf("could not parse reference: %v", err)
+	}
+	can2, ok := ref2.(reference.Canonical)
+	if !ok {
+		t.Fatalf("could not parse canonical reference: %v", ref2)
+	}
+
+	ref3, err := reference.Parse("testrepo@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+	if err != nil {
+		t.Fatalf("could not parse reference: %v", err)
+	}
+	can3, ok := ref3.(reference.Canonical)
+	if !ok {
+		t.Fatalf("could not parse canonical reference: %v", ref3)
+	}
+
+	return can1, can2, can3
+}
+
+func testRefDup(t *testing.T) reference.Canonical {
+	ref, err := reference.Parse("testrepodup@sha256:aaaaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatalf("could not parse reference: %v", err)
+	}
+	can, ok := ref.(reference.Canonical)
+	if !ok {
+		t.Fatalf("could not parse canonical reference: %v", ref)
+	}
+	return can
+}
+
+func testLRU(t *testing.T, driver driver.StorageDriver, path string, options map[string]interface{}) *LRUEvictionController {
+	ec, err := new(dcontext.Background(), driver, path, options)
+	if err != nil {
+		t.Fatalf("Could not create a valid EvictionController, %v", err)
+	}
+	s, ok := ec.(*LRUEvictionController)
+	if !ok {
+		t.Fatalf("Could not create a valid LRUEvictionController")
+	}
+	return s
+}
+
+func TestNewLRU(t *testing.T) {
+	options := map[string]interface{}{
+		"limit": "127",
+	}
+	testLRU(t, inmemory.New(), "/lru", options)
+}
+
+func TestEviction(t *testing.T) {
+	ref1, ref2, ref3 := testRefs(t)
+	expectedEvictions := map[string]bool{
+		ref1.String(): true,
+		ref2.String(): true,
+	}
+
+	fs := inmemory.New()
+	ctx := context.Background()
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": "127"})
+	deleteFunc := func(r reference.Reference) error {
+		if len(expectedEvictions) == 0 {
+			t.Fatal("Incorrect eviction count")
+		}
+		_, ok := expectedEvictions[r.String()]
+		if !ok {
+			t.Fatalf("Trying to remove unexpected repo: %s", r)
+		}
+		t.Log("removing", r)
+		delete(expectedEvictions, r.String())
+		if err := fs.Delete(ctx, testRefPath(r)); err != nil {
+			t.Fatalf("Error while deleting file %s: %v", testRefPath(r), err)
+		}
+
+		return nil
+	}
+	ec.onBlobExpire = deleteFunc
+
+	// Instead of calling Start, we set stopped = false instead so the entries will not be written to fs
+	// This is a workaround to make this test not flaky, as the entries are written every 5 second, which
+	// affects the size/limit calculations
+	ec.stopped = false
+
+	if err := fs.PutContent(ctx, testRefPath(ref1), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := ec.add(ref1, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref1, err)
+	}
+
+	if err := fs.PutContent(ctx, testRefPath(ref2), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := ec.add(ref2, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref2, err)
+	}
+
+	if err := fs.PutContent(ctx, testRefPath(ref3), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := ec.add(ref3, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref3, err)
+	}
+
+	if len(expectedEvictions) != 0 {
+		t.Fatalf("Repositories remaining: %#v", expectedEvictions)
+	}
+}
+
+func TestRestoreOld(t *testing.T) {
+	ref1, ref2, ref3 := testRefs(t)
+	expectedEvictions := map[string]bool{
+		ref1.String(): true,
+		ref2.String(): true,
+	}
+
+	fs := inmemory.New()
+	ctx := dcontext.Background()
+	deleteFunc := func(r reference.Reference) error {
+		if len(expectedEvictions) == 0 {
+			t.Fatal("Incorrect eviction count")
+		}
+		_, ok := expectedEvictions[r.String()]
+		if !ok {
+			t.Fatalf("Trying to remove unexpected repo: %s", r)
+		}
+		t.Log("removing", r)
+		delete(expectedEvictions, r.String())
+		if err := fs.Delete(ctx, testRefPath(r)); err != nil {
+			t.Fatalf("Error while deleting file %s: %v", testRefPath(r), err)
+		}
+
+		return nil
+	}
+
+	serialized, err := json.Marshal(&map[string]lruEntry{
+		entryNameHead: {
+			Key:       entryNameHead,
+			EntryType: 0,
+			Prev:      entryNameHead,
+			Next:      ref1.Digest().String(),
+		},
+		entryNameTail: {
+			Key:       entryNameTail,
+			EntryType: 0,
+			Prev:      ref2.Digest().String(),
+			Next:      entryNameTail,
+		},
+		ref1.Digest().String(): {
+			Key:        ref1.Digest().String(),
+			EntryType:  0,
+			References: []string{ref1.Name()},
+			Prev:       entryNameHead,
+			Next:       ref2.Digest().String(),
+		},
+		ref2.Digest().String(): {
+			Key:        ref2.Digest().String(),
+			EntryType:  0,
+			References: []string{ref2.Name()},
+			Prev:       ref1.Digest().String(),
+			Next:       entryNameTail,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Error serializing test data: %s", err.Error())
+	}
+
+	pathToStatFile := "/lru"
+	err = fs.PutContent(ctx, pathToStatFile, serialized)
+	if err != nil {
+		t.Fatal("Unable to write serialized data to fs")
+	}
+
+	if err := fs.PutContent(ctx, testRefPath(ref1), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := fs.PutContent(ctx, testRefPath(ref2), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+
+	// Account for the disk space of the written entries file
+	limit := 127 + len(serialized)
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": strconv.Itoa(limit)})
+	ec.OnBlobEvict(deleteFunc)
+	err = ec.Start()
+	if err != nil {
+		t.Fatalf("Error starting LRUEvictionController: %s", err)
+	}
+
+	if err := fs.PutContent(ctx, testRefPath(ref3), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := ec.add(ref3, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref3, err)
+	}
+
+	if len(expectedEvictions) != 0 {
+		t.Fatalf("Repositories remaining: %#v", expectedEvictions)
+	}
+
+	if err := ec.Stop(); err != nil {
+		t.Fatalf("Error stopping LRUEvictionController: %s", err)
+	}
+}
+
+func TestStopRestore(t *testing.T) {
+	ref1, ref2, _ := testRefs(t)
+
+	deleteFunc := func(r reference.Reference) error {
+		t.Fatalf("No deletion expected, trying to delete %s", r.String())
+		return nil
+	}
+
+	fs := inmemory.New()
+	pathToStateFile := "/lru"
+	ec := testLRU(t, fs, pathToStateFile, map[string]interface{}{"limit": "127"})
+	ec.onBlobExpire = deleteFunc
+
+	err := ec.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.add(ref1, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref1, err)
+	}
+	if err := ec.add(ref2, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref2, err)
+	}
+
+	// Start and stop before all operations complete
+	// state will be written to fs
+	err = ec.Stop()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ec2 will restore state from fs
+	ec2 := testLRU(t, fs, pathToStateFile, map[string]interface{}{"limit": "127"})
+	ec2.onBlobExpire = deleteFunc
+	err = ec2.Start()
+	if err != nil {
+		t.Fatalf("Error starting v2: %s", err.Error())
+	}
+
+	// We added 2 entries, and there's entries for head and tail
+	if len(ec2.entries) != 4 {
+		t.Fatalf("Unexpected number of restored entries: %v", ec2.entries)
+	}
+}
+
+func TestDoubleStart(t *testing.T) {
+	ec := testLRU(t, inmemory.New(), "/lru", map[string]interface{}{"limit": "127"})
+	err := ec.Start()
+	if err != nil {
+		t.Fatal("Unable to start LRU")
+	}
+	err = ec.Start()
+	if err == nil {
+		t.Fatal("LRU started twice without error")
+	}
+}
+
+func TestEvictEmpty(t *testing.T) {
+	fs := inmemory.New()
+	ctx := context.Background()
+
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": "63"})
+	err := ec.Start()
+	if err != nil {
+		t.Fatal("Unable to start LRU")
+	}
+
+	if err := fs.PutContent(ctx, "/testdata1", testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+
+	// This case should not happen normally, but is possible if, for example, the limit is set too low
+	// and even evicting every entry does not allow for enough space.
+	err = ec.evict()
+	if err.Error() != "cache eviction has evicted all entries but storage is still above limit" {
+		t.Fatalf("Reached unexpected error %s", err)
+	}
+}
+
+func TestEvictNothing(t *testing.T) {
+	fs := inmemory.New()
+
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": "63"})
+	err := ec.Start()
+	if err != nil {
+		t.Fatal("Unable to start LRU")
+	}
+
+	err = ec.evict()
+	if err != nil {
+		t.Fatalf("Reached unexcepted error during eviction: %v", err)
+	}
+}
+
+func TestEvictTouch(t *testing.T) {
+	ref1, ref2, _ := testRefs(t)
+
+	fs := inmemory.New()
+	ctx := context.Background()
+
+	expectedEvictions := map[string]bool{
+		ref1.String(): true,
+		ref2.String(): true,
+	}
+	deleteFunc := func(r reference.Reference) error {
+		if len(expectedEvictions) == 0 {
+			t.Fatal("Incorrect eviction count")
+		}
+
+		if r.String() == ref1.String() && len(expectedEvictions) == 2 {
+			t.Fatalf("ref1 should not be removed first")
+		}
+		_, ok := expectedEvictions[r.String()]
+		if !ok {
+			t.Fatalf("Trying to remove unexpected repo: %s", r)
+		}
+		t.Log("removing", r)
+		delete(expectedEvictions, r.String())
+		if err := fs.Delete(ctx, testRefPath(r)); err != nil {
+			t.Fatalf("Error while deleting file %s: %v", testRefPath(r), err)
+		}
+
+		return nil
+	}
+
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": "63"})
+	ec.OnBlobEvict(deleteFunc)
+	ec.stopped = false
+
+	if err := ec.add(ref1, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref1, err)
+	}
+	if err := ec.add(ref2, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref2, err)
+	}
+
+	if err := fs.PutContent(ctx, testRefPath(ref1), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := fs.PutContent(ctx, testRefPath(ref2), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+
+	if err := ec.touch(ref1, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to touch entry %s in LRUEvictionController: %v", ref1, err)
+	}
+
+	err := ec.evict()
+	if err != nil {
+		t.Fatalf("Reached unexcepted error during eviction: %v", err)
+	}
+}
+
+func TestDuplicate(t *testing.T) {
+	ref1, _, _ := testRefs(t)
+	ref2 := testRefDup(t)
+
+	fs := inmemory.New()
+	ctx := context.Background()
+
+	expectedEvictions := map[string]bool{
+		ref1.String(): true,
+		ref2.String(): true,
+	}
+	deleteFunc := func(r reference.Reference) error {
+		if len(expectedEvictions) == 0 {
+			t.Fatal("Incorrect eviction count")
+		}
+		_, ok := expectedEvictions[r.String()]
+		if !ok {
+			t.Fatalf("Trying to remove unexpected repo: %s", r)
+		}
+		t.Log("removing", r)
+
+		delete(expectedEvictions, r.String())
+		if err := fs.Delete(ctx, testRefPath(r)); err != nil {
+			if errors.Is(err, driver.PathNotFoundError{Path: testRefPath(ref2), DriverName: "inmemory"}) {
+				// the second delete will try to remove the same file
+				return nil
+			}
+			t.Fatalf("Error while deleting file %s: %v", testRefPath(r), err)
+		}
+
+		return nil
+	}
+
+	ec := testLRU(t, fs, "/lru", map[string]interface{}{"limit": "63"})
+	ec.OnBlobEvict(deleteFunc)
+	ec.stopped = false
+
+	if err := ec.add(ref1, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to add entry %s to LRUEvictionController: %v", ref1, err)
+	}
+	if err := ec.touch(ref2, entryTypeBlob); err != nil {
+		t.Fatalf("Failed to touch entry %s in LRUEvictionController: %v", ref2, err)
+	}
+
+	// HEAD, TAIL, and the deduplicated entry of ref1 and ref2
+	if len(ec.entries) != 3 {
+		t.Fatalf("Entry add did not deduplicate entries with the same digest")
+	}
+
+	// testRefPath for ref1 and ref2 should be the same, so this will write a total of 64 bytes
+	if err := fs.PutContent(ctx, testRefPath(ref1), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+	if err := fs.PutContent(ctx, testRefPath(ref2), testData[:]); err != nil {
+		t.Fatalf("Unable to write test data to fs: %v", err)
+	}
+
+	err := ec.evict()
+	if err != nil {
+		t.Fatalf("Reached unexcepted error during eviction: %v", err)
+	}
+
+	if len(expectedEvictions) != 0 {
+		t.Fatalf("Did not evict all references of a duplicated digest entry, left with %v", expectedEvictions)
+	}
+}

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -21,7 +21,6 @@ type proxyBlobStore struct {
 	localStore        distribution.BlobStore
 	remoteStore       distribution.BlobService
 	scheduler         *scheduler.TTLExpirationScheduler
-	ttl               *time.Duration
 	cacheWriteTimeout time.Duration
 	repositoryName    reference.Named
 	authChallenger    authChallenger
@@ -157,8 +156,8 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	if pbs.scheduler != nil && pbs.ttl != nil {
-		if err := pbs.scheduler.AddBlob(blobRef, *pbs.ttl); err != nil {
+	if pbs.scheduler != nil {
+		if err := pbs.scheduler.AddBlob(blobRef); err != nil {
 			dcontext.GetLogger(ctx).Errorf("Error adding blob: %s", err)
 			return err
 		}

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -13,17 +13,16 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/internal/dcontext"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/reference"
 )
 
 type proxyBlobStore struct {
-	localStore        distribution.BlobStore
-	remoteStore       distribution.BlobService
-	scheduler         *scheduler.TTLExpirationScheduler
-	cacheWriteTimeout time.Duration
-	repositoryName    reference.Named
-	authChallenger    authChallenger
+	localStore         distribution.BlobStore
+	remoteStore        distribution.BlobService
+	evictionController EvictionController
+	cacheWriteTimeout  time.Duration
+	repositoryName     reference.Named
+	authChallenger     authChallenger
 }
 
 var _ distribution.BlobStore = &proxyBlobStore{}
@@ -156,8 +155,8 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	if pbs.scheduler != nil {
-		if err := pbs.scheduler.AddBlob(blobRef); err != nil {
+	if pbs.evictionController != nil {
+		if err := pbs.evictionController.AddBlob(blobRef); err != nil {
 			dcontext.GetLogger(ctx).Errorf("Error adding blob: %s", err)
 			return err
 		}

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -74,6 +74,19 @@ func (pbs *proxyBlobStore) serveLocal(ctx context.Context, w http.ResponseWriter
 		return false, nil
 	}
 
+	// Touch the eviction entry
+	if pbs.evictionController != nil {
+		blobRef, err := reference.WithDigest(pbs.repositoryName, dgst)
+		if err != nil {
+			dcontext.GetLogger(ctx).Errorf("Error creating reference: %s", err)
+			return false, err
+		}
+		if err := pbs.evictionController.TouchBlob(blobRef); err != nil {
+			dcontext.GetLogger(ctx).Errorf("Error touching blob: %s", err)
+			return false, err
+		}
+	}
+
 	proxyMetrics.BlobPush(uint64(localDesc.Size), true)
 	return true, pbs.localStore.ServeBlob(ctx, w, r, dgst)
 }

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -177,7 +177,7 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 		blobs: localRepo.Blobs(ctx),
 	}
 
-	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json")
+	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json", nil)
 
 	proxyBlobStore := proxyBlobStore{
 		repositoryName: nameRef,

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -11,11 +11,9 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/cache/memory"
 	"github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
-	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -177,14 +175,13 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 		blobs: localRepo.Blobs(ctx),
 	}
 
-	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json", nil)
-
 	proxyBlobStore := proxyBlobStore{
 		repositoryName: nameRef,
 		remoteStore:    truthBlobs,
 		localStore:     localBlobs,
-		scheduler:      s,
-		authChallenger: &mockChallenger{},
+		// evictionController is nil here for now since importing any eviction controller introduces a cyclic dependency
+		evictionController: nil,
+		authChallenger:     &mockChallenger{},
 	}
 
 	te := &testEnv{
@@ -255,9 +252,9 @@ func TestProxyStoreGet(t *testing.T) {
 	}
 }
 
-func TestProxyStoreGetWithoutScheduler(t *testing.T) {
+func TestProxyStoreGetWithoutEviction(t *testing.T) {
 	te := makeTestEnv(t, "foo/bar")
-	te.store.scheduler = nil
+	te.store.evictionController = nil
 
 	populate(t, te, 1, 10, 1)
 

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -7,17 +7,16 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/internal/dcontext"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/reference"
 )
 
 type proxyManifestStore struct {
-	ctx             context.Context
-	localManifests  distribution.ManifestService
-	remoteManifests distribution.ManifestService
-	repositoryName  reference.Named
-	scheduler       *scheduler.TTLExpirationScheduler
-	authChallenger  authChallenger
+	ctx                context.Context
+	localManifests     distribution.ManifestService
+	remoteManifests    distribution.ManifestService
+	repositoryName     reference.Named
+	evictionController EvictionController
+	authChallenger     authChallenger
 }
 
 var _ distribution.ManifestService = &proxyManifestStore{}
@@ -74,8 +73,8 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 			return nil, err
 		}
 
-		if pms.scheduler != nil {
-			if err := pms.scheduler.AddManifest(repoBlob); err != nil {
+		if pms.evictionController != nil {
+			if err := pms.evictionController.AddManifest(repoBlob); err != nil {
 				dcontext.GetLogger(ctx).Errorf("Error adding manifest: %s", err)
 				return nil, err
 			}

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -83,6 +83,20 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 		// Ensure the manifest blob is cleaned up
 		// pms.scheduler.AddBlob(blobRef, repositoryTTL)
 
+	} else {
+		// Touch the eviction entry
+		repoBlob, err := reference.WithDigest(pms.repositoryName, dgst)
+		if err != nil {
+			dcontext.GetLogger(ctx).Errorf("Error creating reference: %s", err)
+			return nil, err
+		}
+
+		if pms.evictionController != nil {
+			if err := pms.evictionController.TouchManifest(repoBlob); err != nil {
+				dcontext.GetLogger(ctx).Errorf("Error adding manifest: %s", err)
+				return nil, err
+			}
+		}
 	}
 
 	return manifest, err

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"time"
 
 	"github.com/opencontainers/go-digest"
 
@@ -18,7 +17,6 @@ type proxyManifestStore struct {
 	remoteManifests distribution.ManifestService
 	repositoryName  reference.Named
 	scheduler       *scheduler.TTLExpirationScheduler
-	ttl             *time.Duration
 	authChallenger  authChallenger
 }
 
@@ -76,8 +74,8 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 			return nil, err
 		}
 
-		if pms.scheduler != nil && pms.ttl != nil {
-			if err := pms.scheduler.AddManifest(repoBlob, *pms.ttl); err != nil {
+		if pms.scheduler != nil {
+			if err := pms.scheduler.AddManifest(repoBlob); err != nil {
 				dcontext.GetLogger(ctx).Errorf("Error adding manifest: %s", err)
 				return nil, err
 			}

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -132,7 +132,7 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 		stats:     make(map[string]int),
 	}
 
-	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json")
+	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json", nil)
 	return &manifestStoreTestEnv{
 		manifestDigest: manifestDigest,
 		manifestSize:   manifestSize,

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/distribution/distribution/v3/internal/client/auth"
 	"github.com/distribution/distribution/v3/internal/client/auth/challenge"
 	"github.com/distribution/distribution/v3/manifest/schema2"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/cache/memory"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -132,7 +131,6 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 		stats:     make(map[string]int),
 	}
 
-	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json", nil)
 	return &manifestStoreTestEnv{
 		manifestDigest: manifestDigest,
 		manifestSize:   manifestSize,
@@ -140,9 +138,10 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 			ctx:             ctx,
 			localManifests:  localManifests,
 			remoteManifests: truthManifests,
-			scheduler:       s,
-			repositoryName:  nameRef,
-			authChallenger:  &mockChallenger{},
+			// evictionController is nil here for now since importing any eviction controller introduces a cyclic dependency
+			evictionController: nil,
+			repositoryName:     nameRef,
+			authChallenger:     &mockChallenger{},
 		},
 	}
 }
@@ -270,10 +269,10 @@ func TestProxyManifests(t *testing.T) {
 	}
 }
 
-func TestProxyManifestsWithoutScheduler(t *testing.T) {
+func TestProxyManifestsWithoutEviction(t *testing.T) {
 	name := "foo/bar"
 	env := newManifestStoreTestEnv(t, name, "latest")
-	env.manifests.scheduler = nil
+	env.manifests.evictionController = nil
 
 	ctx := context.Background()
 	exists, err := env.manifests.Exists(ctx, env.manifestDigest)
@@ -284,7 +283,7 @@ func TestProxyManifestsWithoutScheduler(t *testing.T) {
 		t.Errorf("Unexpected non-existent manifest")
 	}
 
-	// Get - should succeed without scheduler
+	// Get - should succeed without eviction
 	_, err = env.manifests.Get(ctx, env.manifestDigest)
 	if err != nil {
 		t.Fatal(err)

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
+	_ "github.com/c2h5oh/datasize"
 )
 
 // InitFunc is the type of an EvictionController factory function and is used

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -18,21 +18,28 @@ import (
 	"github.com/distribution/distribution/v3/internal/client/auth/challenge"
 	"github.com/distribution/distribution/v3/internal/client/transport"
 	"github.com/distribution/distribution/v3/internal/dcontext"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 )
 
-var repositoryTTL = 24 * 7 * time.Hour
+// InitFunc is the type of an EvictionController factory function and is used
+// to register the constructor for different EvictionController backends.
+type InitFunc func(ctx context.Context, driver driver.StorageDriver, path string, options map[string]interface{}) (EvictionController, error)
+
+var evictionControllers map[string]InitFunc
+
+func init() {
+	evictionControllers = make(map[string]InitFunc)
+}
 
 // proxyingRegistry fetches content from a remote registry and caches it locally
 type proxyingRegistry struct {
-	embedded          distribution.Namespace // provides local registry functionality
-	scheduler         *scheduler.TTLExpirationScheduler
-	cacheWriteTimeout time.Duration
-	remoteURL         url.URL
-	authChallenger    authChallenger
-	basicAuth         auth.CredentialStore
+	embedded           distribution.Namespace // provides local registry functionality
+	evictionController EvictionController
+	cacheWriteTimeout  time.Duration
+	remoteURL          url.URL
+	authChallenger     authChallenger
+	basicAuth          auth.CredentialStore
 }
 
 // NewRegistryPullThroughCache creates a registry acting as a pull through cache
@@ -44,16 +51,30 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 
 	v := storage.NewVacuum(ctx, driver)
 
-	var s *scheduler.TTLExpirationScheduler
-	var ttl *time.Duration
-	if config.TTL == nil {
-		// Default TTL is 7 days
-		ttl = &repositoryTTL
-	} else if *config.TTL > 0 {
-		ttl = config.TTL
-	} else {
-		// TTL is disabled, never expire
-		ttl = nil
+	var evictionController EvictionController
+
+	// Legacy TTL configuration
+	if config.TTL != "" {
+		if config.EvictionPolicy != nil {
+			panic(fmt.Sprintf("unable to configure eviction, provided both eviction policy (%s) and ttl (%s)", config.EvictionPolicy.Type(), config.TTL))
+		}
+
+		config.EvictionPolicy = &configuration.EvictionPolicy{
+			"ttl": configuration.Parameters{
+				"ttl": config.TTL,
+			},
+		}
+	}
+
+	if config.EvictionPolicy != nil {
+		evictionPolicy := config.EvictionPolicy.Type()
+		if evictionPolicy != "" && !strings.EqualFold(evictionPolicy, "none") {
+			controller, err := getEvictionController(config.EvictionPolicy.Type(), ctx, driver, "/eviction-state.json", config.EvictionPolicy.Parameters())
+			if err != nil {
+				panic(fmt.Sprintf("unable to configure eviction (%s): %v", evictionPolicy, err))
+			}
+			evictionController = controller
+		}
 	}
 
 	// Set default cache write timeout if not specified
@@ -62,9 +83,8 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 		cacheWriteTimeout = *config.CacheWriteTimeout
 	}
 
-	if ttl != nil {
-		s = scheduler.New(ctx, driver, "/scheduler-state.json", ttl)
-		s.OnBlobExpire(func(ref reference.Reference) error {
+	if evictionController != nil {
+		evictionController.OnBlobEvict(func(ref reference.Reference) error {
 			var r reference.Canonical
 			var ok bool
 			if r, ok = ref.(reference.Canonical); !ok {
@@ -92,7 +112,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 			return nil
 		})
 
-		s.OnManifestExpire(func(ref reference.Reference) error {
+		evictionController.OnManifestEvict(func(ref reference.Reference) error {
 			var r reference.Canonical
 			var ok bool
 			if r, ok = ref.(reference.Canonical); !ok {
@@ -115,7 +135,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 			return nil
 		})
 
-		err = s.Start()
+		err = evictionController.Start()
 		if err != nil {
 			return nil, err
 		}
@@ -135,10 +155,10 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}
 
 	return &proxyingRegistry{
-		embedded:          registry,
-		scheduler:         s,
-		cacheWriteTimeout: cacheWriteTimeout,
-		remoteURL:         *remoteURL,
+		embedded:           registry,
+		evictionController: evictionController,
+		cacheWriteTimeout:  cacheWriteTimeout,
+		remoteURL:          *remoteURL,
 		authChallenger: &remoteAuthChallenger{
 			remoteURL: *remoteURL,
 			cm:        challenge.NewSimpleManager(),
@@ -197,20 +217,20 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 
 	return &proxiedRepository{
 		blobStore: &proxyBlobStore{
-			localStore:        localRepo.Blobs(ctx),
-			remoteStore:       remoteRepo.Blobs(ctx),
-			scheduler:         pr.scheduler,
-			cacheWriteTimeout: pr.cacheWriteTimeout,
-			repositoryName:    name,
-			authChallenger:    pr.authChallenger,
+			localStore:         localRepo.Blobs(ctx),
+			remoteStore:        remoteRepo.Blobs(ctx),
+			evictionController: pr.evictionController,
+			cacheWriteTimeout:  pr.cacheWriteTimeout,
+			repositoryName:     name,
+			authChallenger:     pr.authChallenger,
 		},
 		manifests: &proxyManifestStore{
-			repositoryName:  name,
-			localManifests:  localManifests, // Options?
-			remoteManifests: remoteManifests,
-			ctx:             ctx,
-			scheduler:       pr.scheduler,
-			authChallenger:  pr.authChallenger,
+			repositoryName:     name,
+			localManifests:     localManifests, // Options?
+			remoteManifests:    remoteManifests,
+			ctx:                ctx,
+			evictionController: pr.evictionController,
+			authChallenger:     pr.authChallenger,
 		},
 		name: name,
 		tags: &proxyTagService{
@@ -235,10 +255,10 @@ type Closer interface {
 }
 
 func (pr *proxyingRegistry) Close() error {
-	if pr.scheduler == nil {
+	if pr.evictionController == nil {
 		return nil
 	}
-	return pr.scheduler.Stop()
+	return pr.evictionController.Stop()
 }
 
 // authChallenger encapsulates a request to the upstream to establish credential challenges
@@ -314,4 +334,43 @@ func (pr *proxiedRepository) Named() reference.Named {
 
 func (pr *proxiedRepository) Tags(ctx context.Context) distribution.TagService {
 	return pr.tags
+}
+
+// OnEvictFunc is called when a cached entry is evicted
+type OnEvictFunc func(reference.Reference) error
+
+// EvictionController controls the eviction policy that the proxied registry follows.
+type EvictionController interface {
+	Start() error
+	Stop() error
+	// OnBlobEvict attaches the function f to run on a reference when a blob is evicted
+	OnBlobEvict(f OnEvictFunc)
+	// OnManifestEvict attaches the function f to run on a reference when a manifest is evicted
+	OnManifestEvict(f OnEvictFunc)
+	// AddBlob adds a blob to the eviction policy and errors when it is unable to
+	AddBlob(blobRef reference.Canonical) error
+	// AddManifest adds a blob to the eviction policy and errors when it is unable to
+	AddManifest(manifestRef reference.Canonical) error
+}
+
+// Register is used to register an InitFunc for
+// an EvictionController backend with the given name.
+func Register(name string, initFunc InitFunc) error {
+	if _, exists := evictionControllers[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	evictionControllers[name] = initFunc
+
+	return nil
+}
+
+// getEvictionController constructs an EvictionController
+// with the given options using the named backend.
+func getEvictionController(name string, ctx context.Context, driver driver.StorageDriver, path string, options map[string]interface{}) (EvictionController, error) {
+	if initFunc, exists := evictionControllers[name]; exists {
+		return initFunc(ctx, driver, path, options)
+	}
+
+	return nil, fmt.Errorf("no access controller registered with name: %s", name)
 }

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -29,7 +29,6 @@ var repositoryTTL = 24 * 7 * time.Hour
 type proxyingRegistry struct {
 	embedded          distribution.Namespace // provides local registry functionality
 	scheduler         *scheduler.TTLExpirationScheduler
-	ttl               *time.Duration
 	cacheWriteTimeout time.Duration
 	remoteURL         url.URL
 	authChallenger    authChallenger
@@ -64,7 +63,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}
 
 	if ttl != nil {
-		s = scheduler.New(ctx, driver, "/scheduler-state.json")
+		s = scheduler.New(ctx, driver, "/scheduler-state.json", ttl)
 		s.OnBlobExpire(func(ref reference.Reference) error {
 			var r reference.Canonical
 			var ok bool
@@ -138,7 +137,6 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	return &proxyingRegistry{
 		embedded:          registry,
 		scheduler:         s,
-		ttl:               ttl,
 		cacheWriteTimeout: cacheWriteTimeout,
 		remoteURL:         *remoteURL,
 		authChallenger: &remoteAuthChallenger{
@@ -202,7 +200,6 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			localStore:        localRepo.Blobs(ctx),
 			remoteStore:       remoteRepo.Blobs(ctx),
 			scheduler:         pr.scheduler,
-			ttl:               pr.ttl,
 			cacheWriteTimeout: pr.cacheWriteTimeout,
 			repositoryName:    name,
 			authChallenger:    pr.authChallenger,
@@ -213,7 +210,6 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			remoteManifests: remoteManifests,
 			ctx:             ctx,
 			scheduler:       pr.scheduler,
-			ttl:             pr.ttl,
 			authChallenger:  pr.authChallenger,
 		},
 		name: name,

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -20,7 +20,6 @@ import (
 	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
-	_ "github.com/c2h5oh/datasize"
 )
 
 // InitFunc is the type of an EvictionController factory function and is used
@@ -342,7 +341,9 @@ type OnEvictFunc func(reference.Reference) error
 
 // EvictionController controls the eviction policy that the proxied registry follows.
 type EvictionController interface {
+	// Start starts the EvictionController
 	Start() error
+	// Stop gracefully shuts down the EvictionController
 	Stop() error
 	// OnBlobEvict attaches the function f to run on a reference when a blob is evicted
 	OnBlobEvict(f OnEvictFunc)
@@ -352,6 +353,10 @@ type EvictionController interface {
 	AddBlob(blobRef reference.Canonical) error
 	// AddManifest adds a blob to the eviction policy and errors when it is unable to
 	AddManifest(manifestRef reference.Canonical) error
+	// TouchBlob notifies the EvictionController of a cache hit on the blob
+	TouchBlob(blobref reference.Canonical) error
+	// TouchManifest notifies the EvictionController of a cache hit on the manifest
+	TouchManifest(manifestRef reference.Canonical) error
 }
 
 // Register is used to register an InitFunc for

--- a/registry/proxy/proxyregistry_test.go
+++ b/registry/proxy/proxyregistry_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestProxyingRegistryCloseWithoutScheduler(t *testing.T) {
 	pr := &proxyingRegistry{
-		scheduler: nil,
+		evictionController: nil,
 	}
 
 	// verify that `Close()` does not panic when the scheduler is nil

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -130,6 +130,16 @@ func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical
 	return nil
 }
 
+func (ttles *TTLExpirationScheduler) TouchBlob(blobRef reference.Canonical) error {
+	// TTL doesn't care about a cache hit
+	return nil
+}
+
+func (ttles *TTLExpirationScheduler) TouchManifest(blobRef reference.Canonical) error {
+	// TTL doesn't care about a cache hit
+	return nil
+}
+
 // Start starts the scheduler
 func (ttles *TTLExpirationScheduler) Start() error {
 	ttles.Lock()

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -32,11 +32,12 @@ type schedulerEntry struct {
 }
 
 // New returns a new instance of the scheduler
-func New(ctx context.Context, driver driver.StorageDriver, path string) *TTLExpirationScheduler {
+func New(ctx context.Context, driver driver.StorageDriver, path string, ttl *time.Duration) *TTLExpirationScheduler {
 	return &TTLExpirationScheduler{
 		entries:         make(map[string]*schedulerEntry),
 		driver:          driver,
 		pathToStateFile: path,
+		ttl:             ttl,
 		ctx:             ctx,
 		stopped:         true,
 		doneChan:        make(chan struct{}),
@@ -54,6 +55,7 @@ type TTLExpirationScheduler struct {
 	driver          driver.StorageDriver
 	ctx             context.Context
 	pathToStateFile string
+	ttl             *time.Duration
 
 	stopped bool
 
@@ -82,7 +84,10 @@ func (ttles *TTLExpirationScheduler) OnManifestExpire(f expiryFunc) {
 }
 
 // AddBlob schedules a blob cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddBlob(blobRef reference.Canonical, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddBlob(blobRef reference.Canonical) error {
+	if ttles.ttl == nil {
+		return nil
+	}
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -90,12 +95,15 @@ func (ttles *TTLExpirationScheduler) AddBlob(blobRef reference.Canonical, ttl ti
 		return fmt.Errorf("scheduler not started")
 	}
 
-	ttles.add(blobRef, ttl, entryTypeBlob)
+	ttles.add(blobRef, *ttles.ttl, entryTypeBlob)
 	return nil
 }
 
 // AddManifest schedules a manifest cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical) error {
+	if ttles.ttl == nil {
+		return nil
+	}
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -103,7 +111,7 @@ func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical
 		return fmt.Errorf("scheduler not started")
 	}
 
-	ttles.add(manifestRef, ttl, entryTypeManifest)
+	ttles.add(manifestRef, *ttles.ttl, entryTypeManifest)
 	return nil
 }
 

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -63,7 +63,7 @@ func TestSchedule(t *testing.T) {
 	}
 
 	var mu sync.Mutex
-	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	s := New(dcontext.Background(), inmemory.New(), "/ttl", nil)
 	deleteFunc := func(repoName reference.Reference) error {
 		if len(remainingRepos) == 0 {
 			t.Fatal("Incorrect expiry count")
@@ -148,7 +148,7 @@ func TestRestoreOld(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to write serialized data to fs")
 	}
-	s := New(dcontext.Background(), fs, "/ttl")
+	s := New(dcontext.Background(), fs, "/ttl", nil)
 	s.OnBlobExpire(deleteFunc)
 	err = s.Start()
 	if err != nil {
@@ -188,7 +188,7 @@ func TestStopRestore(t *testing.T) {
 
 	fs := inmemory.New()
 	pathToStateFile := "/ttl"
-	s := New(dcontext.Background(), fs, pathToStateFile)
+	s := New(dcontext.Background(), fs, pathToStateFile, nil)
 	s.onBlobExpire = deleteFunc
 
 	err := s.Start()
@@ -207,7 +207,7 @@ func TestStopRestore(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// v2 will restore state from fs
-	s2 := New(dcontext.Background(), fs, pathToStateFile)
+	s2 := New(dcontext.Background(), fs, pathToStateFile, nil)
 	s2.onBlobExpire = deleteFunc
 	err = s2.Start()
 	if err != nil {
@@ -223,7 +223,7 @@ func TestStopRestore(t *testing.T) {
 }
 
 func TestDoubleStart(t *testing.T) {
-	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	s := New(dcontext.Background(), inmemory.New(), "/ttl", nil)
 	err := s.Start()
 	if err != nil {
 		t.Fatal("Unable to start scheduler")

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/distribution/reference"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 )
 
@@ -53,6 +54,25 @@ func testRefsN(t *testing.T, n int) []reference.Canonical {
 	return refs
 }
 
+func testScheduler(t *testing.T, driver driver.StorageDriver, path string, options map[string]interface{}) *TTLExpirationScheduler {
+	ec, err := new(dcontext.Background(), driver, path, options)
+	if err != nil {
+		t.Fatalf("Could not create a valid EvictionController, %v", err)
+	}
+	s, ok := ec.(*TTLExpirationScheduler)
+	if !ok {
+		t.Fatalf("Could not create a valid TTLExpirationScheduler")
+	}
+	return s
+}
+
+func TestNewScheduler(t *testing.T) {
+	options := map[string]interface{}{
+		"ttl": "168h",
+	}
+	testScheduler(t, inmemory.New(), "/ttl", options)
+}
+
 func TestSchedule(t *testing.T) {
 	refs := testRefsN(t, 20)
 	timeUnit := time.Millisecond
@@ -63,7 +83,7 @@ func TestSchedule(t *testing.T) {
 	}
 
 	var mu sync.Mutex
-	s := New(dcontext.Background(), inmemory.New(), "/ttl", nil)
+	s := testScheduler(t, inmemory.New(), "/ttl", map[string]interface{}{"ttl": "1ms"})
 	deleteFunc := func(repoName reference.Reference) error {
 		if len(remainingRepos) == 0 {
 			t.Fatal("Incorrect expiry count")
@@ -85,8 +105,8 @@ func TestSchedule(t *testing.T) {
 		t.Fatalf("Error starting ttlExpirationScheduler: %s", err)
 	}
 
-	for i, ref := range refs {
-		_ = s.AddBlob(ref, time.Duration(i)*timeUnit)
+	for _, ref := range refs {
+		_ = s.AddBlob(ref)
 	}
 
 	// Ensure all repos are deleted
@@ -148,8 +168,8 @@ func TestRestoreOld(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to write serialized data to fs")
 	}
-	s := New(dcontext.Background(), fs, "/ttl", nil)
-	s.OnBlobExpire(deleteFunc)
+	s := testScheduler(t, fs, "/ttl", map[string]interface{}{"ttl": "1ms"})
+	s.OnBlobEvict(deleteFunc)
 	err = s.Start()
 	if err != nil {
 		t.Fatalf("Error starting ttlExpirationScheduler: %s", err)
@@ -188,7 +208,7 @@ func TestStopRestore(t *testing.T) {
 
 	fs := inmemory.New()
 	pathToStateFile := "/ttl"
-	s := New(dcontext.Background(), fs, pathToStateFile, nil)
+	s := testScheduler(t, fs, pathToStateFile, map[string]interface{}{"ttl": "1ms"})
 	s.onBlobExpire = deleteFunc
 
 	err := s.Start()
@@ -207,7 +227,7 @@ func TestStopRestore(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// v2 will restore state from fs
-	s2 := New(dcontext.Background(), fs, pathToStateFile, nil)
+	s2 := testScheduler(t, fs, pathToStateFile, map[string]interface{}{"ttl": "1ms"})
 	s2.onBlobExpire = deleteFunc
 	err = s2.Start()
 	if err != nil {
@@ -223,7 +243,7 @@ func TestStopRestore(t *testing.T) {
 }
 
 func TestDoubleStart(t *testing.T) {
-	s := New(dcontext.Background(), inmemory.New(), "/ttl", nil)
+	s := testScheduler(t, inmemory.New(), "/ttl", map[string]interface{}{"ttl": "1ms"})
 	err := s.Start()
 	if err != nil {
 		t.Fatal("Unable to start scheduler")

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -442,6 +442,11 @@ func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, 
 	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
+// Usage gives the total combined size of all files under the given path.
+func (d *driver) Usage(ctx context.Context, path string) (uint64, error) {
+	return 0, storagedriver.ErrUnsupportedMethod{}
+}
+
 // directDescendants will find direct descendants (blobs or virtual containers)
 // of from list of blob paths and will return their full paths. Elements in blobs
 // list must be prefixed with a "/" and

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/uuid"
@@ -332,6 +335,29 @@ func (d *driver) RedirectURL(*http.Request, string) (string, error) {
 // from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, options ...func(*storagedriver.WalkOptions)) error {
 	return storagedriver.WalkFallback(ctx, d, path, f, options...)
+}
+
+// Usage gives the total combined size of all files under the given path.
+func (d *driver) Usage(ctx context.Context, path string) (uint64, error) {
+	fullPath := d.fullPath(path)
+
+	du := exec.Command("du", "-sB1", fullPath)
+	duOut, err := du.Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to run du for disk usage: %v", err)
+	}
+
+	duStr := string(duOut)
+	sizeStr := strings.SplitN(duStr, "\t", 2)
+	if len(sizeStr) != 2 {
+		return 0, fmt.Errorf("got unexpected output while running du for disk usage: %s", duStr)
+	}
+
+	size, err := strconv.ParseUint(sizeStr[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse result from du for disk usage: %v", err)
+	}
+	return size, nil
 }
 
 // fullPath returns the absolute path of a key within the Driver's storage.

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -814,6 +814,11 @@ func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, 
 	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
+// Usage gives the total combined size of all files under the given path.
+func (d *driver) Usage(ctx context.Context, path string) (uint64, error) {
+	return 0, storagedriver.ErrUnsupportedMethod{}
+}
+
 func (w *writer) newSession() (uri string, err error) {
 	u := &url.URL{
 		Scheme:   "https",

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -250,6 +250,22 @@ func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn, 
 	return storagedriver.WalkFallback(ctx, d, path, f, options...)
 }
 
+// Usage gives the total combined size of all files under the given path.
+func (d *driver) Usage(ctx context.Context, path string) (uint64, error) {
+	usage := uint64(0)
+	err := d.Walk(ctx, path, func(fileInfo storagedriver.FileInfo) error {
+		if fileInfo.Size() < 0 {
+			return fmt.Errorf("expected non-negative file size for %s, got: %d", fileInfo.Path(), fileInfo.Size())
+		}
+		usage += uint64(fileInfo.Size())
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return usage, nil
+}
+
 type writer struct {
 	d         *driver
 	f         *file

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1060,6 +1060,11 @@ func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn, 
 	return nil
 }
 
+// Usage gives the total combined size of all files under the given path.
+func (d *driver) Usage(ctx context.Context, path string) (uint64, error) {
+	return 0, storagedriver.ErrUnsupportedMethod{}
+}
+
 func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, from, startAfter string, f storagedriver.WalkFn) error {
 	var (
 		retError error

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -110,6 +110,9 @@ type StorageDriver interface {
 	// will continue the traversal.
 	// If the returned error from the WalkFn is ErrFilledBuffer, processing stops.
 	Walk(ctx context.Context, path string, f WalkFn, options ...func(*WalkOptions)) error
+
+	// Usage gives the total combined size of all files under the given path.
+	Usage(ctx context.Context, path string) (uint64, error)
 }
 
 // FileWriter provides an abstraction for an opened writable file-like object in

--- a/vendor/github.com/c2h5oh/datasize/.gitignore
+++ b/vendor/github.com/c2h5oh/datasize/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/c2h5oh/datasize/.travis.yml
+++ b/vendor/github.com/c2h5oh/datasize/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+
+language: go
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
+  - tip
+
+script:
+  - go test -v

--- a/vendor/github.com/c2h5oh/datasize/LICENSE
+++ b/vendor/github.com/c2h5oh/datasize/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Maciej Lisiewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/c2h5oh/datasize/README.md
+++ b/vendor/github.com/c2h5oh/datasize/README.md
@@ -1,0 +1,77 @@
+# datasize [![Build Status](https://travis-ci.org/c2h5oh/datasize.svg?branch=master)](https://travis-ci.org/c2h5oh/datasize)
+
+Golang helpers for data sizes
+
+### Constants
+
+Just like `time` package provides `time.Second`, `time.Day` constants `datasize` provides:
+
+* `datasize.B` 1 byte
+* `datasize.KB` 1 kilobyte
+* `datasize.MB` 1 megabyte
+* `datasize.GB` 1 gigabyte
+* `datasize.TB` 1 terabyte
+* `datasize.PB` 1 petabyte
+* `datasize.EB` 1 exabyte
+
+### Helpers
+
+Just like `time` package provides `duration.Nanoseconds() uint64 `, `duration.Hours() float64` helpers `datasize` has.
+
+* `ByteSize.Bytes() uint64`
+* `ByteSize.Kilobytes() float64`
+* `ByteSize.Megabytes() float64`
+* `ByteSize.Gigabytes() float64`
+* `ByteSize.Terabytes() float64`
+* `ByteSize.Petabytes() float64`
+* `ByteSize.Exabytes() float64`
+
+Warning: see limitations at the end of this document about a possible precision loss
+
+### Parsing strings
+
+`datasize.ByteSize` implements `TextUnmarshaler` interface and will automatically parse human readable strings into correct values where it is used:
+
+* `"10 MB"` -> `10* datasize.MB`
+* `"10240 g"` -> `10 * datasize.TB`
+* `"2000"` -> `2000 * datasize.B`
+* `"1tB"` -> `datasize.TB`
+* `"5 peta"` -> `5 * datasize.PB`
+* `"28 kilobytes"` -> `28 * datasize.KB`
+* `"1 gigabyte"` -> `1 * datasize.GB`
+
+You can also do it manually:
+
+```go
+var v datasize.ByteSize
+err := v.UnmarshalText([]byte("100 mb"))
+```
+
+### Printing
+
+`Bytesize.String()` uses largest unit allowing an integer value:
+
+* `(102400 * datasize.MB).String()` -> `"100GB"`
+* `(datasize.MB + datasize.KB).String()` -> `"1025KB"`
+
+Use `%d` format string to get value in bytes without a unit.
+
+### JSON and other encoding
+
+Both `TextMarshaler` and `TextUnmarshaler` interfaces are implemented - JSON will just work. Other encoders will work provided they use those interfaces.
+
+### Human readable
+
+`ByteSize.HumanReadable()` or `ByteSize.HR()` returns a string with 1-3 digits, followed by 1 decimal place, a space and unit big enough to get 1-3 digits
+
+* `(102400 * datasize.MB).String()` -> `"100.0 GB"`
+* `(datasize.MB + 512 * datasize.KB).String()` -> `"1.5 MB"`
+
+### Limitations
+
+* The underlying data type for `data.ByteSize` is `uint64`, so values outside of 0 to 2^64-1 range will overflow
+* size helper functions (like `ByteSize.Kilobytes()`) return `float64`, which can't represent all possible values of `uint64` accurately:
+  * if the returned value is supposed to have no fraction (ie `(10 * datasize.MB).Kilobytes()`) accuracy loss happens when value is more than 2^53 larger than unit: `.Kilobytes()` over 8 petabytes, `.Megabytes()` over 8 exabytes
+  * if the returned value is supposed to have a fraction (ie `(datasize.PB + datasize.B).Megabytes()`) in addition to the above note accuracy loss may occur in fractional part too - larger integer part leaves fewer bytes to store fractional part, the smaller the remainder vs unit the move bytes are required to store the fractional part
+* Parsing a string with `Mb`, `Tb`, etc units will return a syntax error, because capital followed by lower case is commonly used for bits, not bytes
+* Parsing a string with value exceeding 2^64-1 bytes will return 2^64-1 and an out of range error

--- a/vendor/github.com/c2h5oh/datasize/datasize.go
+++ b/vendor/github.com/c2h5oh/datasize/datasize.go
@@ -1,0 +1,239 @@
+package datasize
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ByteSize uint64
+
+const (
+	B  ByteSize = 1
+	KB          = B << 10
+	MB          = KB << 10
+	GB          = MB << 10
+	TB          = GB << 10
+	PB          = TB << 10
+	EB          = PB << 10
+
+	fnUnmarshalText string = "UnmarshalText"
+	maxUint64       uint64 = (1 << 64) - 1
+	cutoff          uint64 = maxUint64 / 10
+)
+
+var ErrBits = errors.New("unit with capital unit prefix and lower case unit (b) - bits, not bytes ")
+
+func (b ByteSize) Bytes() uint64 {
+	return uint64(b)
+}
+
+func (b ByteSize) KBytes() float64 {
+	v := b / KB
+	r := b % KB
+	return float64(v) + float64(r)/float64(KB)
+}
+
+func (b ByteSize) MBytes() float64 {
+	v := b / MB
+	r := b % MB
+	return float64(v) + float64(r)/float64(MB)
+}
+
+func (b ByteSize) GBytes() float64 {
+	v := b / GB
+	r := b % GB
+	return float64(v) + float64(r)/float64(GB)
+}
+
+func (b ByteSize) TBytes() float64 {
+	v := b / TB
+	r := b % TB
+	return float64(v) + float64(r)/float64(TB)
+}
+
+func (b ByteSize) PBytes() float64 {
+	v := b / PB
+	r := b % PB
+	return float64(v) + float64(r)/float64(PB)
+}
+
+func (b ByteSize) EBytes() float64 {
+	v := b / EB
+	r := b % EB
+	return float64(v) + float64(r)/float64(EB)
+}
+
+func (b ByteSize) String() string {
+	switch {
+	case b == 0:
+		return fmt.Sprint("0B")
+	case b%EB == 0:
+		return fmt.Sprintf("%dEB", b/EB)
+	case b%PB == 0:
+		return fmt.Sprintf("%dPB", b/PB)
+	case b%TB == 0:
+		return fmt.Sprintf("%dTB", b/TB)
+	case b%GB == 0:
+		return fmt.Sprintf("%dGB", b/GB)
+	case b%MB == 0:
+		return fmt.Sprintf("%dMB", b/MB)
+	case b%KB == 0:
+		return fmt.Sprintf("%dKB", b/KB)
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+func (b ByteSize) HR() string {
+	return b.HumanReadable()
+}
+
+func (b ByteSize) HumanReadable() string {
+	switch {
+	case b > EB:
+		return fmt.Sprintf("%.1f EB", b.EBytes())
+	case b > PB:
+		return fmt.Sprintf("%.1f PB", b.PBytes())
+	case b > TB:
+		return fmt.Sprintf("%.1f TB", b.TBytes())
+	case b > GB:
+		return fmt.Sprintf("%.1f GB", b.GBytes())
+	case b > MB:
+		return fmt.Sprintf("%.1f MB", b.MBytes())
+	case b > KB:
+		return fmt.Sprintf("%.1f KB", b.KBytes())
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+func (b ByteSize) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+func (b *ByteSize) UnmarshalText(t []byte) error {
+	var val uint64
+	var unit string
+
+	// copy for error message
+	t0 := t
+
+	var c byte
+	var i int
+
+ParseLoop:
+	for i < len(t) {
+		c = t[i]
+		switch {
+		case '0' <= c && c <= '9':
+			if val > cutoff {
+				goto Overflow
+			}
+
+			c = c - '0'
+			val *= 10
+
+			if val > val+uint64(c) {
+				// val+v overflows
+				goto Overflow
+			}
+			val += uint64(c)
+			i++
+
+		default:
+			if i == 0 {
+				goto SyntaxError
+			}
+			break ParseLoop
+		}
+	}
+
+	unit = strings.TrimSpace(string(t[i:]))
+	switch unit {
+	case "Kb", "Mb", "Gb", "Tb", "Pb", "Eb":
+		goto BitsError
+	}
+	unit = strings.ToLower(unit)
+	switch unit {
+	case "", "b", "byte":
+		// do nothing - already in bytes
+
+	case "k", "kb", "kilo", "kilobyte", "kilobytes":
+		if val > maxUint64/uint64(KB) {
+			goto Overflow
+		}
+		val *= uint64(KB)
+
+	case "m", "mb", "mega", "megabyte", "megabytes":
+		if val > maxUint64/uint64(MB) {
+			goto Overflow
+		}
+		val *= uint64(MB)
+
+	case "g", "gb", "giga", "gigabyte", "gigabytes":
+		if val > maxUint64/uint64(GB) {
+			goto Overflow
+		}
+		val *= uint64(GB)
+
+	case "t", "tb", "tera", "terabyte", "terabytes":
+		if val > maxUint64/uint64(TB) {
+			goto Overflow
+		}
+		val *= uint64(TB)
+
+	case "p", "pb", "peta", "petabyte", "petabytes":
+		if val > maxUint64/uint64(PB) {
+			goto Overflow
+		}
+		val *= uint64(PB)
+
+	case "E", "EB", "e", "eb", "eB":
+		if val > maxUint64/uint64(EB) {
+			goto Overflow
+		}
+		val *= uint64(EB)
+
+	default:
+		goto SyntaxError
+	}
+
+	*b = ByteSize(val)
+	return nil
+
+Overflow:
+	*b = ByteSize(maxUint64)
+	return &strconv.NumError{fnUnmarshalText, string(t0), strconv.ErrRange}
+
+SyntaxError:
+	*b = 0
+	return &strconv.NumError{fnUnmarshalText, string(t0), strconv.ErrSyntax}
+
+BitsError:
+	*b = 0
+	return &strconv.NumError{fnUnmarshalText, string(t0), ErrBits}
+}
+
+func Parse(t []byte) (ByteSize, error) {
+	var v ByteSize
+	err := v.UnmarshalText(t)
+	return v, err
+}
+
+func MustParse(t []byte) ByteSize {
+	v, err := Parse(t)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func ParseString(s string) (ByteSize, error) {
+	return Parse([]byte(s))
+}
+
+func MustParseString(s string) ByteSize {
+	return MustParse([]byte(s))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -202,6 +202,9 @@ github.com/beorn7/perks/quantile
 # github.com/bshuster-repo/logrus-logstash-hook v1.1.0
 ## explicit; go 1.16
 github.com/bshuster-repo/logrus-logstash-hook
+# github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
+## explicit
+github.com/c2h5oh/datasize
 # github.com/cenkalti/backoff/v5 v5.0.3
 ## explicit; go 1.23
 github.com/cenkalti/backoff/v5


### PR DESCRIPTION
## Description
This pr implements an LRU eviction policy for the pull through cache. 

## Motivation
As per discussion in #1140, because the TTL scheduler is not aware of the storage usage of the proxy (among other problems), it would be nice to have something like a least-recently-used heuristic for eviction.

## Changes
The commits are made to be isolated for ease of review.

A list of rough changes:
- moves the ttl variable into the TLLScheduler
- make an interface for all eviction policies and make tll implement that instead
- make configuration for eviction policies possible for different policies and still support the old ttl configuration
- add a usage call to find total storage usage at any path
  - `du` is used here because there's no good package that does this (everything uses `statfs` which is not right). This is fine for now since only linux is supported anyways and this works in the environment from Dockerfile.
- add the actual LRU eviction policy, which is done via a hash map and doubly linked list