### PR TITLE
client: add Accept headers to Exists() HEAD

### DIFF
--- a/internal/client/repository.go
+++ b/internal/client/repository.go
@@ -399,6 +399,12 @@ func (ms *manifests) Exists(ctx context.Context, dgst digest.Digest) (bool, erro
 	if err != nil {
 		return false, err
 	}
+
+	mediaTypes := distribution.ManifestMediaTypes()
+	for _, t := range mediaTypes {
+		req.Header.Add("Accept", t)
+	}
+
 	resp, err := ms.client.Do(req)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# client: add Accept headers to Exists() HEAD

Adds Accept headers (from `distribution.ManifestMediaTypes()`) to the
`HEAD` request in `(*manifests).Exists`, aligning it with `Get()` and
fixing failures on registries that require explicit OCI media types.

Real-world example:
```bash
curl -sv -X HEAD \
  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
  'https://<registry>/v2/<repo>/manifests/sha256:<digest>'
# HTTP/1.1 200 OK
# Content-Type: application/vnd.oci.image.manifest.v1+json
# Docker-Content-Digest: sha256:<digest>
```
Without Accept, some registries return 404/406 even when the manifest
exists.
 
Tests:
- Regression: Exists() true with Accept present; false when Accept is
  stripped (negative path).
- Existing tests unchanged.

Risk/compatibility:
- Low. Registries that ignore Accept on HEAD continue to work.
- Redirect handling unchanged; `CheckRedirect` preserves Accept.
