### PR TITLE
fix(ci): Fix broken Azure e2e storage tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ test-azure-storage: start-azure-storage run-azure-tests stop-azure-storage ## ru
 
 .PHONY: start-azure-storage
 start-azure-storage: ## start local Azure storage (Azurite)
-	$(COMPOSE) -f tests/docker-compose-azure-blob-store.yaml up azurite azurite-init -d
+	$(COMPOSE) -f tests/docker-compose-azure-blob-store.yaml up azurite azurite-init -d --wait
 
 .PHONY: stop-azure-storage
 stop-azure-storage: ## stop local Azure storage (minio)

--- a/tests/docker-compose-azure-blob-store.yaml
+++ b/tests/docker-compose-azure-blob-store.yaml
@@ -14,7 +14,7 @@ services:
       "
 
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
     ports:
       - "10000:10000"
     volumes:
@@ -45,7 +45,7 @@ services:
       retries: 10
 
   azurite-init:
-    image: mcr.microsoft.com/azure-cli
+    image: mcr.microsoft.com/azure-cli:2.70.0
     depends_on:
       azurite:
         condition: service_healthy


### PR DESCRIPTION
We were asking for it by not pinning our compose images to specific tags and Azure team delivered: the latest `azure-cli` broke our azure store e2e tests 🥴 

This pins the images to specific tags and adds --wait flag for waiting for the compose to fully start.

PTAL @thaJeztah @wy65701436 @joaodrp 