### PR TITLE
fix: correct Ed25519 JWK thumbprint `kty` from `"OTP"` to `"OKP"`

### DIFF
--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -90,7 +90,7 @@ func getJWKThumbprint(publickey crypto.PublicKey, skipED25519 bool) string {
 		}
 		x := base64.RawURLEncoding.EncodeToString(pubkey)
 
-		return hashAndEncode(fmt.Sprintf(`{"crv":"Ed25519","kty":"OTP","x":"%s"}`, x))
+		return hashAndEncode(fmt.Sprintf(`{"crv":"Ed25519","kty":"OKP","x":"%s"}`, x))
 	default:
 		return ""
 	}

--- a/registry/auth/token/util_test.go
+++ b/registry/auth/token/util_test.go
@@ -1,0 +1,27 @@
+package token
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+)
+
+func TestEd25519JWKThumbprint(t *testing.T) {
+	// Test vector from RFC 8037 Appendix A.2:
+	// https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.2
+	examplePubKeyBase64 := "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+	// Canonical thumbprint from RFC 8037 Appendix A.3:
+	// https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.3
+	expected := "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"
+
+	pubBytes, err := base64.RawURLEncoding.DecodeString(examplePubKeyBase64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey := ed25519.PublicKey(pubBytes)
+
+	got := GetJWKThumbprint(publicKey)
+	if got != expected {
+		t.Errorf("GetJWKThumbprint(ed25519) = %q, expected %q", got, expected)
+	}
+}


### PR DESCRIPTION
Turns out the correct Key Type (per [RFC 8037](https://www.rfc-editor.org/rfc/rfc8037#section-2)) is `OKP` (Octet Key Pair), not `OTP`.