### PR TITLE
feat: add option to walk with delimiter in s3

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -37,6 +37,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `usefipsendpoint` | no | Use AWS FIPS endpoints for S3 API operations. |
 | `objectacl`  | no | The S3 Canned ACL for objects. The default value is "private". |
 | `loglevel`  | no | The log level for the S3 client. The default value is `off`. |
+| `usedelimiterwalk` | no | Use delimiter-based directory traversal for catalog operations. The default value is `false`. |
 
 > **Note** You can provide empty strings for your access and secret keys to run the driver
 > on an ec2 instance and handles authentication with the instance's credentials. If you
@@ -82,6 +83,8 @@ Amazon S3 or S3 compatible services for object storage.
 `objectacl`: (optional) The canned object ACL to be applied to each registry object. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your objects. Other valid options are available in the [AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 
 `loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
+
+`usedelimiterwalk`: (optional) When enabled, uses delimiter-based directory traversal for catalog operations, which can significantly improve performance when listing repositories. The delimiter-based approach uses the S3 `ListObjectsV2` API with the delimiter parameter to efficiently navigate the directory structure level-by-level, rather than listing all objects recursively. This is particularly beneficial for registries with many repositories or deeply nested directory structures. Defaults to `false` to maintain backward compatibility. It is recommended to enable this for production registries with large numbers of repositories.
 
 ## S3 permission scopes
 

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -36,19 +36,18 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 	}
 
 	err = reg.blobStore.driver.Walk(ctx, root, func(fileInfo driver.FileInfo) error {
-		err := handleRepository(fileInfo, root, last, func(repoPath string) error {
+		err := HandleRepository(fileInfo, root, last, func(repoPath string) error {
+			// if we've filled our slice, no need to walk any further
+			if foundRepos >= len(repos) {
+				filledBuffer = true
+				return driver.ErrFilledBuffer
+			}
 			repos[foundRepos] = repoPath
 			foundRepos += 1
 			return nil
 		})
 		if err != nil {
 			return err
-		}
-
-		// if we've filled our slice, no need to walk any further
-		if foundRepos == len(repos) {
-			filledBuffer = true
-			return driver.ErrFilledBuffer
 		}
 
 		return nil
@@ -75,7 +74,7 @@ func (reg *registry) Enumerate(ctx context.Context, ingester func(string) error)
 	}
 
 	err = reg.blobStore.driver.Walk(ctx, root, func(fileInfo driver.FileInfo) error {
-		return handleRepository(fileInfo, root, "", ingester)
+		return HandleRepository(fileInfo, root, "", ingester)
 	})
 
 	return err
@@ -142,12 +141,12 @@ func compareReplaceInline(s1, s2 string, old, new byte) int {
 	return 0
 }
 
-// handleRepository calls function fn with a repository path if fileInfo
+// HandleRepository calls function fn with a repository path if fileInfo
 // has a path of a repository under root and that it is lexographically
 // after last. Otherwise, it will return ErrSkipDir or ErrFilledBuffer.
 // These should be used with Walk to do handling with repositories in a
 // storage.
-func handleRepository(fileInfo driver.FileInfo, root, last string, fn func(repoPath string) error) error {
+func HandleRepository(fileInfo driver.FileInfo, root, last string, fn func(repoPath string) error) error {
 	filePath := fileInfo.Path()
 
 	// lop the base path off

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -115,6 +115,7 @@ type DriverParameters struct {
 	UseDualStack                bool
 	Accelerate                  bool
 	UseFIPSEndpoint             bool
+	UseDelimiterWalk            bool
 	LogLevel                    aws.LogLevelType
 }
 
@@ -153,7 +154,7 @@ func (factory *s3DriverFactory) Create(ctx context.Context, parameters map[strin
 var _ storagedriver.StorageDriver = &driver{}
 
 type driver struct {
-	S3                          *s3.S3
+	S3                          S3Client
 	Bucket                      string
 	ChunkSize                   int
 	Encrypt                     bool
@@ -164,6 +165,7 @@ type driver struct {
 	RootDirectory               string
 	StorageClass                string
 	ObjectACL                   string
+	UseDelimiterWalk            bool
 	pool                        *sync.Pool
 }
 
@@ -341,6 +343,11 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 		return nil, err
 	}
 
+	useDelimiterWalkBool, err := getParameterAsBool(parameters, "usedelimiterwalk", false)
+	if err != nil {
+		return nil, err
+	}
+
 	params := DriverParameters{
 		AccessKey:                   fmt.Sprint(accessKey),
 		SecretKey:                   fmt.Sprint(secretKey),
@@ -365,6 +372,7 @@ func FromParameters(ctx context.Context, parameters map[string]interface{}) (*Dr
 		UseDualStack:                useDualStackBool,
 		Accelerate:                  accelerateBool,
 		UseFIPSEndpoint:             useFIPSEndpointBool,
+		UseDelimiterWalk:            useDelimiterWalkBool,
 		LogLevel:                    getS3LogLevelFromParam(parameters["loglevel"]),
 	}
 
@@ -538,6 +546,7 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		RootDirectory:               params.RootDirectory,
 		StorageClass:                params.StorageClass,
 		ObjectACL:                   params.ObjectACL,
+		UseDelimiterWalk:            params.UseDelimiterWalk,
 		pool: &sync.Pool{
 			New: func() any { return &bytes.Buffer{} },
 		},
@@ -1059,8 +1068,14 @@ func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn, 
 	}
 
 	var objectCount int64
-	if err := d.doWalk(ctx, &objectCount, from, walkOptions.StartAfterHint, f); err != nil {
-		return err
+	if d.UseDelimiterWalk {
+		if err := d.doWalkWithDelimiter(ctx, &objectCount, from, walkOptions.StartAfterHint, f); err != nil {
+			return err
+		}
+	} else {
+		if err := d.doWalk(ctx, &objectCount, from, walkOptions.StartAfterHint, f); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1178,7 +1193,7 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, from, sta
 	return nil
 }
 
-// directoryDiff finds all directories that are not in common between
+// directoryDiff returns the directories that are unique to 'current' relative to 'prev'.
 // the previous and current paths in sorted order.
 //
 // # Examples

--- a/registry/storage/driver/s3-aws/s3_iface.go
+++ b/registry/storage/driver/s3-aws/s3_iface.go
@@ -1,0 +1,29 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// S3Client is a client-side interface for [github.com/aws/aws-sdk-go/service/s3.S3]
+type S3Client interface {
+	GetObjectWithContext(context.Context, *s3.GetObjectInput, ...request.Option) (*s3.GetObjectOutput, error)
+	PutObjectWithContext(context.Context, *s3.PutObjectInput, ...request.Option) (*s3.PutObjectOutput, error)
+	AbortMultipartUploadWithContext(context.Context, *s3.AbortMultipartUploadInput, ...request.Option) (*s3.AbortMultipartUploadOutput, error)
+	CreateMultipartUploadWithContext(context.Context, *s3.CreateMultipartUploadInput, ...request.Option) (*s3.CreateMultipartUploadOutput, error)
+	CompleteMultipartUploadWithContext(context.Context, *s3.CompleteMultipartUploadInput, ...request.Option) (*s3.CompleteMultipartUploadOutput, error)
+	ListMultipartUploadsWithContext(context.Context, *s3.ListMultipartUploadsInput, ...request.Option) (*s3.ListMultipartUploadsOutput, error)
+	ListPartsWithContext(context.Context, *s3.ListPartsInput, ...request.Option) (*s3.ListPartsOutput, error)
+	HeadObjectWithContext(context.Context, *s3.HeadObjectInput, ...request.Option) (*s3.HeadObjectOutput, error)
+	ListObjectsV2WithContext(context.Context, *s3.ListObjectsV2Input, ...request.Option) (*s3.ListObjectsV2Output, error)
+	ListObjectsV2PagesWithContext(context.Context, *s3.ListObjectsV2Input, func(*s3.ListObjectsV2Output, bool) bool, ...request.Option) error
+	CopyObjectWithContext(context.Context, *s3.CopyObjectInput, ...request.Option) (*s3.CopyObjectOutput, error)
+	UploadPartWithContext(context.Context, *s3.UploadPartInput, ...request.Option) (*s3.UploadPartOutput, error)
+	UploadPartCopyWithContext(context.Context, *s3.UploadPartCopyInput, ...request.Option) (*s3.UploadPartCopyOutput, error)
+	DeleteObjectsWithContext(aws.Context, *s3.DeleteObjectsInput, ...request.Option) (*s3.DeleteObjectsOutput, error)
+	GetObjectRequest(*s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput)
+	HeadObjectRequest(*s3.HeadObjectInput) (*request.Request, *s3.HeadObjectOutput)
+}

--- a/registry/storage/driver/s3-aws/s3_iface_test.go
+++ b/registry/storage/driver/s3-aws/s3_iface_test.go
@@ -1,0 +1,182 @@
+package s3
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type mockS3Client struct {
+	objects map[string]*s3.Object
+	mu      sync.RWMutex
+}
+
+func newMockS3Client() *mockS3Client {
+	return &mockS3Client{
+		objects: make(map[string]*s3.Object),
+	}
+}
+
+func (m *mockS3Client) addObject(key string, size int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	m.objects[key] = &s3.Object{
+		Key:          aws.String(key),
+		Size:         aws.Int64(size),
+		LastModified: &now,
+	}
+}
+
+func (m *mockS3Client) GetObjectWithContext(context.Context, *s3.GetObjectInput, ...request.Option) (*s3.GetObjectOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) PutObjectWithContext(context.Context, *s3.PutObjectInput, ...request.Option) (*s3.PutObjectOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) AbortMultipartUploadWithContext(context.Context, *s3.AbortMultipartUploadInput, ...request.Option) (*s3.AbortMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) CreateMultipartUploadWithContext(context.Context, *s3.CreateMultipartUploadInput, ...request.Option) (*s3.CreateMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) CompleteMultipartUploadWithContext(context.Context, *s3.CompleteMultipartUploadInput, ...request.Option) (*s3.CompleteMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) ListMultipartUploadsWithContext(context.Context, *s3.ListMultipartUploadsInput, ...request.Option) (*s3.ListMultipartUploadsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) ListPartsWithContext(context.Context, *s3.ListPartsInput, ...request.Option) (*s3.ListPartsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) HeadObjectWithContext(context.Context, *s3.HeadObjectInput, ...request.Option) (*s3.HeadObjectOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) ListObjectsV2WithContext(context.Context, *s3.ListObjectsV2Input, ...request.Option) (*s3.ListObjectsV2Output, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) ListObjectsV2PagesWithContext(ctx context.Context, input *s3.ListObjectsV2Input, fn func(*s3.ListObjectsV2Output, bool) bool, opts ...request.Option) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	prefix := aws.StringValue(input.Prefix)
+	delimiter := aws.StringValue(input.Delimiter)
+	startAfter := aws.StringValue(input.StartAfter)
+	maxKeys := aws.Int64Value(input.MaxKeys)
+	if maxKeys == 0 {
+		maxKeys = 1000
+	}
+
+	contents := make([]*s3.Object, 0, len(m.objects))
+	prefixMap := make(map[string]bool)
+
+	// Collect all matching keys
+	allKeys := make([]string, 0, len(m.objects))
+	for key := range m.objects {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		if startAfter != "" && key <= startAfter {
+			continue
+		}
+		allKeys = append(allKeys, key)
+	}
+
+	// Sort keys to match S3 behavior
+	sort.Strings(allKeys)
+
+	// Process keys based on delimiter
+	for _, key := range allKeys {
+		if delimiter != "" {
+			// With delimiter, separate files from directories
+			relativePath := strings.TrimPrefix(key, prefix)
+			delimiterIndex := strings.Index(relativePath, delimiter)
+
+			if delimiterIndex > 0 {
+				// This is a subdirectory
+				commonPrefix := prefix + relativePath[:delimiterIndex+1]
+				prefixMap[commonPrefix] = true
+				continue
+			}
+		}
+
+		// This is a file at the current level
+		contents = append(contents, m.objects[key])
+	}
+
+	// Convert prefix map to CommonPrefixes slice
+	var commonPrefixes []*s3.CommonPrefix
+	if delimiter != "" {
+		prefixList := make([]string, 0, len(prefixMap))
+		for p := range prefixMap {
+			prefixList = append(prefixList, p)
+		}
+		sort.Strings(prefixList)
+		for _, p := range prefixList {
+			commonPrefixes = append(commonPrefixes, &s3.CommonPrefix{
+				Prefix: aws.String(p),
+			})
+		}
+	}
+
+	// Simulate pagination if we have more results than maxKeys
+	totalResults := int64(len(contents) + len(commonPrefixes))
+	isLastPage := totalResults <= maxKeys
+
+	// For simplicity in tests, we'll return everything in one page
+	// A more sophisticated implementation would chunk results by maxKeys
+	output := &s3.ListObjectsV2Output{
+		Contents:       contents,
+		CommonPrefixes: commonPrefixes,
+		IsTruncated:    aws.Bool(!isLastPage),
+	}
+
+	// Call the callback with the output and whether this is the last page
+	shouldContinue := fn(output, isLastPage)
+
+	// In real S3, if callback returns false, we stop pagination
+	if !shouldContinue {
+		return nil
+	}
+
+	return nil
+}
+
+func (m *mockS3Client) CopyObjectWithContext(context.Context, *s3.CopyObjectInput, ...request.Option) (*s3.CopyObjectOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) UploadPartWithContext(context.Context, *s3.UploadPartInput, ...request.Option) (*s3.UploadPartOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) UploadPartCopyWithContext(context.Context, *s3.UploadPartCopyInput, ...request.Option) (*s3.UploadPartCopyOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) DeleteObjectsWithContext(aws.Context, *s3.DeleteObjectsInput, ...request.Option) (*s3.DeleteObjectsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockS3Client) GetObjectRequest(*s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
+	return nil, nil
+}
+
+func (m *mockS3Client) HeadObjectRequest(*s3.HeadObjectInput) (*request.Request, *s3.HeadObjectOutput) {
+	return nil, nil
+}

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -361,8 +361,9 @@ func TestClientTransport(t *testing.T) {
 			}
 
 			s3drv := drv.baseEmbed.Base.StorageDriver.(*driver)
+			s3Client := s3drv.S3.(*s3.S3)
 			if tc.skipverify {
-				tr, ok := s3drv.S3.Client.Config.HTTPClient.Transport.(*http.Transport)
+				tr, ok := s3Client.Client.Config.HTTPClient.Transport.(*http.Transport)
 				if !ok {
 					t.Fatal("unexpected driver transport")
 				}
@@ -379,7 +380,7 @@ func TestClientTransport(t *testing.T) {
 			}
 			// if tc.skipverify is false we do not override the driver
 			// HTTP client transport and leave it to the AWS SDK.
-			if s3drv.S3.Client.Config.HTTPClient.Transport != nil {
+			if s3Client.Config.HTTPClient.Transport != nil {
 				t.Errorf("unexpected S3 driver client transport")
 			}
 		})
@@ -415,7 +416,7 @@ func TestStorageClass(t *testing.T) {
 		defer s3Driver.Delete(ctx, filename)
 
 		driverUnwrapped := s3Driver.Base.StorageDriver.(*driver)
-		resp, err := driverUnwrapped.S3.GetObject(&s3.GetObjectInput{
+		resp, err := driverUnwrapped.S3.GetObjectWithContext(context.Background(), &s3.GetObjectInput{
 			Bucket: aws.String(driverUnwrapped.Bucket),
 			Key:    aws.String(driverUnwrapped.s3Path(filename)),
 		})
@@ -1129,5 +1130,66 @@ func compareWalked(t *testing.T, expected, walked []string) {
 		if walked[i] != expected[i] {
 			t.Fatalf("walked in unexpected order: expected %s; walked %s", expected, walked)
 		}
+	}
+}
+
+func TestGetInitialPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		from       string
+		startAfter string
+		expected   string
+	}{
+		{
+			name:       "empty strings",
+			from:       "",
+			startAfter: "",
+			expected:   "",
+		},
+		{
+			name:       "startAfter ending in _manifests",
+			from:       "docker/registry/v2/repositories/",
+			startAfter: "docker/registry/v2/repositories/cloud/cs-artemisregister/_manifests",
+			expected:   "docker/registry/v2/repositories/cloud",
+		},
+		{
+			name:       "deeper path ending in _manifests",
+			from:       "/v2/repositories",
+			startAfter: "/v2/repositories/myrepo/subpath/_manifests",
+			expected:   "/v2/repositories/myrepo",
+		},
+		{
+			name:       "nested org/project ending in _manifests",
+			from:       "/v2/repositories",
+			startAfter: "/v2/repositories/org/project/_manifests",
+			expected:   "/v2/repositories/org",
+		},
+		{
+			name:       "from is root ending in _manifests",
+			from:       "/",
+			startAfter: "/v2/repositories/repo/_manifests",
+			expected:   "/v2/repositories",
+		},
+		{
+			name:       "multiple levels ending in _manifests",
+			from:       "/v2",
+			startAfter: "/v2/repositories/a/b/c/_manifests",
+			expected:   "/v2/repositories/a/b",
+		},
+		{
+			name:       "nested path without underscore directory",
+			from:       "",
+			startAfter: "/mycompany/another/nested/app",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getInitialPath(tt.startAfter)
+			if result != tt.expected {
+				t.Errorf("getInitialPath(%q, %q) = %q, want %q", tt.from, tt.startAfter, result, tt.expected)
+			}
+		})
 	}
 }

--- a/registry/storage/driver/s3-aws/walk_delimiter.go
+++ b/registry/storage/driver/s3-aws/walk_delimiter.go
@@ -1,0 +1,363 @@
+package s3
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/distribution/distribution/v3/internal/dcontext"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+)
+
+type walkItem struct {
+	path       string
+	startAfter string
+}
+
+// getInitialPath optimizes the walk start position by finding the deepest common parent
+// directory before a repository-specific directory (one that starts with underscore).
+//
+// For Docker Registry paths like /v2/repositories/org/repo/_manifests, this returns
+// /v2/repositories/org (the parent of the repository), allowing the walk to skip
+// listing from the root and start closer to the target.
+//
+// Returns empty string if:
+//   - startAfter is empty
+//   - No underscore-prefixed directory is found (not a registry path)
+//   - The repository would be at the root level
+func getInitialPath(startAfter string) string {
+	if startAfter == "" {
+		return ""
+	}
+
+	pathComponents := strings.Split(startAfter, "/")
+
+	// Find the rightmost underscore-prefixed directory (e.g., _manifests, _layers)
+	underscoreDirIndex := -1
+	for i := len(pathComponents) - 1; i >= 0; i-- {
+		if strings.HasPrefix(pathComponents[i], "_") {
+			underscoreDirIndex = i
+			break
+		}
+	}
+
+	if underscoreDirIndex == -1 {
+		return "" // Not a registry-structured path
+	}
+
+	// The repository name is immediately before the underscore directory
+	// Return the parent of the repository (one level up)
+	repoIndex := underscoreDirIndex - 1
+	if repoIndex <= 0 {
+		return "" // Repository is at root level
+	}
+
+	parentIndex := repoIndex
+	return strings.Join(pathComponents[0:parentIndex], "/")
+}
+
+// buildInitialStack creates the initial directory stack for walking.
+// The stack contains all directories that need to be explored, with startAfter
+// propagated to help skip already-processed paths.
+//
+// The function optimizes the starting point using getInitialPath to avoid
+// unnecessary directory traversal when possible.
+func buildInitialStack(from, startAfter string) []walkItem {
+	if startAfter == "" {
+		return []walkItem{{path: from, startAfter: ""}}
+	}
+
+	initialPath := getInitialPath(startAfter)
+
+	// Case 1: initialPath matches from exactly (both non-empty)
+	if initialPath != "" && initialPath == from {
+		return []walkItem{{path: from, startAfter: startAfter}}
+	}
+
+	// Case 2: No underscore dirs found and from is empty
+	// Build intermediate paths from startAfter to ensure proper traversal
+	if initialPath == "" && from == "" {
+		return buildIntermediatePaths(startAfter)
+	}
+
+	// Case 3: No underscore dirs found but from is set
+	if initialPath == "" {
+		return []walkItem{{path: from, startAfter: startAfter}}
+	}
+
+	// Case 4: Build path hierarchy from 'from' down to 'initialPath'
+	return buildPathHierarchy(from, initialPath, startAfter)
+}
+
+// buildIntermediatePaths creates a stack of all parent directories
+// up to (but not including) the last component of startAfter.
+// Example: "/a/b/c/d" -> ["", "/a", "/a/b", "/a/b/c"]
+func buildIntermediatePaths(startAfter string) []walkItem {
+	parts := strings.Split(strings.Trim(startAfter, "/"), "/")
+	paths := make([]string, 0, len(parts))
+	paths = append(paths, "")
+
+	currentPath := ""
+	for i := 0; i < len(parts)-1; i++ {
+		currentPath = currentPath + "/" + parts[i]
+		paths = append(paths, currentPath)
+	}
+
+	stack := make([]walkItem, 0, len(paths))
+	for _, p := range paths {
+		stack = append(stack, walkItem{path: p, startAfter: startAfter})
+	}
+	return stack
+}
+
+// buildPathHierarchy creates a stack containing all paths from 'from' down to 'to'.
+// Example: from="/", to="/a/b" -> ["/", "/a", "/a/b"]
+func buildPathHierarchy(from, to, startAfter string) []walkItem {
+	var paths []string
+	paths = append(paths, from)
+
+	// Only build intermediate paths if 'to' is under 'from'
+	if from == "" || strings.HasPrefix(to, from) {
+		relativePath := strings.TrimPrefix(to, from)
+		if from == "/" || from == "" {
+			relativePath = strings.TrimPrefix(to, "")
+		}
+		relativePath = strings.Trim(relativePath, "/")
+
+		if relativePath != "" {
+			parts := strings.Split(relativePath, "/")
+			currentPath := from
+			if currentPath == "/" || currentPath == "" {
+				currentPath = ""
+			}
+
+			for _, part := range parts {
+				currentPath = currentPath + "/" + part
+				if currentPath != to {
+					paths = append(paths, currentPath)
+				}
+			}
+		}
+	}
+
+	// Add the final path if different from start
+	if to != from {
+		paths = append(paths, to)
+	}
+
+	stack := make([]walkItem, 0, len(paths))
+	for _, p := range paths {
+		stack = append(stack, walkItem{path: p, startAfter: startAfter})
+	}
+	return stack
+}
+
+// shouldSkipDirectory determines if a directory should be skipped based on the startAfter hint.
+// It returns true if the directory should be skipped (already processed or needs to be filtered).
+func shouldSkipDirectory(dirPath, startAfter string) bool {
+	if startAfter == "" {
+		return false
+	}
+
+	// Skip if dirPath <= startAfter lexicographically
+	return dirPath <= startAfter
+}
+
+// doWalkWithDelimiter implements directory traversal using S3's delimiter feature.
+// This performs hierarchical walking by listing one directory level at a time,
+// which is more efficient than the flat listing approach when StartAfter hints are used.
+func (d *driver) doWalkWithDelimiter(parentCtx context.Context, objectCount *int64, from, startAfter string, f storagedriver.WalkFn) error {
+	prefix := d.getPathPrefix()
+	ctx, done := dcontext.WithTrace(parentCtx)
+	defer done("s3aws.doWalkWithDelimiter(%s)", from)
+
+	skipDirs := make(map[string]bool)
+	stack := buildInitialStack(from, startAfter)
+
+	for len(stack) > 0 {
+		current := popStack(&stack)
+
+		dirs, files, err := d.listDirectory(ctx, current, prefix, skipDirs)
+		if err != nil {
+			return err
+		}
+
+		// Process directories and collect child directories for further traversal
+		childDirs, err := d.processDirectories(dirs, current, skipDirs, objectCount, f)
+		if err != nil {
+			if err == storagedriver.ErrFilledBuffer {
+				return nil
+			}
+			return err
+		}
+
+		// Push child directories onto stack in reverse order for depth-first traversal
+		d.pushChildDirectories(&stack, childDirs, current, skipDirs)
+
+		// Process files at this level
+		if err := d.processFiles(files, current, objectCount, f); err != nil {
+			if err == storagedriver.ErrFilledBuffer {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getPathPrefix returns the prefix to add to registry paths based on root directory config
+func (d *driver) getPathPrefix() string {
+	if d.s3Path("") == "" {
+		return "/"
+	}
+	return ""
+}
+
+// popStack removes and returns the top item from the stack
+func popStack(stack *[]walkItem) walkItem {
+	current := (*stack)[len(*stack)-1]
+	*stack = (*stack)[:len(*stack)-1]
+	return current
+}
+
+// listDirectory lists all subdirectories and files at the current directory level
+func (d *driver) listDirectory(ctx context.Context, current walkItem, prefix string, skipDirs map[string]bool) ([]string, []storagedriver.FileInfoInternal, error) {
+	s3Prefix := d.s3Path(current.path)
+	if !strings.HasSuffix(s3Prefix, "/") {
+		s3Prefix = s3Prefix + "/"
+	}
+
+	listInput := &s3.ListObjectsV2Input{
+		Bucket:    aws.String(d.Bucket),
+		Prefix:    aws.String(s3Prefix),
+		Delimiter: aws.String("/"),
+		MaxKeys:   aws.Int64(listMax),
+	}
+
+	if current.startAfter != "" && strings.HasPrefix(current.startAfter, current.path) {
+		listInput.StartAfter = aws.String(d.s3Path(current.startAfter))
+	}
+
+	var dirs []string
+	var files []storagedriver.FileInfoInternal
+
+	err := d.S3.ListObjectsV2PagesWithContext(ctx, listInput, func(output *s3.ListObjectsV2Output, lastPage bool) bool {
+		// Collect directories (common prefixes)
+		for _, commonPrefix := range output.CommonPrefixes {
+			dirPath := strings.Replace(strings.TrimSuffix(*commonPrefix.Prefix, "/"), d.s3Path(""), prefix, 1)
+			if !skipDirs[dirPath] {
+				dirs = append(dirs, dirPath)
+			}
+		}
+
+		// Collect files
+		for _, obj := range output.Contents {
+			filePath := strings.Replace(*obj.Key, d.s3Path(""), prefix, 1)
+			if !strings.HasSuffix(filePath, "/") {
+				files = append(files, storagedriver.FileInfoInternal{
+					FileInfoFields: storagedriver.FileInfoFields{
+						IsDir:   false,
+						Size:    *obj.Size,
+						ModTime: *obj.LastModified,
+						Path:    filePath,
+					},
+				})
+			}
+		}
+
+		return true
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Sort for deterministic ordering
+	sort.Strings(dirs)
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path() < files[j].Path()
+	})
+
+	return dirs, files, nil
+}
+
+// processDirectories calls the walk function on each directory and returns
+// the list of directories that should be traversed further
+func (d *driver) processDirectories(dirs []string, current walkItem, skipDirs map[string]bool, objectCount *int64, f storagedriver.WalkFn) ([]string, error) {
+	childDirs := make([]string, 0, len(dirs))
+
+	for _, dirPath := range dirs {
+		// Skip directories based on startAfter hint
+		if shouldSkipDirectory(dirPath, current.startAfter) {
+			skipDirs[dirPath] = true
+			continue
+		}
+
+		walkInfo := storagedriver.FileInfoInternal{
+			FileInfoFields: storagedriver.FileInfoFields{
+				IsDir: true,
+				Path:  dirPath,
+			},
+		}
+
+		*objectCount++
+		err := f(walkInfo)
+
+		if err != nil {
+			if err == storagedriver.ErrSkipDir {
+				skipDirs[dirPath] = true
+				continue
+			}
+			if err == storagedriver.ErrFilledBuffer {
+				return nil, storagedriver.ErrFilledBuffer
+			}
+			return nil, err
+		}
+
+		childDirs = append(childDirs, dirPath)
+	}
+
+	return childDirs, nil
+}
+
+// pushChildDirectories adds child directories to the stack for further traversal.
+// Directories are pushed in reverse order so they pop in forward (alphabetical) order.
+func (d *driver) pushChildDirectories(stack *[]walkItem, childDirs []string, current walkItem, skipDirs map[string]bool) {
+	for i := len(childDirs) - 1; i >= 0; i-- {
+		dirPath := childDirs[i]
+		if skipDirs[dirPath] {
+			continue
+		}
+
+		// Only pass startAfter to child if startAfter is within that child's path
+		childStartAfter := ""
+		if current.startAfter != "" && strings.HasPrefix(current.startAfter, dirPath+"/") {
+			childStartAfter = current.startAfter
+		}
+
+		*stack = append(*stack, walkItem{path: dirPath, startAfter: childStartAfter})
+	}
+}
+
+// processFiles calls the walk function on each file at the current level
+func (d *driver) processFiles(files []storagedriver.FileInfoInternal, current walkItem, objectCount *int64, f storagedriver.WalkFn) error {
+	for _, fileInfo := range files {
+		// Skip files that are <= startAfter
+		if current.startAfter != "" && fileInfo.Path() <= current.startAfter {
+			continue
+		}
+
+		*objectCount++
+		err := f(fileInfo)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/registry/storage/driver/s3-aws/walk_delimiter_test.go
+++ b/registry/storage/driver/s3-aws/walk_delimiter_test.go
@@ -1,0 +1,523 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/distribution/distribution/v3/registry/storage"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+)
+
+func TestDirectoryDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		prev     string
+		current  string
+		expected []string
+	}{
+		{
+			name:     "one level deep",
+			prev:     "/path/to/folder",
+			current:  "/path/to/folder/folder/file",
+			expected: []string{"/path/to/folder/folder"},
+		},
+		{
+			name:     "different siblings",
+			prev:     "/path/to/folder/folder1",
+			current:  "/path/to/folder/folder2/file",
+			expected: []string{"/path/to/folder/folder2"},
+		},
+		{
+			name:     "different sibling files",
+			prev:     "/path/to/folder/folder1/file",
+			current:  "/path/to/folder/folder2/file",
+			expected: []string{"/path/to/folder/folder2"},
+		},
+		{
+			name:     "two levels deep",
+			prev:     "/path/to/folder/folder1/file",
+			current:  "/path/to/folder/folder2/folder1/file",
+			expected: []string{"/path/to/folder/folder2", "/path/to/folder/folder2/folder1"},
+		},
+		{
+			name:     "from root",
+			prev:     "/",
+			current:  "/path/to/folder/folder/file",
+			expected: []string{"/path", "/path/to", "/path/to/folder", "/path/to/folder/folder"},
+		},
+		{
+			name:     "empty prev",
+			prev:     "",
+			current:  "/path/to/file",
+			expected: []string{},
+		},
+		{
+			name:     "empty current",
+			prev:     "/path",
+			current:  "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := directoryDiff(tt.prev, tt.current)
+			if len(result) != len(tt.expected) {
+				t.Errorf("directoryDiff() = %v, expected %v", result, tt.expected)
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("directoryDiff()[%d] = %q, expected %q", i, result[i], tt.expected[i])
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestDriverS3Path(t *testing.T) {
+	tests := []struct {
+		name          string
+		rootDirectory string
+		path          string
+		expected      string
+	}{
+		{
+			name:          "empty root with slash path",
+			rootDirectory: "",
+			path:          "/file",
+			expected:      "file",
+		},
+		{
+			name:          "empty root with nested path",
+			rootDirectory: "",
+			path:          "/folder/file",
+			expected:      "folder/file",
+		},
+		{
+			name:          "root directory with slash",
+			rootDirectory: "/root",
+			path:          "/file",
+			expected:      "root/file",
+		},
+		{
+			name:          "root directory without trailing slash",
+			rootDirectory: "root",
+			path:          "/folder/file",
+			expected:      "root/folder/file",
+		},
+		{
+			name:          "root directory with trailing slash",
+			rootDirectory: "root/",
+			path:          "/folder/file",
+			expected:      "root/folder/file",
+		},
+		{
+			name:          "nested root directory",
+			rootDirectory: "docker/registry/v2/repositories",
+			path:          "/myrepo/_manifests",
+			expected:      "docker/registry/v2/repositories/myrepo/_manifests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &driver{
+				RootDirectory: tt.rootDirectory,
+			}
+			result := d.s3Path(tt.path)
+			if result != tt.expected {
+				t.Errorf("s3Path(%q) with root %q = %q, expected %q", tt.path, tt.rootDirectory, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDriverS3PathWithTrailingSlash(t *testing.T) {
+	d := &driver{
+		RootDirectory: "testroot",
+	}
+
+	path := "/folder1/subfolder1"
+	s3Prefix := d.s3Path(path)
+
+	if s3Prefix != "testroot/folder1/subfolder1" {
+		t.Errorf("s3Path(%q) = %q, expected %q", path, s3Prefix, "testroot/folder1/subfolder1")
+	}
+
+	// Ensure trailing slash is not added by s3Path itself
+	// (walkDirectory should add it)
+	if s3Prefix[len(s3Prefix)-1] == '/' {
+		t.Errorf("s3Path should not add trailing slash, got %q", s3Prefix)
+	}
+}
+
+func TestBuildInitialStack(t *testing.T) {
+	tests := []struct {
+		name       string
+		from       string
+		startAfter string
+		expected   []walkItem
+	}{
+		{
+			name:       "no startAfter",
+			from:       "/",
+			startAfter: "",
+			expected: []walkItem{
+				{path: "/", startAfter: ""},
+			},
+		},
+		{
+			name:       "startAfter at root level",
+			from:       "/",
+			startAfter: "/library/nginx/_manifests",
+			expected: []walkItem{
+				{path: "/", startAfter: "/library/nginx/_manifests"},
+				{path: "/library", startAfter: "/library/nginx/_manifests"},
+			},
+		},
+		{
+			name:       "startAfter deeply nested",
+			from:       "/",
+			startAfter: "/a/b/c/repo/_manifests",
+			expected: []walkItem{
+				{path: "/", startAfter: "/a/b/c/repo/_manifests"},
+				{path: "/a", startAfter: "/a/b/c/repo/_manifests"},
+				{path: "/a/b", startAfter: "/a/b/c/repo/_manifests"},
+				{path: "/a/b/c", startAfter: "/a/b/c/repo/_manifests"},
+			},
+		},
+		{
+			name:       "from equals initialPath",
+			from:       "/library",
+			startAfter: "/library/nginx/_manifests",
+			expected: []walkItem{
+				{path: "/library", startAfter: "/library/nginx/_manifests"},
+			},
+		},
+		{
+			name:       "from is nested, startAfter deeper",
+			from:       "/a/b",
+			startAfter: "/a/b/c/d/repo/_manifests",
+			expected: []walkItem{
+				{path: "/a/b", startAfter: "/a/b/c/d/repo/_manifests"},
+				{path: "/a/b/c", startAfter: "/a/b/c/d/repo/_manifests"},
+				{path: "/a/b/c/d", startAfter: "/a/b/c/d/repo/_manifests"},
+			},
+		},
+		{
+			name:       "empty from with deeply nested startAfter",
+			from:       "",
+			startAfter: "/mycompany/another/nested/app",
+			expected: []walkItem{
+				{path: "", startAfter: "/mycompany/another/nested/app"},
+				{path: "/mycompany", startAfter: "/mycompany/another/nested/app"},
+				{path: "/mycompany/another", startAfter: "/mycompany/another/nested/app"},
+				{path: "/mycompany/another/nested", startAfter: "/mycompany/another/nested/app"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildInitialStack(tt.from, tt.startAfter)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("buildInitialStack() returned %d items, expected %d", len(result), len(tt.expected))
+				t.Errorf("result: %+v", result)
+				t.Errorf("expected: %+v", tt.expected)
+				return
+			}
+
+			for i := range result {
+				if result[i].path != tt.expected[i].path || result[i].startAfter != tt.expected[i].startAfter {
+					t.Errorf("buildInitialStack()[%d] = %+v, expected %+v", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDoWalkWithDelimiterMock(t *testing.T) {
+	mockClient := newMockS3Client()
+
+	// Create realistic Docker registry paths
+	// Structure: docker/registry/v2/repositories/{repo}/_manifests, _layers, _uploads
+
+	// Top-level repositories
+	mockClient.addObject("docker/registry/v2/repositories/postgres/_manifests/revisions/sha256/aaa111/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/postgres/_manifests/tags/16/current/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/postgres/_layers/sha256/bbb222/link", 71)
+
+	mockClient.addObject("docker/registry/v2/repositories/redis/_manifests/revisions/sha256/ccc333/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/redis/_manifests/tags/7/current/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/redis/_layers/sha256/ddd444/link", 71)
+
+	mockClient.addObject("docker/registry/v2/repositories/mysql/_manifests/revisions/sha256/eee555/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/mysql/_layers/sha256/fff666/link", 71)
+
+	// Nested repositories
+	mockClient.addObject("docker/registry/v2/repositories/library/nginx/_manifests/revisions/sha256/abc123/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/library/nginx/_manifests/tags/latest/current/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/library/nginx/_layers/sha256/def456/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/library/nginx/_uploads/uuid-123/startedat", 30)
+
+	mockClient.addObject("docker/registry/v2/repositories/library/ubuntu/_manifests/revisions/sha256/xyz789/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/library/ubuntu/_layers/sha256/aaa999/link", 71)
+
+	mockClient.addObject("docker/registry/v2/repositories/mycompany/myapp/_manifests/revisions/sha256/bbb222/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/mycompany/myapp/_manifests/tags/v1.0/current/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/mycompany/myapp/_layers/sha256/ccc333/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/mycompany/myapp/_layers/sha256/ddd444/link", 71)
+
+	mockClient.addObject("docker/registry/v2/repositories/mycompany/another/nested/app/_manifests/revisions/sha256/eee555/link", 71)
+
+	// Add repos that come alphabetically BEFORE library to test proper handling
+	mockClient.addObject("docker/registry/v2/repositories/alpine/_manifests/revisions/sha256/aaa111/link", 71)
+	mockClient.addObject("docker/registry/v2/repositories/busybox/_manifests/revisions/sha256/bbb222/link", 71)
+
+	d := &driver{
+		S3:               mockClient,
+		Bucket:           "test-bucket",
+		RootDirectory:    "docker/registry/v2/repositories",
+		UseDelimiterWalk: true,
+	}
+
+	tests := []struct {
+		name           string
+		from           string
+		startAfter     string
+		stopAt         string
+		expectedWalked []string
+		expectedRepos  []string
+	}{
+		{
+			name:       "catalog: walk all repos and skip underscore dirs",
+			from:       "/",
+			startAfter: "",
+			expectedRepos: []string{
+				"alpine",
+				"busybox",
+				"library/nginx",
+				"library/ubuntu",
+				"mycompany/another/nested/app",
+				"mycompany/myapp",
+				"mysql",
+				"postgres",
+				"redis",
+			},
+		},
+		{
+			name:       "walk from specific repo",
+			from:       "/library/nginx",
+			startAfter: "",
+			expectedRepos: []string{
+				"library/nginx",
+			},
+			expectedWalked: []string{
+				"/library/nginx/_layers",
+				"/library/nginx/_manifests",
+				"/library/nginx/_uploads",
+			},
+		},
+		{
+			name:       "start after library/nginx",
+			from:       "/",
+			startAfter: "/library/nginx/_uploads/uuid-123/startedat",
+			expectedRepos: []string{
+				"library/ubuntu",
+				"mycompany/another/nested/app",
+				"mycompany/myapp",
+				"mysql",
+				"postgres",
+				"redis",
+			},
+		},
+		{
+			name:       "start after deeply nested repo",
+			from:       "",
+			startAfter: "/mycompany/another/nested/app",
+			expectedRepos: []string{
+				"mycompany/myapp",
+				"mysql",
+				"postgres",
+				"redis",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var walked []string
+			var repos []string
+			var mu sync.Mutex
+			var objectCount int64
+			// root := d.RootDirectory
+
+			walkFn := func(fileInfo storagedriver.FileInfo) error {
+				mu.Lock()
+				walked = append(walked, fileInfo.Path())
+				mu.Unlock()
+
+				// Always use HandleRepository to mimic catalog behavior
+				// Root is empty "" because paths from walk are registry-relative (start with /)
+				return storage.HandleRepository(fileInfo, "", "", func(repoPath string) error {
+					mu.Lock()
+					repos = append(repos, repoPath)
+					mu.Unlock()
+					return nil
+				})
+			}
+
+			err := d.doWalkWithDelimiter(context.Background(), &objectCount, tt.from, tt.startAfter, walkFn)
+			if err != nil {
+				t.Fatalf("doWalkWithDelimiter() error = %v", err)
+			}
+
+			// Check repos
+			if len(repos) != len(tt.expectedRepos) {
+				t.Errorf("found %d repos, expected %d", len(repos), len(tt.expectedRepos))
+				t.Errorf("repos: %v", repos)
+				t.Errorf("expected: %v", tt.expectedRepos)
+				return
+			}
+
+			for i := range repos {
+				if repos[i] != tt.expectedRepos[i] {
+					t.Errorf("repos[%d] = %q, expected %q", i, repos[i], tt.expectedRepos[i])
+				}
+			}
+
+			// Check walked paths if expectedWalked is set
+			if tt.expectedWalked != nil {
+				if len(walked) != len(tt.expectedWalked) {
+					t.Errorf("walked %d items, expected %d", len(walked), len(tt.expectedWalked))
+					t.Errorf("walked: %v", walked)
+					t.Errorf("expected: %v", tt.expectedWalked)
+					return
+				}
+
+				for i := range walked {
+					if walked[i] != tt.expectedWalked[i] {
+						t.Errorf("walked[%d] = %q, expected %q", i, walked[i], tt.expectedWalked[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDoWalkWithDelimiterConcurrency(t *testing.T) {
+	mockClient := newMockS3Client()
+
+	// Create many repos to test concurrent recursion
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 5; j++ {
+			mockClient.addObject(fmt.Sprintf("docker/registry/v2/repositories/repo%d/_manifests/revisions/sha256/hash%d/link", i, j), 71)
+		}
+	}
+
+	d := &driver{
+		S3:               mockClient,
+		Bucket:           "test-bucket",
+		RootDirectory:    "docker/registry/v2/repositories",
+		UseDelimiterWalk: true,
+	}
+
+	var walked []string
+	var mu sync.Mutex
+	var objectCount int64
+
+	walkFn := func(fileInfo storagedriver.FileInfo) error {
+		mu.Lock()
+		walked = append(walked, fileInfo.Path())
+		mu.Unlock()
+		return nil
+	}
+
+	err := d.doWalkWithDelimiter(context.Background(), &objectCount, "/", "", walkFn)
+	if err != nil {
+		t.Fatalf("doWalkWithDelimiter() error = %v", err)
+	}
+
+	// Should have many directories + 50 files
+	// Each repo has: repo%d, _manifests, revisions, sha256, hash%d (5 times), link (5 times)
+	// 10 repos * (1 + 1 + 1 + 1 + 5 + 5) = 10 * 14 = 140 items
+	expectedCount := 140
+	if len(walked) != expectedCount {
+		t.Errorf("Expected %d items, got %d", expectedCount, len(walked))
+	}
+}
+
+func TestShouldSkipDirectory(t *testing.T) {
+	tests := []struct {
+		name        string
+		dirPath     string
+		startAfter  string
+		shouldSkip  bool
+		description string
+	}{
+		{
+			name:        "no startAfter",
+			dirPath:     "/mycompany/myapp",
+			startAfter:  "",
+			shouldSkip:  false,
+			description: "When startAfter is empty, never skip",
+		},
+		{
+			name:        "dirPath equals startAfter",
+			dirPath:     "/mycompany/another/nested/app",
+			startAfter:  "/mycompany/another/nested/app",
+			shouldSkip:  true,
+			description: "When dirPath equals startAfter, skip it",
+		},
+		{
+			name:        "dirPath before startAfter",
+			dirPath:     "/alpine",
+			startAfter:  "/library/nginx/_manifests",
+			shouldSkip:  true,
+			description: "Alpine comes before library, should skip",
+		},
+		{
+			name:        "dirPath after startAfter",
+			dirPath:     "/mycompany/myapp",
+			startAfter:  "/mycompany/another/nested/app",
+			shouldSkip:  false,
+			description: "myapp comes after another/nested/app, should not skip",
+		},
+		{
+			name:        "sibling directory after startAfter",
+			dirPath:     "/library/ubuntu",
+			startAfter:  "/library/nginx/_uploads/uuid-123/startedat",
+			shouldSkip:  false,
+			description: "ubuntu comes after nginx alphabetically, should not skip",
+		},
+		{
+			name:        "directory at root level",
+			dirPath:     "/mysql",
+			startAfter:  "/mycompany/another/nested/app",
+			shouldSkip:  false,
+			description: "mysql (root level) comes after mycompany at first character, should not skip",
+		},
+		{
+			name:        "nested dir within startAfter path",
+			dirPath:     "/mycompany/another",
+			startAfter:  "/mycompany/another/nested/app",
+			shouldSkip:  true,
+			description: "Parent directory of startAfter should be skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSkipDirectory(tt.dirPath, tt.startAfter)
+			if result != tt.shouldSkip {
+				t.Errorf("%s: shouldSkipDirectory(%q, %q) = %v, want %v",
+					tt.description, tt.dirPath, tt.startAfter, result, tt.shouldSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When walking without a delimiter it requires iterating over every file in s3 including all layers + manifest objects. Everything is filtered client side. For large registries this will likely time out. Use delimiter + a stack to process directories, and interpret directories as repositories.