### PR TITLE
Add return error when list object

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1013,11 +1013,13 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	for {
 		// list all the objects
 		resp, err := d.S3.ListObjectsV2WithContext(ctx, listObjectsInput)
-
+		if err != nil {
+			return err
+		}
 		// resp.Contents can only be empty on the first call
 		// if there were no more results to return after the first call, resp.IsTruncated would have been false
 		// and the loop would exit without recalling ListObjects
-		if err != nil || len(resp.Contents) == 0 {
+		if len(resp.Contents) == 0 {
 			return storagedriver.PathNotFoundError{Path: path}
 		}
 


### PR DESCRIPTION
In the previous version of the Harbor Helm chart, S3 credentials for the registry were not configured. This caused the garbage collection process to throw a misleading 'Path not found' error instead of an 'Invalid credentials' error, which led to confusion during debugging.

Related issue: 
- https://github.com/goharbor/harbor/issues/22111
- https://github.com/goharbor/harbor/issues/19234
