### PR TITLE
chore: labeler: add area/client mapping for internal/client/**

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -53,6 +53,10 @@ area/storage/s3:
   - changed-files:
     - any-glob-to-any-file:
       - registry/storage/driver/s3-aws/**
+area/client:
+  - changed-files:
+    - any-glob-to-any-file:
+      - internal/client/**
 dependencies:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
I opened another PR https://github.com/distribution/distribution/pull/4715 recently, and it didn't get automatically labeled with `area/client`. 

In the past, I noticed that the label was [hand-added](https://github.com/distribution/distribution/pull/3849). This PR automates that in the labeler. 