### PR TITLE
feat(auth/token): support remote JWKS URL, periodic and on-demand key refresh

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -193,6 +193,7 @@ auth:
     issuer: registry-token-issuer
     rootcertbundle: /root/certs/bundle
     jwks: /path/to/jwks
+    jwksrefreshinterval: 1h
     signingalgorithms:
         - EdDSA
         - HS256
@@ -615,6 +616,7 @@ auth:
     issuer: registry-token-issuer
     rootcertbundle: /root/certs/bundle
     jwks: /path/to/jwks
+    jwksrefreshinterval: 1h
     signingalgorithms:
         - EdDSA
         - HS256
@@ -663,7 +665,8 @@ security.
 | `autoredirect`       | no       | When set to `true`, `realm` will be set to the Host header of the request as the domain and a path of `/auth/token/`(or specified by `autoredirectpath`), the `realm` URL Scheme will use `X-Forwarded-Proto` header if set, otherwise it will be set to `https`. |
 | `autoredirectpath`   | no       | The path to redirect to if `autoredirect` is set to `true`, default: `/auth/token/`. |
 | `signingalgorithms`  | no       | A list of token signing algorithms to use for verifying token signatures. If left empty the default list of signing algorithms is used. Please see below for allowed values and default. |
-| `jwks`               | no       | The absolute path to the JSON Web Key Set (JWKS) file. The JWKS file contains the trusted keys used to verify the signature of authentication tokens. |
+| `jwks`               | no       | The path or URL of the JSON Web Key Set (JWKS). Accepts either an absolute file path or an `http`/`https` URL. The JWKS contains the trusted public keys used to verify the signature of authentication tokens. |
+| `jwksrefreshinterval` | no      | How often to re-fetch the JWKS source and refresh the trusted keys. Accepts any Go duration string (e.g. `10m`, `1h`). Defaults to `1h` when `jwks` is set. Set to `0` to disable periodic refresh. |
 
 Available `signingalgorithms`:
 - EdDSA
@@ -699,6 +702,14 @@ Additional notes on `rootcertbundle`:
 
 - The public key of this certificate will be automatically added to the list of known keys.
 - The public key will be identified by its JWK Thumbprint. See [RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638) and [RFC 8037](https://datatracker.ietf.org/doc/html/rfc8037) for reference.
+
+Additional notes on `jwks` and `jwksrefreshinterval`:
+
+- `jwks` accepts either a local file path (e.g. `/etc/registry/jwks.json`) or a remote URL (e.g. `https://auth.example.com/.well-known/jwks.json`).
+- When `jwksrefreshinterval` is set (or defaulted to `1h`), a background goroutine periodically re-fetches the JWKS and replaces the trusted keys. Set `jwksrefreshinterval` to `0` to disable periodic refresh.
+- When a token arrives signed with an unknown key ID, the registry performs an immediate on-demand re-fetch of the JWKS before rejecting the request. This covers the window between a key rotation on the auth server and the next periodic refresh tick. On-demand refresh is active regardless of the `jwksrefreshinterval` value, as long as `jwks` is configured.
+- If any refresh attempt fails (network error, non-200 response, or invalid JSON), the previously loaded keys are kept and the error is logged. The registry continues to serve requests using the existing keys.
+- `rootcertbundle` and `jwks` can be used together; the registry will trust keys from both sources.
 
 For more information about Token based authentication configuration, see the
 [specification](../spec/auth/token.md).

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/json"
@@ -12,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/distribution/distribution/v3/registry/auth"
 	"github.com/go-jose/go-jose/v4"
@@ -152,31 +155,39 @@ func (ac authChallenge) SetHeaders(r *http.Request, w http.ResponseWriter) {
 
 // accessController implements the auth.AccessController interface.
 type accessController struct {
-	realm             string
-	autoRedirect      bool
-	autoRedirectPath  string
-	issuer            string
-	service           string
-	rootCerts         *x509.CertPool
-	trustedKeys       map[string]crypto.PublicKey
-	signingAlgorithms []jose.SignatureAlgorithm
+	realm               string
+	autoRedirect        bool
+	autoRedirectPath    string
+	issuer              string
+	service             string
+	rootCerts           *x509.CertPool
+	mu                  sync.RWMutex
+	trustedKeys         map[string]crypto.PublicKey
+	signingAlgorithms   []jose.SignatureAlgorithm
+	jwksSource          string
+	jwksRefreshInterval time.Duration
+	cancel              context.CancelFunc
 }
 
 const (
-	defaultAutoRedirectPath = "/auth/token"
+	defaultAutoRedirectPath    = "/auth/token"
+	defaultJWKSRefreshInterval = 1 * time.Hour
+	defaultJWKSRefreshTimeout  = 10 * time.Second
 )
 
 // tokenAccessOptions is a convenience type for handling
 // options to the constructor of an accessController.
 type tokenAccessOptions struct {
-	realm             string
-	autoRedirect      bool
-	autoRedirectPath  string
-	issuer            string
-	service           string
-	rootCertBundle    string
-	jwks              string
-	signingAlgorithms []string
+	realm                  string
+	autoRedirect           bool
+	autoRedirectPath       string
+	issuer                 string
+	service                string
+	rootCertBundle         string
+	jwks                   string
+	jwksRefreshInterval    time.Duration
+	jwksRefreshIntervalSet bool // true when jwksrefreshinterval was explicitly configured
+	signingAlgorithms      []string
 }
 
 // checkOptions gathers the necessary options
@@ -205,6 +216,13 @@ func checkOptions(options map[string]any) (tokenAccessOptions, error) {
 
 	opts.realm, opts.issuer, opts.service, opts.rootCertBundle, opts.jwks = vals[0], vals[1], vals[2], vals[3], vals[4]
 
+	if strings.HasPrefix(opts.jwks, "http://") || strings.HasPrefix(opts.jwks, "https://") {
+		u, err := url.ParseRequestURI(opts.jwks)
+		if err != nil || u.Host == "" {
+			return tokenAccessOptions{}, fmt.Errorf("invalid jwks URL %q: must be a valid http/https URL", opts.jwks)
+		}
+	}
+
 	autoRedirectVal, ok := options["autoredirect"]
 	if ok {
 		autoRedirect, ok := autoRedirectVal.(bool)
@@ -225,6 +243,15 @@ func checkOptions(options map[string]any) (tokenAccessOptions, error) {
 		if opts.autoRedirectPath == "" {
 			opts.autoRedirectPath = defaultAutoRedirectPath
 		}
+	}
+
+	if intervalStr, ok := options["jwksrefreshinterval"]; ok {
+		interval, err := time.ParseDuration(intervalStr.(string))
+		if err != nil {
+			return tokenAccessOptions{}, fmt.Errorf("invalid jwksrefreshinterval: %v", err)
+		}
+		opts.jwksRefreshInterval = interval
+		opts.jwksRefreshIntervalSet = true
 	}
 
 	signingAlgos, ok := options["signingalgorithms"]
@@ -282,18 +309,36 @@ func getRootCerts(path string) ([]*x509.Certificate, error) {
 	return rootCerts, nil
 }
 
-func getJwks(path string) (*jose.JSONWebKeySet, error) {
-	// TODO(milosgajdos): we should consider providing a JWKS
-	// URL from which the JWKS could be fetched
-	jp, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open jwks file %q: %s", path, err)
-	}
-	defer jp.Close()
+func getJwks(source string) (*jose.JSONWebKeySet, error) {
+	var rawJWKS []byte
 
-	rawJWKS, err := io.ReadAll(jp)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read token jwks file %q: %s", path, err)
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		client := &http.Client{Timeout: defaultJWKSRefreshTimeout}
+		resp, err := client.Get(source)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch JWKS from %q: %s", source, err)
+		}
+
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status %d fetching JWKS from %q", resp.StatusCode, source)
+		}
+
+		rawJWKS, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read JWKS response from %q: %s", source, err)
+		}
+	} else {
+		jp, err := os.Open(source)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open jwks file %q: %s", source, err)
+		}
+
+		defer jp.Close()
+		rawJWKS, err = io.ReadAll(jp)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read token jwks file %q: %s", source, err)
+		}
 	}
 
 	var jwks jose.JSONWebKeySet
@@ -373,16 +418,78 @@ func newAccessController(options map[string]any) (auth.AccessController, error) 
 		signAlgos = defaultSigningAlgorithms
 	}
 
-	return &accessController{
-		realm:             config.realm,
-		autoRedirect:      config.autoRedirect,
-		autoRedirectPath:  config.autoRedirectPath,
-		issuer:            config.issuer,
-		service:           config.service,
-		rootCerts:         rootPool,
-		trustedKeys:       trustedKeys,
-		signingAlgorithms: signAlgos,
-	}, nil
+	refreshInterval := config.jwksRefreshInterval
+	if config.jwks != "" && !config.jwksRefreshIntervalSet {
+		refreshInterval = defaultJWKSRefreshInterval
+	}
+
+	ac := &accessController{
+		realm:               config.realm,
+		autoRedirect:        config.autoRedirect,
+		autoRedirectPath:    config.autoRedirectPath,
+		issuer:              config.issuer,
+		service:             config.service,
+		rootCerts:           rootPool,
+		trustedKeys:         trustedKeys,
+		signingAlgorithms:   signAlgos,
+		jwksSource:          config.jwks,
+		jwksRefreshInterval: refreshInterval,
+	}
+
+	if ac.jwksSource != "" && ac.jwksRefreshInterval > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		ac.cancel = cancel
+		ac.startRefresh(ctx)
+	}
+
+	return ac, nil
+}
+
+// refreshKeys fetches the JWKS from jwksSource and atomically replaces the
+// trusted key set. On failure the existing keys are preserved.
+func (ac *accessController) refreshKeys() error {
+	jwks, err := jwkFetcher(ac.jwksSource)
+	if err != nil {
+		return err
+	}
+
+	newKeys := make(map[string]crypto.PublicKey, len(jwks.Keys))
+	for _, key := range jwks.Keys {
+		newKeys[key.KeyID] = key.Public()
+	}
+
+	ac.mu.Lock()
+	ac.trustedKeys = newKeys
+	ac.mu.Unlock()
+	logrus.Debugf("token auth: refreshed %d JWKS keys from %q", len(newKeys), ac.jwksSource)
+	return nil
+}
+
+// startRefresh spawns a goroutine that periodically calls refreshKeys.
+// On fetch failure the existing keys are kept and the error is logged.
+func (ac *accessController) startRefresh(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(ac.jwksRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := ac.refreshKeys(); err != nil {
+					logrus.Errorf("token auth: failed to refresh JWKS from %q: %v", ac.jwksSource, err)
+				}
+			}
+		}
+	}()
+}
+
+// Close stops the background JWKS refresh goroutine if one was started.
+func (ac *accessController) Close() error {
+	if ac.cancel != nil {
+		ac.cancel()
+	}
+	return nil
 }
 
 // Authorized handles checking whether the given request is authorized
@@ -408,17 +515,38 @@ func (ac *accessController) Authorized(req *http.Request, accessItems ...auth.Ac
 		return nil, challenge
 	}
 
+	ac.mu.RLock()
+	trustedKeys := ac.trustedKeys
+	ac.mu.RUnlock()
+
 	verifyOpts := VerifyOptions{
 		TrustedIssuers:    []string{ac.issuer},
 		AcceptedAudiences: []string{ac.service},
 		Roots:             ac.rootCerts,
-		TrustedKeys:       ac.trustedKeys,
+		TrustedKeys:       trustedKeys,
 	}
 
 	claims, err := token.Verify(verifyOpts)
 	if err != nil {
-		challenge.err = err
-		return nil, challenge
+		// If the key ID is not in our current set and we have a remote source, re-fetch
+		if errors.Is(err, ErrUnknownKeyID) && ac.jwksSource != "" {
+			if refreshErr := ac.refreshKeys(); refreshErr != nil {
+				logrus.Errorf("token auth: on-demand JWKS refresh from %q failed: %v", ac.jwksSource, refreshErr)
+			} else {
+				ac.mu.RLock()
+				verifyOpts.TrustedKeys = ac.trustedKeys
+				ac.mu.RUnlock()
+				claims, err = token.Verify(verifyOpts)
+			}
+		}
+		if err != nil {
+			// Normalize ErrUnknownKeyID so the WWW-Authenticate header
+			if errors.Is(err, ErrUnknownKeyID) {
+				err = ErrInvalidToken
+			}
+			challenge.err = err
+			return nil, challenge
+		}
 	}
 
 	accessSet := claims.accessSet()

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -216,7 +216,10 @@ func checkOptions(options map[string]any) (tokenAccessOptions, error) {
 
 	opts.realm, opts.issuer, opts.service, opts.rootCertBundle, opts.jwks = vals[0], vals[1], vals[2], vals[3], vals[4]
 
-	if strings.HasPrefix(opts.jwks, "http://") || strings.HasPrefix(opts.jwks, "https://") {
+	if strings.Contains(opts.jwks, "://") {
+		if !strings.HasPrefix(opts.jwks, "http://") && !strings.HasPrefix(opts.jwks, "https://") {
+			return tokenAccessOptions{}, fmt.Errorf("invalid jwks URL %q: only http and https schemes are supported", opts.jwks)
+		}
 		u, err := url.ParseRequestURI(opts.jwks)
 		if err != nil || u.Host == "" {
 			return tokenAccessOptions{}, fmt.Errorf("invalid jwks URL %q: must be a valid http/https URL", opts.jwks)

--- a/registry/auth/token/accesscontroller_test.go
+++ b/registry/auth/token/accesscontroller_test.go
@@ -1,16 +1,17 @@
 package token
 
 import (
-	"testing"
-
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/sirupsen/logrus"
 )
 
 func TestBuildAutoRedirectURL(t *testing.T) {
@@ -118,6 +119,63 @@ func mockGetJwks(path string) (*jose.JSONWebKeySet, error) {
 	}, nil
 }
 
+func TestCheckOptionsInvalidJWKSURL(t *testing.T) {
+	base := map[string]any{
+		"realm":   "https://auth.example.com/token/",
+		"issuer":  "test-issuer.example.com",
+		"service": "test-service.example.com",
+	}
+
+	cases := []struct {
+		name string
+		jwks string
+	}{
+		{"no host", "https://"},
+		{"invalid url", "https://[::1]invalid"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := make(map[string]any, len(base)+1)
+			maps.Copy(opts, base)
+			opts["jwks"] = tc.jwks
+
+			if _, err := checkOptions(opts); err == nil {
+				t.Fatalf("expected error for jwks=%q, got nil", tc.jwks)
+			}
+		})
+	}
+}
+
+func TestCheckOptionsValidJWKSURL(t *testing.T) {
+	cases := []string{
+		"https://auth.example.com/.well-known/jwks.json",
+		"http://localhost:8080/jwks",
+	}
+
+	base := map[string]any{
+		"realm":   "https://auth.example.com/token/",
+		"issuer":  "test-issuer.example.com",
+		"service": "test-service.example.com",
+	}
+
+	for _, jwks := range cases {
+		t.Run(jwks, func(t *testing.T) {
+			opts := make(map[string]any, len(base)+1)
+			maps.Copy(opts, base)
+			opts["jwks"] = jwks
+
+			ta, err := checkOptions(opts)
+			if err != nil {
+				t.Fatalf("unexpected error for jwks=%q: %v", jwks, err)
+			}
+			if ta.jwks != jwks {
+				t.Fatalf("expected jwks=%q, got %q", jwks, ta.jwks)
+			}
+		})
+	}
+}
+
 func TestRootCertIncludedInTrustedKeys(t *testing.T) {
 	old := rootCertFetcher
 	rootCertFetcher = mockGetRootCerts
@@ -170,10 +228,135 @@ func TestJWKSIncludedInTrustedKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = ac.(*accessController).Close() })
+
 	// newAccessController return type is an interface built from
 	// accessController struct. The type check can be safely ignored.
 	ac2, _ := ac.(*accessController)
 	if got := len(ac2.trustedKeys); got != 1 {
 		t.Fatalf("Unexpected number of trusted keys, expected 1 got: %d", got)
+	}
+}
+
+func TestGetJWKSFromURL(t *testing.T) {
+	// Hardcoded JWKS JSON to avoid marshaling issues with nil key material.
+	const body = `{"keys":[{"kty":"oct","kid":"key-from-url","k":"c2VjcmV0"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	got, err := getJwks(srv.URL)
+	if err != nil {
+		t.Fatalf("getJwks from URL: %v", err)
+	}
+	if len(got.Keys) != 1 || got.Keys[0].KeyID != "key-from-url" {
+		t.Fatalf("unexpected keys: %+v", got.Keys)
+	}
+}
+
+func TestGetJWKSFromURLNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if _, err := getJwks(srv.URL); err == nil {
+		t.Fatal("expected error for non-200 response, got nil")
+	}
+}
+
+func TestJWKSRefresh(t *testing.T) {
+	originalLevel := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(originalLevel) })
+	logrus.SetLevel(logrus.FatalLevel)
+	const (
+		initialJWKS = `{"keys":[{"kty":"oct","kid":"initial-key","k":"c2VjcmV0"}]}`
+		rotatedJWKS = `{"keys":[{"kty":"oct","kid":"rotated-key","k":"c2VjcmV0"}]}`
+	)
+
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		body := initialJWKS
+		if callCount > 1 {
+			body = rotatedJWKS
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	options := map[string]any{
+		"realm":               "https://auth.example.com/token/",
+		"issuer":              "test-issuer.example.com",
+		"service":             "test-service.example.com",
+		"jwks":                srv.URL,
+		"jwksrefreshinterval": "100ms",
+	}
+
+	ac, err := newAccessController(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac2 := ac.(*accessController)
+	defer ac2.Close()
+
+	// Wait for at least one refresh cycle.
+	time.Sleep(200 * time.Millisecond)
+
+	ac2.mu.RLock()
+	_, hasRotated := ac2.trustedKeys["rotated-key"]
+	ac2.mu.RUnlock()
+
+	if !hasRotated {
+		t.Fatalf("expected trustedKeys to contain %q after refresh, got: %v", "rotated-key", ac2.trustedKeys)
+	}
+}
+
+func TestJWKSRefreshKeepsOldKeysOnError(t *testing.T) {
+	originalLevel := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(originalLevel) })
+	logrus.SetLevel(logrus.FatalLevel)
+	const initialJWKS = `{"keys":[{"kty":"oct","kid":"original-key","k":"c2VjcmV0"}]}`
+
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount > 1 {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initialJWKS))
+	}))
+	defer srv.Close()
+
+	options := map[string]any{
+		"realm":               "https://auth.example.com/token/",
+		"issuer":              "test-issuer.example.com",
+		"service":             "test-service.example.com",
+		"jwks":                srv.URL,
+		"jwksrefreshinterval": "100ms",
+	}
+
+	ac, err := newAccessController(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac2 := ac.(*accessController)
+	defer ac2.Close()
+
+	// Wait for a failed refresh cycle.
+	time.Sleep(200 * time.Millisecond)
+
+	ac2.mu.RLock()
+	_, hasOriginal := ac2.trustedKeys["original-key"]
+	ac2.mu.RUnlock()
+
+	if !hasOriginal {
+		t.Fatalf("expected original key to be preserved after failed refresh, got: %v", ac2.trustedKeys)
 	}
 }

--- a/registry/auth/token/accesscontroller_test.go
+++ b/registry/auth/token/accesscontroller_test.go
@@ -132,6 +132,8 @@ func TestCheckOptionsInvalidJWKSURL(t *testing.T) {
 	}{
 		{"no host", "https://"},
 		{"invalid url", "https://[::1]invalid"},
+		{"ftp scheme", "ftp://auth.example.com/jwks.json"},
+		{"ssh scheme", "ssh://auth.example.com/jwks.json"},
 	}
 
 	for _, tc := range cases {

--- a/registry/auth/token/token.go
+++ b/registry/auth/token/token.go
@@ -59,6 +59,7 @@ var defaultSigningAlgorithms = []jose.SignatureAlgorithm{
 var (
 	ErrMalformedToken = errors.New("malformed token")
 	ErrInvalidToken   = errors.New("invalid token")
+	ErrUnknownKeyID   = errors.New("unknown key ID")
 )
 
 // ResourceActions stores allowed actions on a named and typed resource.
@@ -120,6 +121,9 @@ func (t *Token) Verify(verifyOpts VerifyOptions) (*ClaimSet, error) {
 	signingKey, err := t.VerifySigningKey(verifyOpts)
 	if err != nil {
 		log.Infof("failed to verify token: %v", err)
+		if errors.Is(err, ErrUnknownKeyID) {
+			return nil, ErrUnknownKeyID
+		}
 		return nil, ErrInvalidToken
 	}
 
@@ -184,7 +188,7 @@ func (t *Token) VerifySigningKey(verifyOpts VerifyOptions) (crypto.PublicKey, er
 				if signingKey, ok := verifyOpts.TrustedKeys[header.KeyID]; ok {
 					return signingKey, nil
 				}
-				return nil, fmt.Errorf("token signed by untrusted key with ID: %q", header.KeyID)
+				return nil, fmt.Errorf("%w: %q", ErrUnknownKeyID, header.KeyID)
 			default:
 				return nil, ErrInvalidToken
 			}

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -10,10 +10,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -214,6 +216,51 @@ func generateCACert(signer *ecdsa.PrivateKey, trustedKey *ecdsa.PrivateKey) (*x5
 	}
 
 	return generateCert(signer, trustedKey.Public(), subjectInfo, issuerInfo)
+}
+
+// makeTestTokenKIDOnly creates a signed JWT that includes only the key ID in
+// the header (no embedded JWK, no certificate chain). This is the standard
+// OIDC pattern where the verifier must resolve the key from a JWKS by kid.
+func makeTestTokenKIDOnly(privKey *ecdsa.PrivateKey, keyID, issuer, audience string, access []*ResourceActions, now, exp time.Time) (*Token, error) {
+	jwk := &jose.JSONWebKey{
+		Key:       privKey,
+		KeyID:     keyID,
+		Algorithm: string(jose.ES256),
+	}
+	signingKey := jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key:       jwk,
+	}
+	signerOpts := jose.SignerOptions{}
+	signerOpts.WithType("JWT")
+
+	signer, err := jose.NewSigner(signingKey, &signerOpts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create signer: %s", err)
+	}
+
+	randomBytes := make([]byte, 15)
+	if _, err = rand.Read(randomBytes); err != nil {
+		return nil, fmt.Errorf("unable to read random bytes for jwt id: %s", err)
+	}
+
+	claimSet := &ClaimSet{
+		Issuer:     issuer,
+		Subject:    "foo",
+		Audience:   []string{audience},
+		Expiration: exp.Unix(),
+		NotBefore:  now.Unix(),
+		IssuedAt:   now.Unix(),
+		JWTID:      base64.URLEncoding.EncodeToString(randomBytes),
+		Access:     access,
+	}
+
+	tokenString, err := jwt.Signed(signer).Claims(claimSet).Serialize()
+	if err != nil {
+		return nil, fmt.Errorf("unable to build token string: %v", err)
+	}
+
+	return NewToken(tokenString, []jose.SignatureAlgorithm{jose.ES256})
 }
 
 // This test makes 4 tokens with a varying number of intermediate
@@ -698,5 +745,113 @@ func TestVerifyJWKWithTrustedKey(t *testing.T) {
 	}
 	if err.Error() != "untrusted JWK with no certificate chain" {
 		t.Errorf("Expected 'untrusted JWK with no certificate chain' error, got: %v", err)
+	}
+}
+
+func TestVerifyReturnsErrUnknownKeyID(t *testing.T) {
+	keys, err := makeRootKeys(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jwk, err := makeSigningKeyWithChain(keys[0], 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := makeTestTokenKIDOnly(keys[0], jwk.KeyID, "issuer", "audience", nil, time.Now(), time.Now().Add(5*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty trusted keys — kid will not be found.
+	verifyOpts := VerifyOptions{
+		TrustedIssuers:    []string{"issuer"},
+		AcceptedAudiences: []string{"audience"},
+		TrustedKeys:       map[string]crypto.PublicKey{},
+	}
+
+	_, err = token.Verify(verifyOpts)
+	if !errors.Is(err, ErrUnknownKeyID) {
+		t.Fatalf("expected ErrUnknownKeyID, got: %v", err)
+	}
+}
+
+func TestAuthorizedOnDemandJWKSRefresh(t *testing.T) {
+	const (
+		issuer  = "test-issuer.example.com"
+		service = "test-service.example.com"
+	)
+
+	keys, err := makeRootKeys(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyAID := keys[0].X.String()
+	keyBID := keys[1].X.String()
+
+	// JWKS server: first call (init) returns only key A.
+	// Second call (on-demand re-fetch) returns key A + key B.
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		jwkKeys := []jose.JSONWebKey{
+			{Key: &keys[0].PublicKey, KeyID: keyAID, Algorithm: string(jose.ES256)},
+		}
+		if callCount > 1 {
+			jwkKeys = append(jwkKeys, jose.JSONWebKey{
+				Key: &keys[1].PublicKey, KeyID: keyBID, Algorithm: string(jose.ES256),
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jose.JSONWebKeySet{Keys: jwkKeys})
+	}))
+	defer srv.Close()
+
+	options := map[string]any{
+		"realm":               "https://auth.example.com/token/",
+		"issuer":              issuer,
+		"service":             service,
+		"jwks":                srv.URL,
+		"jwksrefreshinterval": "0s", // disable periodic refresh; only on-demand
+	}
+
+	ac, err := newAccessController(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ac.(*accessController).Close()
+
+	testAccess := auth.Access{
+		Resource: auth.Resource{Type: "repository", Name: "foo/bar"},
+		Action:   "pull",
+	}
+
+	// Token signed with key B — not yet in trustedKeys (only key A is loaded).
+	tokenB, err := makeTestTokenKIDOnly(
+		keys[1], keyBID, issuer, service,
+		[]*ResourceActions{{Type: "repository", Name: "foo/bar", Actions: []string{"pull"}}},
+		time.Now(), time.Now().Add(5*time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/v2/foo/bar/manifests/latest", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenB.Raw))
+
+	// Authorized should trigger an on-demand re-fetch and succeed.
+	grant, err := ac.Authorized(req, testAccess)
+	if err != nil {
+		t.Fatalf("expected authorization to succeed after on-demand refresh, got: %v", err)
+	}
+	if grant.User.Name != "foo" {
+		t.Fatalf("expected user name %q, got %q", "foo", grant.User.Name)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 JWKS fetches (init + on-demand), got %d", callCount)
 	}
 }

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"expvar"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"net"
@@ -449,6 +450,11 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 
 // Shutdown close the underlying registry
 func (app *App) Shutdown() error {
+	if c, ok := app.accessController.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return err
+		}
+	}
 	if r, ok := app.registry.(proxy.Closer); ok {
 		return r.Close()
 	}


### PR DESCRIPTION
## Problem

Rotating signing keys on the auth server required redeploying the registry to pick up the new `rootcertbundle` or `jwks` file. There was no mechanism to refresh trusted keys at runtime, making zero-downtime key rotation impossible.

## Solution

Three complementary mechanisms:

1. `jwks` now accepts an `http`/`https` URL in addition to a local file path. This resolves a [TODO left explicitly in the code](https://github.com/distribution/distribution/blob/bd2137921581321923800d654f31436ccf61b36b/registry/auth/token/accesscontroller.go#L286) by @milosgajdos.
3. **Periodic background refresh**, re-fetches the JWKS source on a configurable interval and atomically replaces the trusted key set, enabling auth server key rotation without restarting the registry.
4. **On-demand refresh** When a token arrives with an unknown key ID, the registry immediately re-fetches the JWKS before rejecting the request. This covers the window between a key rotation on the auth server and the next periodic refresh tick.

## Design decisions

### Availability over strictness on refresh failure
If any refresh attempt fails (network error, non-200 response, or invalid JSON), the registry keeps the previously loaded keys and logs the error. The alternative — rejecting all tokens on fetch failure — would cause an outage during transient network issues, which is a worse tradeoff for a registry serving production traffic.

### On-demand refresh is active regardless of `jwksrefreshinterval`
Setting `jwksrefreshinterval: 0` disables the periodic goroutine but on-demand refresh still fires on unknown key IDs, as long as `jwks` is configured. This allows operators to manage refresh timing externally while still handling key rotations transparently.

### `ErrUnknownKeyID` as a sentinel error
A new exported error distinguishes "key ID not found in trusted set" from other verification failures. This is what allows `Authorized` to decide whether to trigger an on-demand re-fetch, and it normalizes to `ErrInvalidToken` in the `WWW-Authenticate` challenge as required by RFC 6750.

### URL validation at startup
When `jwks` is an `http`/`https` value, `checkOptions` validates the URL with `url.ParseRequestURI` before the registry starts. This surfaces misconfiguration immediately rather than at the first token verification request.

### Refresh applies to both local files and remote URLs
Consistent behavior regardless of source type. For local files this is useful when an external process rotates the JWKS file on disk (e.g. a sidecar or secret manager agent); for remote URLs it enables direct consumption of standard JWKS endpoints.

### Default refresh interval: 1h
Applied automatically when `jwks` is configured and `jwksrefreshinterval` is not set. Set `jwksrefreshinterval: 0` to disable periodic refresh entirely. 

## Configuration

```yaml
auth:
   token:
      # accepts a file path or an http/https URL
      jwks: https://auth.example.com/.well-known/jwks.json
      jwksrefreshinterval: 1h   # optional, default 1h; set 0s to disable periodic refresh
```

Closes #3166