### PR TITLE
fix: handle nil platform in `platformMustExist` for OCI index validation

### DIFF
--- a/registry/storage/manifestlisthandler.go
+++ b/registry/storage/manifestlisthandler.go
@@ -113,6 +113,13 @@ func (ms *manifestListHandler) platformMustExist(descriptor v1.Descriptor) bool 
 
 	imagePlatform := descriptor.Platform
 
+	// Platform can be nil per the OCI image spec (e.g., attestation manifests, SBOMs).
+	// A platform-less descriptor cannot match any configured platform, so skip existence
+	// validation for it.
+	if imagePlatform == nil {
+		return false
+	}
+
 	// If the platform matches a platform that is configured to validate, we must check the existence.
 	for _, platform := range ms.validateImageIndexes.imagePlatforms {
 		if imagePlatform.Architecture == platform.architecture &&

--- a/registry/storage/manifestlisthandler_test.go
+++ b/registry/storage/manifestlisthandler_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestPlatformMustExist(t *testing.T) {
+	platforms := []platform{{architecture: "amd64", os: "linux"}}
+
+	tests := []struct {
+		name       string
+		platforms  []platform
+		descriptor *v1.Platform
+		expected   bool
+	}{
+		// No filter
+		{
+			name:       "no filter/nil platform",
+			platforms:  nil,
+			descriptor: nil,
+			expected:   true,
+		},
+		{
+			name:       "no filter/with platform",
+			platforms:  nil,
+			descriptor: &v1.Platform{Architecture: "amd64", OS: "linux"},
+			expected:   true,
+		},
+		// With filter
+		{
+			name:       "with filter/nil platform",
+			platforms:  platforms,
+			descriptor: nil,
+			expected:   false,
+		},
+		{
+			name:       "with filter/matching platform",
+			platforms:  platforms,
+			descriptor: &v1.Platform{Architecture: "amd64", OS: "linux"},
+			expected:   true,
+		},
+		{
+			name:       "with filter/non-matching platform",
+			platforms:  platforms,
+			descriptor: &v1.Platform{Architecture: "arm64", OS: "linux"},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &manifestListHandler{
+				validateImageIndexes: validateImageIndexes{
+					imagesExist:    true,
+					imagePlatforms: tt.platforms,
+				},
+			}
+			desc := v1.Descriptor{
+				MediaType: v1.MediaTypeImageManifest,
+				Digest:    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Size:      42,
+				Platform:  tt.descriptor,
+			}
+			if got := handler.platformMustExist(desc); got != tt.expected {
+				t.Errorf("platformMustExist() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`platformMustExist` method dereferences `descriptor.Platform` without a nil check when comparing against configured image platforms. Since the OCI image spec permits `platform` to be omitted (it's listed as optional field), Distribution needs to account for that possibility for types of manifests where that may be the case (such as attestations or SBOMs).