### PR TITLE
fix: report error in `DeleteManifest` when `Delete` returns `ErrDigestUnsupported`

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -461,8 +461,7 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 	err = manifests.Delete(imh, imh.Digest)
 	if err != nil {
 		switch err {
-		case digest.ErrDigestUnsupported:
-		case digest.ErrDigestInvalidFormat:
+		case digest.ErrDigestUnsupported, digest.ErrDigestInvalidFormat:
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeDigestInvalid)
 			return
 		case distribution.ErrBlobUnknown:


### PR DESCRIPTION
I believe the prior implementation intended to combine the case for handling `digest.ErrDigestUnsupported` and `digest.ErrDigestInvalidFormat` errors, but inadvertently it ended up skipping over the error instead.

This fixes the handling.

I had also considered explicitly handling `digest.ErrDigestUnsupported` by itself as:
```go
		case digest.ErrDigestUnsupported:
			imh.Errors = append(imh.Errors, errcode.ErrorCodeDigestInvalid)
			return
```

But given that there probably isn't a more appropriate error code for `ErrDigestUnsupported`, this seems like a reasonable alternative.

I'm quite certain I've actually ran into this issue in production previously, but didn't think to look into the underlying issue deeply enough to come across this.