### PR TITLE
fix(registry/proxy): use detached context when flushing write buffer

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -692,6 +692,12 @@ type Proxy struct {
 	// if not set, defaults to 7 * 24 hours
 	// If set to zero, will never expire cache
 	TTL *time.Duration `yaml:"ttl,omitempty"`
+
+	// CacheWriteTimeout is the maximum duration allowed for cache write operations
+	// to complete when pulling blobs from the remote registry. This timeout ensures
+	// that cache writes don't hang indefinitely if the storage backend is slow.
+	// If not set, defaults to 5 minutes.
+	CacheWriteTimeout *time.Duration `yaml:"cachewritetimeout,omitempty"`
 }
 
 // ExecConfig defines the configuration for executing a command as a credential helper.

--- a/internal/client/blob_writer.go
+++ b/internal/client/blob_writer.go
@@ -123,7 +123,7 @@ func (hbu *httpBlobUpload) StartedAt() time.Time {
 
 func (hbu *httpBlobUpload) Commit(ctx context.Context, desc v1.Descriptor) (v1.Descriptor, error) {
 	// TODO(dmcgowan): Check if already finished, if so just fetch
-	req, err := http.NewRequestWithContext(hbu.ctx, http.MethodPut, hbu.location, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, hbu.location, nil)
 	if err != nil {
 		return v1.Descriptor{}, err
 	}
@@ -146,7 +146,7 @@ func (hbu *httpBlobUpload) Commit(ctx context.Context, desc v1.Descriptor) (v1.D
 }
 
 func (hbu *httpBlobUpload) Cancel(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(hbu.ctx, http.MethodDelete, hbu.location, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, hbu.location, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We often see errors like these when pulling through blobs that do not exist on the storage backend: 

```
{
  "err.code": "unknown",
  "err.detail": "upload part: RequestCanceled: request context canceled\ncaused by: context canceled",
  "http.response.duration": "1.661110175s",
  "http.response.status": 500,
  "http.response.written": 66008988
}
```

```
{
  "msg": "error resolving descriptor in ServeBlob listener: s3aws: RequestCanceled: request context canceled\ncaused by: context canceled"
}
```
In the case of `s3` backend, we are hitting the error here, during `flush()`:

https://github.com/distribution/distribution/blob/40594bd98e6d6ed993b5c6021c93fdf96d2e5851/registry/storage/driver/s3-aws/s3.go#L1518-L1552

The context comes from this writer struct:

https://github.com/distribution/distribution/blob/40594bd98e6d6ed993b5c6021c93fdf96d2e5851/registry/storage/driver/s3-aws/s3.go#L1273-L1274

Which appears to flow down from the http handler:

https://github.com/distribution/distribution/blob/40594bd98e6d6ed993b5c6021c93fdf96d2e5851/registry/handlers/app.go#L677

So when the buffer fills and the response is streamed to the client, the http request completes before `flush()` finishes writing to the storage backend. When this occurs, we end up with a number of stranded MPUs, and while the blob is delivered to the client, it does not end up written to the storage backend, resulting in a cache miss on next pull. 

Using a detached context for operations that may persist longer than the duration of the http request appears to solve the problem. 

As the duration of time needed by `flush()` can vary by blob size and the speed of the storage backend, the duration of the detached context timeout is configurable via `CacheWriteTimeout`. 

Closes https://github.com/distribution/distribution/issues/4649

