### PR TITLE
fix(storage): s3, increase max idle conns per host

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -102,6 +102,7 @@ type DriverParameters struct {
 	KeyID                       string
 	Secure                      bool
 	SkipVerify                  bool
+	MaxIdleConnsPerHost         int
 	V4Auth                      bool
 	ChunkSize                   int
 	MultipartCopyChunkSize      int64
@@ -240,6 +241,11 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		return nil, err
 	}
 
+	maxIdleConnsPerHostInt, err := getParameterAsInteger(parameters, "maxidleconnsperhost", 0, 0, math.MaxInt)
+	if err != nil {
+		return nil, err
+	}
+
 	v4Bool, err := getParameterAsBool(parameters, "v4auth", true)
 	if err != nil {
 		return nil, err
@@ -352,6 +358,7 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		KeyID:                       fmt.Sprint(keyID),
 		Secure:                      secureBool,
 		SkipVerify:                  skipVerifyBool,
+		MaxIdleConnsPerHost:         maxIdleConnsPerHostInt,
 		V4Auth:                      v4Bool,
 		ChunkSize:                   chunkSize,
 		MultipartCopyChunkSize:      multipartCopyChunkSize,
@@ -487,9 +494,10 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		awsConfig.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
-	if params.SkipVerify {
+	if params.SkipVerify || params.MaxIdleConnsPerHost > 0 {
 		httpTransport := http.DefaultTransport.(*http.Transport).Clone()
-		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: params.SkipVerify}
+		httpTransport.MaxIdleConnsPerHost = params.MaxIdleConnsPerHost
 		awsConfig.WithHTTPClient(&http.Client{
 			Transport: httpTransport,
 		})

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -51,6 +51,8 @@ const minChunkSize = 5 * 1024 * 1024
 
 const defaultChunkSize = 2 * minChunkSize
 
+const defaultMaxIdleConnsPerHost = 50
+
 const (
 	// defaultMultipartCopyChunkSize defines the default chunk size for all
 	// but the last Upload Part - Copy operation of a multipart copy.
@@ -490,13 +492,12 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		awsConfig.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
+	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+	httpTransport.MaxIdleConnsPerHost = defaultMaxIdleConnsPerHost
 	if params.SkipVerify {
-		httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		awsConfig.WithHTTPClient(&http.Client{
-			Transport: httpTransport,
-		})
 	}
+	awsConfig.WithHTTPClient(&http.Client{Transport: httpTransport})
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -30,23 +30,24 @@ var (
 
 func init() {
 	var (
-		accessKey       = os.Getenv("AWS_ACCESS_KEY")
-		secretKey       = os.Getenv("AWS_SECRET_KEY")
-		bucket          = os.Getenv("S3_BUCKET")
-		encrypt         = os.Getenv("S3_ENCRYPT")
-		keyID           = os.Getenv("S3_KEY_ID")
-		secure          = os.Getenv("S3_SECURE")
-		skipVerify      = os.Getenv("S3_SKIP_VERIFY")
-		v4Auth          = os.Getenv("S3_V4_AUTH")
-		region          = os.Getenv("AWS_REGION")
-		objectACL       = os.Getenv("S3_OBJECT_ACL")
-		regionEndpoint  = os.Getenv("REGION_ENDPOINT")
-		forcePathStyle  = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
-		sessionToken    = os.Getenv("AWS_SESSION_TOKEN")
-		useDualStack    = os.Getenv("S3_USE_DUALSTACK")
-		accelerate      = os.Getenv("S3_ACCELERATE")
-		useFIPSEndpoint = os.Getenv("S3_USE_FIPS_ENDPOINT")
-		logLevel        = os.Getenv("S3_LOGLEVEL")
+		accessKey           = os.Getenv("AWS_ACCESS_KEY")
+		secretKey           = os.Getenv("AWS_SECRET_KEY")
+		bucket              = os.Getenv("S3_BUCKET")
+		encrypt             = os.Getenv("S3_ENCRYPT")
+		keyID               = os.Getenv("S3_KEY_ID")
+		secure              = os.Getenv("S3_SECURE")
+		skipVerify          = os.Getenv("S3_SKIP_VERIFY")
+		maxIdleConnsPerHost = os.Getenv("S3_MAX_IDLE_CONNS_PER_HOST")
+		v4Auth              = os.Getenv("S3_V4_AUTH")
+		region              = os.Getenv("AWS_REGION")
+		objectACL           = os.Getenv("S3_OBJECT_ACL")
+		regionEndpoint      = os.Getenv("REGION_ENDPOINT")
+		forcePathStyle      = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
+		sessionToken        = os.Getenv("AWS_SESSION_TOKEN")
+		useDualStack        = os.Getenv("S3_USE_DUALSTACK")
+		accelerate          = os.Getenv("S3_ACCELERATE")
+		useFIPSEndpoint     = os.Getenv("S3_USE_FIPS_ENDPOINT")
+		logLevel            = os.Getenv("S3_LOGLEVEL")
 	)
 
 	var err error
@@ -70,6 +71,14 @@ func init() {
 		skipVerifyBool := false
 		if skipVerify != "" {
 			skipVerifyBool, err = strconv.ParseBool(skipVerify)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var maxIdleConnsPerHostInt int
+		if maxIdleConnsPerHost != "" {
+			maxIdleConnsPerHostInt, err = strconv.Atoi(maxIdleConnsPerHost)
 			if err != nil {
 				return nil, err
 			}
@@ -126,6 +135,7 @@ func init() {
 			KeyID:                       keyID,
 			Secure:                      secureBool,
 			SkipVerify:                  skipVerifyBool,
+			MaxIdleConnsPerHost:         maxIdleConnsPerHostInt,
 			V4Auth:                      v4Bool,
 			ChunkSize:                   minChunkSize,
 			MultipartCopyChunkSize:      defaultMultipartCopyChunkSize,
@@ -340,10 +350,13 @@ func TestClientTransport(t *testing.T) {
 	skipCheck(t)
 
 	testCases := []struct {
-		skipverify bool
+		skipverify          bool
+		maxIdleConnsPerHost int
 	}{
-		{true},
-		{false},
+		{true, 0},
+		{false, 0},
+		{true, 1024},
+		{false, 1024},
 	}
 
 	for _, tc := range testCases {
@@ -351,9 +364,10 @@ func TestClientTransport(t *testing.T) {
 		// because s3DriverConstructor is initialized in init() using the process
 		// env vars: we can not override S3_SKIP_VERIFY env var with t.Setenv
 		params := map[string]any{
-			"region":     os.Getenv("AWS_REGION"),
-			"bucket":     os.Getenv("S3_BUCKET"),
-			"skipverify": tc.skipverify,
+			"region":              os.Getenv("AWS_REGION"),
+			"bucket":              os.Getenv("S3_BUCKET"),
+			"skipverify":          tc.skipverify,
+			"maxidleconnsperhost": tc.maxIdleConnsPerHost,
 		}
 		t.Run(fmt.Sprintf("SkipVerify %v", tc.skipverify), func(t *testing.T) {
 			drv, err := FromParameters(context.TODO(), params)
@@ -362,26 +376,34 @@ func TestClientTransport(t *testing.T) {
 			}
 
 			s3drv := drv.baseEmbed.Base.StorageDriver.(*driver)
-			if tc.skipverify {
+			if tc.skipverify || tc.maxIdleConnsPerHost > 0 {
 				tr, ok := s3drv.S3.Client.Config.HTTPClient.Transport.(*http.Transport)
 				if !ok {
 					t.Fatal("unexpected driver transport")
 				}
-				if !tr.TLSClientConfig.InsecureSkipVerify {
+
+				if tr.TLSClientConfig.InsecureSkipVerify != tc.skipverify {
 					t.Errorf("unexpected TLS Config. Expected InsecureSkipVerify: %v, got %v",
 						tc.skipverify,
 						tr.TLSClientConfig.InsecureSkipVerify)
 				}
+
+				if tr.MaxIdleConnsPerHost != tc.maxIdleConnsPerHost {
+					t.Errorf("unexpected MaxIdleConnsPerHost Config. Expected MaxIdleConnsPerHost: %v, got %v",
+						tc.maxIdleConnsPerHost,
+						tr.MaxIdleConnsPerHost)
+				}
+
 				// make sure the proxy is always set
 				if tr.Proxy == nil {
 					t.Fatal("missing HTTP transport proxy config")
 				}
-				return
-			}
-			// if tc.skipverify is false we do not override the driver
-			// HTTP client transport and leave it to the AWS SDK.
-			if s3drv.S3.Client.Config.HTTPClient.Transport != nil {
-				t.Errorf("unexpected S3 driver client transport")
+			} else {
+				// if tc.skipverify is false we do not override the driver
+				// HTTP client transport and leave it to the AWS SDK.
+				if s3drv.S3.Client.Config.HTTPClient.Transport != nil {
+					t.Errorf("unexpected S3 driver client transport")
+				}
 			}
 		})
 	}

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -386,51 +386,36 @@ func TestEmptyRootList(t *testing.T) {
 }
 
 func TestClientTransport(t *testing.T) {
-	skipCheck(t)
-
-	testCases := []struct {
-		skipverify bool
-	}{
-		{true},
-		{false},
-	}
-
-	for _, tc := range testCases {
-		// NOTE(milosgajdos): we cannot simply reuse s3DriverConstructor
-		// because s3DriverConstructor is initialized in init() using the process
-		// env vars: we can not override S3_SKIP_VERIFY env var with t.Setenv
+	for _, skipVerify := range []bool{true, false} {
 		params := map[string]any{
-			"region":     os.Getenv("AWS_REGION"),
-			"bucket":     os.Getenv("S3_BUCKET"),
-			"skipverify": tc.skipverify,
+			"region":     "us-east-1",
+			"bucket":     "test",
+			"skipverify": skipVerify,
 		}
-		t.Run(fmt.Sprintf("SkipVerify %v", tc.skipverify), func(t *testing.T) {
+		t.Run(fmt.Sprintf("SkipVerify %v", skipVerify), func(t *testing.T) {
 			drv, err := FromParameters(context.TODO(), params)
 			if err != nil {
 				t.Fatalf("failed to create driver: %v", err)
 			}
 
 			s3drv := drv.baseEmbed.Base.StorageDriver.(*driver)
-			if tc.skipverify {
-				tr, ok := s3drv.S3.Client.Config.HTTPClient.Transport.(*http.Transport)
-				if !ok {
-					t.Fatal("unexpected driver transport")
-				}
-				if !tr.TLSClientConfig.InsecureSkipVerify {
-					t.Errorf("unexpected TLS Config. Expected InsecureSkipVerify: %v, got %v",
-						tc.skipverify,
-						tr.TLSClientConfig.InsecureSkipVerify)
-				}
-				// make sure the proxy is always set
-				if tr.Proxy == nil {
-					t.Fatal("missing HTTP transport proxy config")
-				}
-				return
+			tr, ok := s3drv.S3.Client.Config.HTTPClient.Transport.(*http.Transport)
+			if !ok {
+				t.Fatal("unexpected driver transport")
 			}
-			// if tc.skipverify is false we do not override the driver
-			// HTTP client transport and leave it to the AWS SDK.
-			if s3drv.S3.Client.Config.HTTPClient.Transport != nil {
-				t.Errorf("unexpected S3 driver client transport")
+
+			insecureSkipVerify := tr.TLSClientConfig != nil && tr.TLSClientConfig.InsecureSkipVerify
+			if insecureSkipVerify != skipVerify {
+				t.Errorf("unexpected TLS config: InsecureSkipVerify = %v, want %v", insecureSkipVerify, skipVerify)
+			}
+
+			if tr.MaxIdleConnsPerHost != defaultMaxIdleConnsPerHost {
+				t.Errorf("unexpected MaxIdleConnsPerHost: %v", tr.MaxIdleConnsPerHost)
+			}
+
+			// make sure the proxy is always set
+			if tr.Proxy == nil {
+				t.Fatal("missing HTTP transport proxy config")
 			}
 		})
 	}


### PR DESCRIPTION
Increase the S3 HTTP transport's `MaxIdleConnsPerHost` from Go's default of 2 to 50. The transport continues to inherit `MaxIdleConns = 100` and `MaxConnsPerHost = 0` from `http.DefaultTransport`.

This reduces connection churn that can exhaust ephemeral ports during garbage collection, without adding a new configuration option.

Tests:
- `go test ./registry/storage/driver/s3-aws -count=1`