### PR TITLE
Add params for sorting with modified at in tags/list

### DIFF
--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1147,6 +1147,7 @@ The error codes encountered via the API are enumerated in the following table:
  `NAME_INVALID` | invalid repository name | Invalid repository name encountered either during manifest validation or any API operation.
  `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry.
  `PAGINATION_NUMBER_INVALID` | invalid number of results requested | Returned when the "n" parameter (number of results to return) is not an integer, "n" is negative or "n" is bigger than the maximum allowed.
+ `QUERY_PARAMETER_INVALID` | invalid query parameter value | Returned when a query parameter contains an unrecognised or unsupported value.
  `RANGE_INVALID` | invalid content range | When a layer is uploaded, the provided range is checked against the uploaded chunk. This error is returned if the range is out of order.
  `SIZE_INVALID` | provided length did not match content length | When a layer is uploaded, the provided size will be checked against the uploaded content. If they do not match, this error will be returned.
  `TAG_INVALID` | manifest tag did not match URI | During a manifest upload, if the tag in the manifest does not match the uri tag, this error will be returned.

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -224,6 +224,15 @@ var (
 		the maximum allowed.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})
+
+	// ErrorCodeQueryParameterInvalid is returned when a query parameter
+	// contains an unrecognised or unsupported value.
+	ErrorCodeQueryParameterInvalid = register(errGroup, ErrorDescriptor{
+		Value:          "QUERY_PARAMETER_INVALID",
+		Message:        "invalid query parameter value",
+		Description:    `Returned when a query parameter contains an unrecognised or unsupported value.`,
+		HTTPStatusCode: http.StatusBadRequest,
+	})
 )
 
 var (

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -669,6 +669,225 @@ func TestTagsAPIMaxTagsClamp(t *testing.T) {
 	}
 }
 
+// TestTagsAPISortedByUpdated tests the /v2/<name>/tags/list endpoint with sort=updated.
+func TestTagsAPISortedByUpdated(t *testing.T) {
+	env := newTestEnv(t, false)
+	defer env.Shutdown()
+
+	imageName, err := reference.WithName("test")
+	if err != nil {
+		t.Fatalf("unable to parse reference: %v", err)
+	}
+
+	// Create tags; order of creation intentionally differs from alphabetical order.
+	creationOrder := []string{"kb0j5", "2j2ar", "sb71y", "asj9e", "jyi7b"}
+	for _, tag := range creationOrder {
+		createRepository(env, t, imageName.Name(), tag)
+	}
+
+	t.Run("sort=updated returns all tags", func(t *testing.T) {
+		tagsURL, err := env.builder.BuildTagsURL(imageName, url.Values{"sort": []string{"updated"}})
+		if err != nil {
+			t.Fatalf("unexpected error building tags URL: %v", err)
+		}
+		resp, err := http.Get(tagsURL)
+		if err != nil {
+			t.Fatalf("unexpected error issuing request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var body tagsAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected error decoding response body: %v", err)
+		}
+
+		if body.Name != imageName.Name() {
+			t.Errorf("expected name %q, got %q", imageName.Name(), body.Name)
+		}
+
+		// All tags must be present.
+		if len(body.Tags) != len(creationOrder) {
+			t.Fatalf("expected %d tags, got %d", len(creationOrder), len(body.Tags))
+		}
+		got := make(map[string]bool, len(body.Tags))
+		for _, tag := range body.Tags {
+			got[tag] = true
+		}
+		for _, tag := range creationOrder {
+			if !got[tag] {
+				t.Errorf("tag %q missing from response", tag)
+			}
+		}
+	})
+
+	t.Run("sort=updated with n paginates correctly", func(t *testing.T) {
+		// Fetch first page.
+		tagsURL, err := env.builder.BuildTagsURL(imageName, url.Values{
+			"sort": []string{"updated"},
+			"n":    []string{"2"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error building tags URL: %v", err)
+		}
+		resp, err := http.Get(tagsURL)
+		if err != nil {
+			t.Fatalf("unexpected error issuing request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var firstPage tagsAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&firstPage); err != nil {
+			t.Fatalf("unexpected error decoding response body: %v", err)
+		}
+		if len(firstPage.Tags) != 2 {
+			t.Fatalf("expected 2 tags on first page, got %d", len(firstPage.Tags))
+		}
+
+		// Parse the Link header and verify sort=updated is preserved, then use
+		// the URL from the header directly (not reconstructed) for the next page.
+		linkHeader := resp.Header.Get("Link")
+		if linkHeader == "" {
+			t.Fatal("expected Link header for first page")
+		}
+		nextURL := checkTagsLink(t, linkHeader, env.server.URL, 2, firstPage.Tags[len(firstPage.Tags)-1], "updated")
+
+		// Fetch second page via the Link header URL.
+		resp2, err := http.Get(nextURL)
+		if err != nil {
+			t.Fatalf("unexpected error issuing request: %v", err)
+		}
+		defer resp2.Body.Close()
+
+		if resp2.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp2.StatusCode)
+		}
+
+		var secondPage tagsAPIResponse
+		if err := json.NewDecoder(resp2.Body).Decode(&secondPage); err != nil {
+			t.Fatalf("unexpected error decoding response body: %v", err)
+		}
+		if len(secondPage.Tags) != 2 {
+			t.Fatalf("expected 2 tags on second page, got %d", len(secondPage.Tags))
+		}
+
+		// No overlap between pages.
+		firstSet := make(map[string]bool)
+		for _, tag := range firstPage.Tags {
+			firstSet[tag] = true
+		}
+		for _, tag := range secondPage.Tags {
+			if firstSet[tag] {
+				t.Errorf("tag %q appeared on both pages", tag)
+			}
+		}
+	})
+
+	t.Run("no sort param preserves alphabetical order (backward compat)", func(t *testing.T) {
+		tagsURL, err := env.builder.BuildTagsURL(imageName, nil)
+		if err != nil {
+			t.Fatalf("unexpected error building tags URL: %v", err)
+		}
+		resp, err := http.Get(tagsURL)
+		if err != nil {
+			t.Fatalf("unexpected error issuing request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var body tagsAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected error decoding response body: %v", err)
+		}
+
+		alphabetical := slices.Sorted(slices.Values(creationOrder))
+		if !reflect.DeepEqual(body.Tags, alphabetical) {
+			t.Errorf("expected alphabetical order %v, got %v", alphabetical, body.Tags)
+		}
+	})
+
+	t.Run("unrecognized sort value returns 400", func(t *testing.T) {
+		tagsURL, err := env.builder.BuildTagsURL(imageName, url.Values{"sort": []string{"invalid"}})
+		if err != nil {
+			t.Fatalf("unexpected error building tags URL: %v", err)
+		}
+		resp, err := http.Get(tagsURL)
+		if err != nil {
+			t.Fatalf("unexpected error issuing request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestTagsAPISortedByUpdatedMaxTagsClamp verifies that sort=updated respects
+// the server's configured MaxTags limit, clamping an oversized n rather than
+// returning 400.
+func TestTagsAPISortedByUpdatedMaxTagsClamp(t *testing.T) {
+	config := configuration.Configuration{
+		Storage: configuration.Storage{
+			"inmemory":    configuration.Parameters{},
+			"maintenance": configuration.Parameters{"uploadpurging": map[any]any{"enabled": false}},
+		},
+		Catalog: configuration.Catalog{MaxEntries: 5},
+		Tags:    configuration.Tags{MaxTags: 2},
+	}
+	config.HTTP.Headers = headerConfig
+	env := newTestEnvWithConfig(t, &config)
+	defer env.Shutdown()
+
+	imageName, err := reference.WithName("test")
+	if err != nil {
+		t.Fatalf("unable to parse reference: %v", err)
+	}
+
+	tags := []string{"2j2ar", "asj9e", "jyi7b", "kb0j5", "sb71y"}
+	for _, tag := range tags {
+		createRepository(env, t, imageName.Name(), tag)
+	}
+
+	tagsURL, err := env.builder.BuildTagsURL(imageName, url.Values{
+		"sort": []string{"updated"},
+		"n":    []string{"100"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building tags URL: %v", err)
+	}
+
+	resp, err := http.Get(tagsURL)
+	if err != nil {
+		t.Fatalf("unexpected error issuing request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected response status code to be %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var body tagsAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("unexpected error decoding response body: %v", err)
+	}
+	if len(body.Tags) != 2 {
+		t.Fatalf("expected 2 tags (clamped by MaxTags), got %d", len(body.Tags))
+	}
+
+	linkHeader := resp.Header.Get("Link")
+	if linkHeader == "" {
+		t.Fatal("expected Link header indicating more results")
+	}
+	checkTagsLink(t, linkHeader, env.server.URL, 2, body.Tags[len(body.Tags)-1], "updated")
+}
+
 func checkLink(t *testing.T, urlStr string, numEntries int, last string) url.Values {
 	re := regexp.MustCompile("<(/v2/_catalog.*)>; rel=\"next\"")
 	matches := re.FindStringSubmatch(urlStr)
@@ -688,6 +907,32 @@ func checkLink(t *testing.T, urlStr string, numEntries int, last string) url.Val
 	}
 
 	return urlValues
+}
+
+// checkTagsLink parses a tags Link header, asserts n, last, and sort values,
+// and returns the full URL (prefixed with serverURL) ready for the next request.
+func checkTagsLink(t *testing.T, linkHeader, serverURL string, numEntries int, last, sort string) string {
+	t.Helper()
+	re := regexp.MustCompile(`<(/v2/[^>]*/tags/list[^>]*)>; rel="next"`)
+	matches := re.FindStringSubmatch(linkHeader)
+	if len(matches) != 2 {
+		t.Fatalf("tags link header was incorrect: %q", linkHeader)
+	}
+	linkURL, err := url.Parse(matches[1])
+	if err != nil {
+		t.Fatalf("failed to parse tags link URL: %v", err)
+	}
+	q := linkURL.Query()
+	if q.Get("n") != strconv.Itoa(numEntries) {
+		t.Errorf("link n param: expected %d, got %q", numEntries, q.Get("n"))
+	}
+	if q.Get("last") != last {
+		t.Errorf("link last param: expected %q, got %q", last, q.Get("last"))
+	}
+	if sort != "" && q.Get("sort") != sort {
+		t.Errorf("link sort param: expected %q, got %q", sort, q.Get("sort"))
+	}
+	return serverURL + matches[1]
 }
 
 func contains(elems []string, e string) bool {

--- a/registry/handlers/catalog.go
+++ b/registry/handlers/catalog.go
@@ -106,17 +106,18 @@ func (ch *catalogHandler) GetCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Use the original URL from the request to create a new URL for
-// the link header
+// createLinkEntry builds a Link header value for the next page of results.
+// It preserves all existing query parameters from origURL, overwriting n and
+// last with the provided values.
 func createLinkEntry(origURL string, maxEntries int, lastEntry string) (string, error) {
 	calledURL, err := url.Parse(origURL)
 	if err != nil {
 		return "", err
 	}
 
-	v := url.Values{}
-	v.Add("n", strconv.Itoa(maxEntries))
-	v.Add("last", lastEntry)
+	v := calledURL.Query()
+	v.Set("n", strconv.Itoa(maxEntries))
+	v.Set("last", lastEntry)
 
 	calledURL.RawQuery = v.Encode()
 

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -34,11 +34,114 @@ type tagsAPIResponse struct {
 
 // GetTags returns a json list of tags for a specific image name.
 func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	tagService := th.Repository.Tags(th)
+
+	switch q.Get("sort") {
+	case "":
+		// Default path: use List() for efficient storage-level pagination.
+	case "updated":
+		if ts, ok := tagService.(distribution.TagServiceWithTimestamp); ok {
+			th.getTagsSortedByTime(w, r, ts)
+			return
+		}
+		// Fall through to default path if interface is not supported.
+	default:
+		th.Errors = append(th.Errors, errcode.ErrorCodeQueryParameterInvalid.WithDetail(
+			map[string]string{"sort": q.Get("sort")},
+		))
+		return
+	}
+
+	th.getTagsDefault(w, r, tagService)
+}
+
+// getTagsSortedByTime handles the sort=updated case using AllWithModifiedTime.
+func (th *tagsHandler) getTagsSortedByTime(w http.ResponseWriter, r *http.Request, ts distribution.TagServiceWithTimestamp) {
+	q := r.URL.Query()
+
+	tagDescs, err := ts.AllWithModifiedTime(th)
+	if err != nil {
+		switch err := err.(type) {
+		case distribution.ErrRepositoryUnknown:
+			th.Errors = append(th.Errors, errcode.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Named().Name()}))
+		case errcode.Error:
+			th.Errors = append(th.Errors, err)
+		default:
+			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	tags := make([]string, len(tagDescs))
+	for i, d := range tagDescs {
+		tags[i] = d.Name
+	}
+
+	// Apply last-based pagination via linear search (list is time-ordered, not alphabetical).
+	if lastEntry := q.Get("last"); lastEntry != "" {
+		idx := -1
+		for i, t := range tags {
+			if t == lastEntry {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 || idx == len(tags)-1 {
+			tags = []string{}
+		} else {
+			tags = tags[idx+1:]
+		}
+	}
+
+	// Apply n limit and set Link header if there are more entries.
+	if n := q.Get("n"); n != "" {
+		maxEntries, err := strconv.Atoi(n)
+		if err != nil || maxEntries < 0 {
+			th.Errors = append(th.Errors, errcode.ErrorCodePaginationNumberInvalid.WithDetail(map[string]string{"n": n}))
+			return
+		}
+
+		// Per the OCI distribution-spec, a server MAY return fewer than n
+		// results when a Link header is provided for continuation. Clamp to
+		// MaxTags instead of rejecting oversized requests.
+		if maxTags := th.App.Config.Tags.MaxTags; maxTags > 0 && maxEntries > maxTags {
+			maxEntries = maxTags
+		}
+
+		if maxEntries >= len(tags) {
+			maxEntries = len(tags)
+		} else if maxEntries > 0 {
+			urlStr, err := createLinkEntry(r.URL.String(), maxEntries, tags[maxEntries-1])
+			if err != nil {
+				th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+				return
+			}
+			w.Header().Set("Link", urlStr)
+		}
+
+		tags = tags[:maxEntries]
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(tagsAPIResponse{
+		Name: th.Repository.Named().Name(),
+		Tags: tags,
+	}); err != nil {
+		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}
+
+// getTagsDefault handles the default (unsorted) case using List() for efficient pagination.
+func (th *tagsHandler) getTagsDefault(w http.ResponseWriter, r *http.Request, tagService distribution.TagService) {
+	q := r.URL.Query()
+
 	var moreEntries = true
 
-	q := r.URL.Query()
 	lastEntry := q.Get("last")
-
 	limit := -1
 
 	if n := q.Get("n"); n != "" {
@@ -61,7 +164,6 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	if limit == 0 {
 		moreEntries = false
 	} else {
-		tagService := th.Repository.Tags(th)
 		// if limit is -1, we want to list all the tags, and receive a io.EOF error
 		returnedTags, err := tagService.List(th.Context, limit, lastEntry)
 		if err != nil {

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -62,6 +62,70 @@ func (ts *tagStore) All(ctx context.Context) ([]string, error) {
 	return tags, nil
 }
 
+// AllWithModifiedTime returns all tags with their last modification time,
+// sorted by modification time in descending order (newest first).
+// It retrieves the modification time of each tag's current link file in parallel.
+func (ts *tagStore) AllWithModifiedTime(ctx context.Context) ([]distribution.TagDescriptor, error) {
+	pathSpec, err := pathFor(manifestTagsPathSpec{
+		name: ts.repository.Named().Name(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := ts.blobStore.driver.List(ctx, pathSpec)
+	if err != nil {
+		switch err.(type) {
+		case storagedriver.PathNotFoundError:
+			return nil, distribution.ErrRepositoryUnknown{Name: ts.repository.Named().Name()}
+		default:
+			return nil, err
+		}
+	}
+
+	descs := make([]distribution.TagDescriptor, len(entries))
+	for i, entry := range entries {
+		_, filename := path.Split(entry)
+		descs[i].Name = filename
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(ts.concurrencyLimit)
+
+	for i := range descs {
+		i := i
+		g.Go(func() error {
+			currentPath, err := pathFor(manifestTagCurrentPathSpec{
+				name: ts.repository.Named().Name(),
+				tag:  descs[i].Name,
+			})
+			if err != nil {
+				return err
+			}
+			fi, err := ts.blobStore.driver.Stat(ctx, currentPath)
+			if err != nil {
+				switch err.(type) {
+				case storagedriver.PathNotFoundError:
+					return nil
+				}
+				return err
+			}
+			descs[i].ModifiedTime = fi.ModTime()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(descs, func(i, j int) bool {
+		return descs[i].ModifiedTime.After(descs[j].ModifiedTime)
+	})
+
+	return descs, nil
+}
+
 // Tag tags the digest with the given tag, updating the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) Tag(ctx context.Context, tag string, desc v1.Descriptor) error {

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -305,6 +305,65 @@ func TestTagIndexes(t *testing.T) {
 	}
 }
 
+func TestTagStoreAllWithModifiedTime(t *testing.T) {
+	env := testTagStore(t)
+	ctx := env.ctx
+
+	ts, ok := env.ts.(distribution.TagServiceWithTimestamp)
+	if !ok {
+		t.Fatal("tagStore does not implement TagServiceWithTimestamp")
+	}
+
+	// empty store
+	_, err := ts.AllWithModifiedTime(ctx)
+	if err == nil {
+		t.Fatal("expected error on empty repository")
+	}
+
+	desc := v1.Descriptor{Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	tagNames := []string{"v1.0", "v2.0", "latest"}
+	for _, name := range tagNames {
+		if err := env.ts.Tag(ctx, name, desc); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	descs, err := ts.AllWithModifiedTime(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(descs) != len(tagNames) {
+		t.Fatalf("expected %d tags, got %d", len(tagNames), len(descs))
+	}
+
+	// verify all tag names are present
+	got := make(map[string]bool, len(descs))
+	for _, d := range descs {
+		got[d.Name] = true
+	}
+	for _, name := range tagNames {
+		if !got[name] {
+			t.Errorf("tag %q missing from result", name)
+		}
+	}
+
+	// verify sorted descending by ModifiedTime (each entry >= next)
+	for i := 1; i < len(descs); i++ {
+		if descs[i].ModifiedTime.After(descs[i-1].ModifiedTime) {
+			t.Errorf("result not sorted descending: descs[%d].ModifiedTime %v > descs[%d].ModifiedTime %v",
+				i, descs[i].ModifiedTime, i-1, descs[i-1].ModifiedTime)
+		}
+	}
+
+	// zero ModifiedTime should not appear (Stat should have succeeded)
+	for _, d := range descs {
+		if d.ModifiedTime.IsZero() {
+			t.Errorf("tag %q has zero ModifiedTime", d.Name)
+		}
+	}
+}
+
 func digestMap(dgsts []digest.Digest) map[digest.Digest]struct{} {
 	set := make(map[digest.Digest]struct{})
 	for _, dgst := range dgsts {

--- a/tags.go
+++ b/tags.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"context"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -30,6 +31,20 @@ type TagService interface {
 
 	// List returns the set of tags after last managed by this tag service
 	List(ctx context.Context, limit int, last string) ([]string, error)
+}
+
+// TagDescriptor holds a tag name and its last modification time.
+type TagDescriptor struct {
+	Name         string
+	ModifiedTime time.Time
+}
+
+// TagServiceWithTimestamp is an optional interface that TagService implementations
+// may implement to support listing tags with modification times.
+type TagServiceWithTimestamp interface {
+	// AllWithModifiedTime returns all tags with their last modification time,
+	// sorted by modification time in descending order (newest first).
+	AllWithModifiedTime(ctx context.Context) ([]TagDescriptor, error)
 }
 
 // TagManifestsProvider provides method to retrieve the digests of manifests that a tag historically


### PR DESCRIPTION
We would like to sort the tags with modified at in tags/list API, but The API doesn't sorting with its modified at.  
Thus, we added the params in  tags/list API sorting with modified at.
Internally, it must call Stat() for each tags, it had occurred a something to be the N+1 problems. To resolve this problem, it can be resolved with concurrency processing using goroutine.