### PR TITLE
fix: set OTEL traces to disabled by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apk add --no-cache ca-certificates
 COPY cmd/registry/config-dev.yml /etc/distribution/config.yml
 COPY --from=binary /registry /bin/registry
 VOLUME ["/var/lib/registry"]
+ENV OTEL_TRACES_EXPORTER=none
 EXPOSE 5000
 ENTRYPOINT ["registry"]
 CMD ["serve", "/etc/distribution/config.yml"]


### PR DESCRIPTION
This updates the default container invocation to avoid spamming the system logs with failure to send trace data.

I think this resolves https://github.com/distribution/distribution/issues/4270 while leaving it easy for folks using this to setup their collectors.