### PR TITLE
fix: set MD5 on GCS writer before first `Write` call in `putContent`

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -423,7 +423,7 @@ func (d *driver) putContent(ctx context.Context, obj *storage.ObjectHandle, cont
 	wc.ContentType = contentType
 	wc.ChunkSize = d.chunkSize
 
-	// NOTE(milosgajdos): Apparently it's possible to to upload 0-byte content to GCS.
+	// NOTE(milosgajdos): Apparently it's possible to upload 0-byte content to GCS.
 	// Setting MD5 on the Writer helps to prevent presisting that data.
 	// If set, the uploaded data is rejected if its MD5 hash does not match this field.
 	// See: https://pkg.go.dev/cloud.google.com/go/storage#ObjectAttrs


### PR DESCRIPTION
Per the comment on [`storage.Writer`](https://pkg.go.dev/cloud.google.com/go/storage#Writer):
```go
// ObjectAttrs are optional attributes to set on the object. Any attributes
// must be initialized before the first Write call. Nil or zero-valued
// attributes are ignored.
```
Therefore, MD5 has to be set before the first to call to Write.