### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/internal/client/transport/http_reader_test.go
+++ b/internal/client/transport/http_reader_test.go
@@ -104,7 +104,6 @@ func TestContentEncoding(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.encodingHeader, func(t *testing.T) {
 			t.Parallel()
 			content := make([]byte, 128)

--- a/internal/dcontext/trace_test.go
+++ b/internal/dcontext/trace_test.go
@@ -41,7 +41,6 @@ func TestWithTrace(t *testing.T) {
 		expected: f.Name(),
 	})
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.key, func(t *testing.T) {
 			t.Parallel()
 			v := ctx.Value(tc.key)
@@ -74,7 +73,6 @@ func TestWithTrace(t *testing.T) {
 			expected: parentID,
 		})
 		for _, tc := range tests {
-			tc := tc
 			t.Run(tc.key, func(t *testing.T) {
 				t.Parallel()
 				v := ctx.Value(tc.key)

--- a/registry/api/errcode/errors_test.go
+++ b/registry/api/errcode/errors_test.go
@@ -40,7 +40,6 @@ func TestErrorCodes(t *testing.T) {
 	}
 
 	for ec := range errorCodeToDescriptors {
-		ec := ec
 		t.Run(ec.String(), func(t *testing.T) {
 			t.Parallel()
 			desc := errorCodeToDescriptors[ec]

--- a/registry/api/v2/routes_test.go
+++ b/registry/api/v2/routes_test.go
@@ -254,7 +254,6 @@ func checkTestRouter(t *testing.T, tests []routeTestCase, prefix string, deeplyE
 	server := httptest.NewServer(router)
 
 	for _, tc := range tests {
-		tc := tc
 		requestURI := strings.TrimSuffix(prefix, "/") + tc.RequestURI
 		t.Run("("+tc.RouteName+")"+requestURI, func(t *testing.T) {
 			t.Parallel()

--- a/registry/auth/token/types_test.go
+++ b/registry/auth/token/types_test.go
@@ -27,7 +27,6 @@ func TestAudienceList_Unmarshal(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			tc := tc
 			t.Run("", func(t *testing.T) {
 				t.Parallel()
 				var actual AudienceList

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -491,7 +491,6 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 	g := errgroup.Group{}
 	g.SetLimit(storage.DefaultConcurrencyLimit)
 	for _, tag := range referencedTags {
-		tag := tag
 
 		g.Go(func() error {
 			if err := tagService.Untag(imh, tag); err != nil {

--- a/registry/storage/driver/errors_test.go
+++ b/registry/storage/driver/errors_test.go
@@ -63,7 +63,6 @@ func TestErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := tc.errs.Error(); got != tc.exp {

--- a/registry/storage/driver/middleware/cloudfront/s3filter_test.go
+++ b/registry/storage/driver/middleware/cloudfront/s3filter_test.go
@@ -311,7 +311,6 @@ func TestEligibleForS3(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(fmt.Sprintf("Client IP = %v", tc.RemoteAddr), func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{RemoteAddr: tc.RemoteAddr}
@@ -340,7 +339,6 @@ func TestEligibleForS3WithAWSIPNotInitialized(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(fmt.Sprintf("Client IP = %v", tc.RemoteAddr), func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{RemoteAddr: tc.RemoteAddr}


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore