### PR TITLE
fix(registry): Correct log formatting for upstream challenge

### DIFF
--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -274,8 +274,8 @@ func (r *remoteAuthChallenger) tryEstablishChallenges(ctx context.Context) error
 	if err := ping(r.cm, remoteURL.String(), challengeHeader); err != nil {
 		return err
 	}
+	dcontext.GetLogger(ctx).Infof("Challenge established with upstream: %s", remoteURL.Redacted())
 
-	dcontext.GetLogger(ctx).Infof("Challenge established with upstream : %s %s", remoteURL, r.cm)
 	return nil
 }
 


### PR DESCRIPTION
## Description

This PR fixes a logging issue where the "Challenge established with upstream" log message was garbled and unreadable. This affected both v2 and v3 registry versions.

## Problem
The log call was using an incorrect format specifier (`%s`) for the challenge and response structs. This produced useless log output like:

`msg="Challenge established with upstream : {https registry-1.docker.io /v2/ %!s(bool=false) %!s(bool=false) } &{{{%!s(int32=0) ..."`

## Solution

This commit updates the logging call to use the `%+v` format specifier.

**Before:**
`level=info msg="Challenge established with upstream : {https ... %!s(bool=false) ..."`

**After (Example):**
`level=info msg="Challenge established with upstream : {Scheme:https Host:registry-1.docker.io Path:/v2/ ...} ..."`

Closes: #4697

Signed-off-by: Sumedh Vats <sumedhvats2004@gmail.com>