### PR TITLE
fix: nil-check scheduler in `proxyingRegistry.Close()`

### DIFF
--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -229,6 +229,9 @@ type Closer interface {
 }
 
 func (pr *proxyingRegistry) Close() error {
+	if pr.scheduler == nil {
+		return nil
+	}
 	return pr.scheduler.Stop()
 }
 

--- a/registry/proxy/proxyregistry_test.go
+++ b/registry/proxy/proxyregistry_test.go
@@ -1,0 +1,17 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestProxyingRegistryCloseWithoutScheduler(t *testing.T) {
+	pr := &proxyingRegistry{
+		scheduler: nil,
+	}
+
+	// verify that `Close()` does not panic when the scheduler is nil
+	err := pr.Close()
+	if err != nil {
+		t.Fatalf("Close() returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
If the Proxy.TTL configuration is set to  0, [`NewRegistryPullThroughCache` skips creating a `TTLExpirationScheduler`](https://github.com/distribution/distribution/blob/main/registry/proxy/proxyregistry.go#L48-L58). 

When the system is being shut down and `Close()` gets called, the internal method call to `pr.scheduler.Stop()` causes causing a nil pointer dereference panic.