### PR TITLE
Expose `useFIPSEndpoint` for S3

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -162,6 +162,7 @@ storage:
     multipartcopythresholdsize: 33554432
     rootdirectory: /s3/object/name/prefix
     usedualstack: false
+    usefipsendpoint: false
     loglevel: debug
   inmemory:  # This driver takes no parameters
   tag:
@@ -455,6 +456,7 @@ storage:
     multipartcopymaxconcurrency: 100
     multipartcopythresholdsize: 33554432
     rootdirectory: /s3/object/name/prefix
+    usefipsendpoint: false
     loglevel: debug
   inmemory:
   delete:

--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -34,6 +34,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `useragent` | no | The `User-Agent` header value for S3 API operations. |
 | `usedualstack` | no | Use AWS dual-stack API endpoints. |
 | `accelerate` | no | Enable S3 Transfer Acceleration. |
+| `usefipsendpoint` | no | Use AWS FIPS endpoints for S3 API operations. |
 | `objectacl`  | no | The S3 Canned ACL for objects. The default value is "private". |
 | `loglevel`  | no | The log level for the S3 client. The default value is `off`. |
 
@@ -75,6 +76,8 @@ Amazon S3 or S3 compatible services for object storage.
 `usedualstack`: (optional) Use AWS dual-stack API endpoints which support requests to S3 buckets over IPv6 and IPv4.
 
 `accelerate`: (optional) Enable S3 transfer acceleration for faster transfers of files over long distances.
+
+`usefipsendpoint`: (optional) Whether to use FIPS-compliant endpoints for S3 API operations. Defaults to `false`. When enabled, the driver uses TLS software that complies with FIPS 140-2, which is required for US Government agencies and partners doing business with the federal government. See [FIPS endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html) for more details.
 
 `objectacl`: (optional) The canned object ACL to be applied to each registry object. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your objects. Other valid options are available in the [AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -114,6 +114,7 @@ type DriverParameters struct {
 	SessionToken                string
 	UseDualStack                bool
 	Accelerate                  bool
+	UseFIPSEndpoint             bool
 	LogLevel                    aws.LogLevelType
 }
 
@@ -335,6 +336,11 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 		return nil, err
 	}
 
+	useFIPSEndpointBool, err := getParameterAsBool(parameters, "usefipsendpoint", false)
+	if err != nil {
+		return nil, err
+	}
+
 	params := DriverParameters{
 		AccessKey:                   fmt.Sprint(accessKey),
 		SecretKey:                   fmt.Sprint(secretKey),
@@ -358,6 +364,7 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 		SessionToken:                fmt.Sprint(sessionToken),
 		UseDualStack:                useDualStackBool,
 		Accelerate:                  accelerateBool,
+		UseFIPSEndpoint:             useFIPSEndpointBool,
 		LogLevel:                    getS3LogLevelFromParam(parameters["loglevel"]),
 	}
 
@@ -475,6 +482,9 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 	awsConfig.WithDisableSSL(!params.Secure)
 	if params.UseDualStack {
 		awsConfig.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
+	}
+	if params.UseFIPSEndpoint {
+		awsConfig.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if params.SkipVerify {

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -29,22 +29,23 @@ var (
 
 func init() {
 	var (
-		accessKey      = os.Getenv("AWS_ACCESS_KEY")
-		secretKey      = os.Getenv("AWS_SECRET_KEY")
-		bucket         = os.Getenv("S3_BUCKET")
-		encrypt        = os.Getenv("S3_ENCRYPT")
-		keyID          = os.Getenv("S3_KEY_ID")
-		secure         = os.Getenv("S3_SECURE")
-		skipVerify     = os.Getenv("S3_SKIP_VERIFY")
-		v4Auth         = os.Getenv("S3_V4_AUTH")
-		region         = os.Getenv("AWS_REGION")
-		objectACL      = os.Getenv("S3_OBJECT_ACL")
-		regionEndpoint = os.Getenv("REGION_ENDPOINT")
-		forcePathStyle = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
-		sessionToken   = os.Getenv("AWS_SESSION_TOKEN")
-		useDualStack   = os.Getenv("S3_USE_DUALSTACK")
-		accelerate     = os.Getenv("S3_ACCELERATE")
-		logLevel       = os.Getenv("S3_LOGLEVEL")
+		accessKey       = os.Getenv("AWS_ACCESS_KEY")
+		secretKey       = os.Getenv("AWS_SECRET_KEY")
+		bucket          = os.Getenv("S3_BUCKET")
+		encrypt         = os.Getenv("S3_ENCRYPT")
+		keyID           = os.Getenv("S3_KEY_ID")
+		secure          = os.Getenv("S3_SECURE")
+		skipVerify      = os.Getenv("S3_SKIP_VERIFY")
+		v4Auth          = os.Getenv("S3_V4_AUTH")
+		region          = os.Getenv("AWS_REGION")
+		objectACL       = os.Getenv("S3_OBJECT_ACL")
+		regionEndpoint  = os.Getenv("REGION_ENDPOINT")
+		forcePathStyle  = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
+		sessionToken    = os.Getenv("AWS_SESSION_TOKEN")
+		useDualStack    = os.Getenv("S3_USE_DUALSTACK")
+		accelerate      = os.Getenv("S3_ACCELERATE")
+		useFIPSEndpoint = os.Getenv("S3_USE_FIPS_ENDPOINT")
+		logLevel        = os.Getenv("S3_LOGLEVEL")
 	)
 
 	var err error
@@ -101,6 +102,14 @@ func init() {
 			}
 		}
 
+		useFIPSEndpointBool := false
+		if useFIPSEndpoint != "" {
+			useFIPSEndpointBool, err = strconv.ParseBool(useFIPSEndpoint)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		if objectACL == "" {
 			objectACL = s3.ObjectCannedACLPrivate
 		}
@@ -128,6 +137,7 @@ func init() {
 			SessionToken:                sessionToken,
 			UseDualStack:                useDualStackBool,
 			Accelerate:                  accelerateBool,
+			UseFIPSEndpoint:             useFIPSEndpointBool,
 			LogLevel:                    getS3LogLevelFromParam(logLevel),
 		}
 

--- a/tests/conf-local-s3.yml
+++ b/tests/conf-local-s3.yml
@@ -34,5 +34,5 @@ storage:
     encrypt: false
     secure: false
     chunksize: 33554432
-    secure: true
     v4auth: true
+    usefipsendpoint: false


### PR DESCRIPTION
Similar to `useDualstackEndpoint`. This would tell the S3 client to use the FIPS-compliant endpoints. 

~~Includes changes from #4763~~ Merged