### PR TITLE
Switch UUIDs to UUIDv7

### DIFF
--- a/internal/client/repository_test.go
+++ b/internal/client/repository_test.go
@@ -18,11 +18,11 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	"github.com/distribution/distribution/v3/testutil"
 	"github.com/distribution/reference"
-	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"

--- a/internal/dcontext/context.go
+++ b/internal/dcontext/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/uuid"
+	"github.com/distribution/distribution/v3/internal/uuid"
 )
 
 // instanceContext is a context that provides only an instance id. It is

--- a/internal/dcontext/http.go
+++ b/internal/dcontext/http.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/requestutil"
-	"github.com/google/uuid"
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/gorilla/mux"
 )
 

--- a/internal/dcontext/trace.go
+++ b/internal/dcontext/trace.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/distribution/distribution/v3/internal/uuid"
 )
 
 // WithTrace allocates a traced timing span in a new context. This allows a

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,11 @@
+package uuid
+
+import (
+	"github.com/google/uuid"
+)
+
+// Returns a new V7 UUID string. V7 UUIDs are time-ordered for better database performance.
+// Panics on error to maintain compatibility with google/uuid's NewString() method.
+func NewString() string {
+	return uuid.Must(uuid.NewV7()).String()
+}

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/internal/requestutil"
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/distribution/reference"
 	events "github.com/docker/go-events"
-	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	v2 "github.com/distribution/distribution/v3/registry/api/v2"
 	"github.com/distribution/reference"
 	events "github.com/docker/go-events"
-	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -12,10 +12,10 @@ import (
 	"path"
 	"time"
 
+	"github.com/distribution/distribution/v3/internal/uuid"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/base"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
-	"github.com/google/uuid"
 )
 
 const (

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/reference"
-	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/distribution/distribution/v3/internal/uuid"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
-	"github.com/google/uuid"
 )
 
 func testUploadFS(t *testing.T, numUploads int, repoName string, startedAt time.Time) (driver.StorageDriver, context.Context) {


### PR DESCRIPTION
This PR switches UUIDs to UUIDv7. UUIDv7s are time ordered which makes them more efficient to store and query.
 Here are some UUIDv4 vs UUIDv7 benchmarks with Postgres:

- https://ardentperf.com/2024/02/03/uuid-benchmark-war/
- https://dev.to/umangsinha12/postgresql-uuid-performance-benchmarking-random-v4-and-time-based-v7-uuids-n9b

There's no downside to switching - these are still valid UUIDs so the change is fully backwards compatible. Being able to store things like events with UUIDv7 IDs will be beneficial to everyone.

Also, this makes it easier to change the UUID version in the future.

Closes: https://github.com/distribution/distribution/issues/4665