### PR TITLE
Makefile: remove duplicate ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ version/version.go:
 
 bin/%: cmd/% FORCE ## build individual binary
 	@echo "$(WHALE) $@${BINARY_SUFFIX}"
-	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS}  ./$<
+	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS}  ./$<
 
 binaries: $(BINARIES) ## build binaries
 	@echo "$(WHALE) $@"
 
 build: ## build go packages
 	@echo "$(WHALE) $@"
-	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS} $(PACKAGES)
+	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} ${GO_TAGS} $(PACKAGES)
 
 image: ## build docker image IMAGE_NAME=<name>
 	docker buildx bake --set "*.tags=${IMAGE_NAME}" image-local


### PR DESCRIPTION
The second ldflags will override the first one in GO_LDFLAGS, and make user cannot set GO_LDFLAGS by passing this variable