### PR TITLE
chore: clean code in s3 storage Write to prepare multiple goroutines uploading

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -746,6 +746,19 @@ func (d *driver) Writer(ctx context.Context, path string, appendMode bool) (stor
 				}
 				allParts = append(allParts, partsList.Parts...)
 			}
+			// If the last written part is smaller than minChunkSize, we need to make a
+			// new multipart upload :sadface:
+			if len(allParts) > 0 && int(*allParts[len(allParts)-1].Size) < minChunkSize {
+				newUploadID, parts, buf, err := d.reassemblyMultipart(ctx, key, *multi.UploadId, allParts)
+				if err != nil {
+					return nil, storagedriver.Error{
+						DriverName: driverName,
+						Detail:     fmt.Errorf("append to discrete partitions unsupported, path %s, upload id %s", path, *multi.UploadId),
+					}
+				}
+				return d.newWriterWithBuffer(ctx, key, newUploadID, parts, buf), nil
+			}
+
 			return d.newWriter(ctx, key, *multi.UploadId, allParts), nil
 		}
 
@@ -759,6 +772,94 @@ func (d *driver) Writer(ctx context.Context, path string, appendMode bool) (stor
 		}
 	}
 	return nil, storagedriver.PathNotFoundError{Path: path}
+}
+
+func (d *driver) reassemblyMultipart(ctx context.Context, key string, uploadId string, parts []*s3.Part) (string, []*s3.Part, *bytes.Buffer, error) {
+	completedUploadedParts := make(completedParts, len(parts))
+	for i, part := range parts {
+		completedUploadedParts[i] = &s3.CompletedPart{
+			ETag:       part.ETag,
+			PartNumber: part.PartNumber,
+		}
+	}
+
+	sort.Sort(completedUploadedParts)
+
+	_, err := d.S3.CompleteMultipartUploadWithContext(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(d.Bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadId),
+		MultipartUpload: &s3.CompletedMultipartUpload{
+			Parts: completedUploadedParts,
+		},
+	})
+
+	if err != nil {
+		if _, aErr := d.S3.AbortMultipartUploadWithContext(ctx, &s3.AbortMultipartUploadInput{
+			Bucket:   aws.String(d.Bucket),
+			Key:      aws.String(key),
+			UploadId: aws.String(uploadId),
+		}); aErr != nil {
+			return "", nil, nil, errors.Join(err, aErr)
+		}
+		return "", nil, nil, err
+	}
+
+	resp, err := d.S3.CreateMultipartUploadWithContext(ctx, &s3.CreateMultipartUploadInput{
+		Bucket:               aws.String(d.Bucket),
+		Key:                  aws.String(key),
+		ContentType:          d.getContentType(),
+		ACL:                  d.getACL(),
+		ServerSideEncryption: d.getEncryptionMode(),
+		StorageClass:         d.getStorageClass(),
+	})
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	newUploadID := *resp.UploadId
+
+	var size int64
+	for _, part := range parts {
+		size += *part.Size
+	}
+
+	// If the entire written file is smaller than minChunkSize, we need to make
+	// a new part from scratch :double sad face:
+	if size < minChunkSize {
+		resp, err := d.S3.GetObjectWithContext(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(d.Bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			return "", nil, nil, err
+		}
+		defer resp.Body.Close()
+
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, resp.Body); err != nil {
+			return "", nil, nil, err
+		}
+		return newUploadID, []*s3.Part{}, buf, nil
+	} else {
+		// Otherwise we can use the old file as the new first part
+		copyPartResp, err := d.S3.UploadPartCopyWithContext(ctx, &s3.UploadPartCopyInput{
+			Bucket:     aws.String(d.Bucket),
+			CopySource: aws.String(d.Bucket + "/" + key),
+			Key:        aws.String(key),
+			PartNumber: aws.Int64(1),
+			UploadId:   resp.UploadId,
+		})
+		if err != nil {
+			return "", nil, nil, err
+		}
+		parts := []*s3.Part{{
+			ETag:       copyPartResp.CopyPartResult.ETag,
+			PartNumber: aws.Int64(1),
+			Size:       aws.Int64(size),
+		}}
+		return newUploadID, parts, nil, nil
+	}
 }
 
 func (d *driver) statHead(ctx context.Context, path string) (*storagedriver.FileInfoFields, error) {
@@ -1336,10 +1437,21 @@ type writer struct {
 }
 
 func (d *driver) newWriter(ctx context.Context, key, uploadID string, parts []*s3.Part) storagedriver.FileWriter {
+	buf := d.pool.Get().(*bytes.Buffer)
+	return d.newWriterWithBuffer(ctx, key, uploadID, parts, buf)
+}
+
+func (d *driver) newWriterWithBuffer(ctx context.Context, key, uploadID string, parts []*s3.Part, buf *bytes.Buffer) storagedriver.FileWriter {
 	var size int64
 	for _, part := range parts {
 		size += *part.Size
 	}
+
+	if buf == nil {
+		buf = d.pool.Get().(*bytes.Buffer)
+	}
+
+	size += int64(buf.Len())
 	return &writer{
 		ctx:      ctx,
 		driver:   d,
@@ -1347,7 +1459,7 @@ func (d *driver) newWriter(ctx context.Context, key, uploadID string, parts []*s
 		uploadID: uploadID,
 		parts:    parts,
 		size:     size,
-		buf:      d.pool.Get().(*bytes.Buffer),
+		buf:      buf,
 	}
 }
 
@@ -1363,6 +1475,7 @@ func (w *writer) Write(p []byte) (int, error) {
 	}
 
 	n, _ := w.buf.Write(p)
+	w.size += int64(n)
 
 	for w.buf.Len() >= w.driver.ChunkSize {
 		if err := w.flush(); err != nil {
@@ -1508,8 +1621,6 @@ func (w *writer) flush() error {
 		PartNumber: partNumber,
 		Size:       aws.Int64(int64(partSize)),
 	})
-
-	w.size += int64(partSize)
 
 	return nil
 }


### PR DESCRIPTION
In early commit: https://github.com/distribution/distribution/commit/5ee5aaa058c53bf881327164c323eadca85d0766

```
	for w.buf.Len() >= w.driver.ChunkSize {
		if err := w.flush(); err != nil {
			return 0, fmt.Errorf("flush: %w", err)
		}
	}
```

We use a consistent multipart chunk size for s3 storage driver, all uploaded part size except last part is always bigger than minChunkSize.

So the following code is only working for append case:

```
func (w *writer) Write(p []byte) (int, error) {
	...

	// If the last written part is smaller than minChunkSize, we need to make a
	// new multipart upload :sadface:
	if len(w.parts) > 0 && int(*w.parts[len(w.parts)-1].Size) < minChunkSize {
		...
	}
```
Refer: https://github.com/distribution/distribution/blob/v3.0.0/registry/storage/driver/s3-aws/s3.go#L1356

After moving this corner case code from `writer.Write` to `driver.Writer` function, we can optimize s3 blob uploading in background with multiple goroutines.