### PR TITLE
Fix broken link to Docker Hub fair use policy

### DIFF
--- a/docs/content/recipes/mirror.md
+++ b/docs/content/recipes/mirror.md
@@ -38,7 +38,7 @@ The following table shows examples of allowed and disallowed mirror URLs.
 
 > **Note**
 >
-> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates).
+> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://docs.docker.com/docker-hub/usage/).
 
 ### Solution
 


### PR DESCRIPTION
The link to https://www.docker.com/pricing/resource-consumption-updates ([archived copy](https://web.archive.org/web/20220901000000*/https://www.docker.com/pricing/resource-consumption-updates)) no longer works, so I changed it to go to https://docs.docker.com/docker-hub/usage/ instead.