### PR TITLE
Fixes #4683 - uses X/Y instead of Gx/Gy for thumbprint of ecdsa keys

### DIFF
--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -84,10 +84,9 @@ func getJWKThumbprint(publickey crypto.PublicKey, skipED25519 bool) string {
 
 		return hashAndEncode(fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, e, n))
 	case *ecdsa.PublicKey:
-		params := pubkey.Params()
-		crv := params.Name
-		x := base64.RawURLEncoding.EncodeToString(params.Gx.Bytes())
-		y := base64.RawURLEncoding.EncodeToString(params.Gy.Bytes())
+		crv := pubkey.Params().Name
+		x := base64.RawURLEncoding.EncodeToString(pubkey.X.Bytes())
+		y := base64.RawURLEncoding.EncodeToString(pubkey.Y.Bytes())
 
 		return hashAndEncode(fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`, crv, x, y))
 	case ed25519.PublicKey:


### PR DESCRIPTION
Simply fixes  registry/auth/token/util handling of ecdsa key prints