### PR TITLE
BUG: Fix notification filtering to work with actions when mediatypes is empty

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -1048,6 +1048,15 @@ accept event notifications.
 | `mediatypes`|no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
 | `actions`   |no| A list of actions to ignore. Events with these actions are not published to the endpoint. |
 
+The `mediatypes` and `actions` filters work independently. You can specify:
+
+- Only `mediatypes` to filter by media type.
+- Only `actions` to filter by action (e.g., `pull`, `push`, `delete`, `mount`)
+- Both to filter events matching either condition (OR logic)
+- Neither to receive all events
+
+Common use case: Set `mediatypes: []` with `actions: [pull, delete, mount]` to receive only push events regardless of media type.
+
 ### `events`
 
 The `events` structure configures the information provided in event notifications.

--- a/notifications/sinks.go
+++ b/notifications/sinks.go
@@ -128,7 +128,7 @@ type ignoredSink struct {
 }
 
 func newIgnoredSink(sink events.Sink, ignored []string, ignoreActions []string) events.Sink {
-	if len(ignored) == 0 {
+	if len(ignored) == 0 && len(ignoreActions) == 0 {
 		return sink
 	}
 

--- a/notifications/sinks_test.go
+++ b/notifications/sinks_test.go
@@ -79,6 +79,9 @@ func TestIgnoredSink(t *testing.T) {
 		{ignoreMediaTypes: []string{"blob", "manifest"}, ignoreActions: []string{"other"}},
 		{ignoreMediaTypes: []string{"other"}, ignoreActions: []string{"pull"}, expected: blob},
 		{ignoreMediaTypes: []string{"other"}, ignoreActions: []string{"pull", "push"}},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"pull"}, expected: blob},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"push"}},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"mount", "delete"}, expected: blob},
 	}
 
 	for _, tc := range tests {
@@ -103,6 +106,9 @@ func TestIgnoredSink(t *testing.T) {
 		{ignoreMediaTypes: []string{"blob", "manifest"}, ignoreActions: []string{"other"}},
 		{ignoreMediaTypes: []string{"other"}, ignoreActions: []string{"push"}, expected: manifest},
 		{ignoreMediaTypes: []string{"other"}, ignoreActions: []string{"pull", "push"}},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"push"}, expected: manifest},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"pull"}},
+		{ignoreMediaTypes: []string{}, ignoreActions: []string{"mount", "delete"}, expected: manifest},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The newIgnoredSink function had a bug where it would return the unfiltered sink when the mediatypes list was empty, even if ignoreActions was populated. This made it impossible to filter events by action alone.

This fix changes the early return condition to check both parameters:
- Only returns unfiltered sink when BOTH are empty
- Allows filtering by actions alone
- Allows filtering by mediatypes alone
- Maintains existing OR logic when both are specified

Added test cases specifically for the edge case of empty mediatypes with populated actions list.

Updated documentation to clarify how the filtering works and that the two parameters work independently.

Fixes: #4729