### PR TITLE
S3: support disabling ACL headers

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -137,6 +137,7 @@ func init() {
 	} {
 		validObjectACLs[objectACL] = struct{}{}
 	}
+	validObjectACLs[""] = struct{}{}
 
 	// Register this as the default s3 driver in addition to s3aws
 	factory.Register("s3", &s3DriverFactory{})
@@ -310,7 +311,7 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		userAgent = ""
 	}
 
-	objectACL := s3.ObjectCannedACLPrivate
+	objectACL := ""
 	objectACLParam := parameters["objectacl"]
 	if objectACLParam != nil {
 		objectACLString, ok := objectACLParam.(string)
@@ -1255,6 +1256,9 @@ func (d *driver) getContentType() *string {
 }
 
 func (d *driver) getACL() *string {
+	if d.ObjectACL == "" {
+		return nil
+	}
 	return aws.String(d.ObjectACL)
 }
 

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -1117,6 +1117,58 @@ func TestListObjectsV2(t *testing.T) {
 	}
 }
 
+func TestValidObjectACLEmptyString(t *testing.T) {
+	if _, ok := validObjectACLs[""]; !ok {
+		t.Fatal("empty string should be a valid objectacl value")
+	}
+}
+
+func TestGetACL(t *testing.T) {
+	tests := []struct {
+		name      string
+		objectACL string
+		wantNil   bool
+		wantValue string
+	}{
+		{
+			name:      "empty string returns nil",
+			objectACL: "",
+			wantNil:   true,
+		},
+		{
+			name:      "private returns pointer",
+			objectACL: s3.ObjectCannedACLPrivate,
+			wantNil:   false,
+			wantValue: s3.ObjectCannedACLPrivate,
+		},
+		{
+			name:      "public-read returns pointer",
+			objectACL: s3.ObjectCannedACLPublicRead,
+			wantNil:   false,
+			wantValue: s3.ObjectCannedACLPublicRead,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &driver{ObjectACL: tt.objectACL}
+			got := d.getACL()
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("getACL() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("getACL() = nil, want %q", tt.wantValue)
+			}
+			if *got != tt.wantValue {
+				t.Fatalf("getACL() = %q, want %q", *got, tt.wantValue)
+			}
+		})
+	}
+}
+
 func compareWalked(t *testing.T, expected, walked []string) {
 	if len(walked) != len(expected) {
 		t.Fatalf("Mismatch number of fileInfo walked %d expected %d; walked %s; expected %s;", len(walked), len(expected), walked, expected)


### PR DESCRIPTION
S3 buckets with `BucketOwnerEnforced` ownership reject any request that includes an `x-amz-acl` header. The current driver always sends this header via `getACL()`, which returns `aws.String(d.ObjectACL)`.

This change implements a way to omit the header entirely by setting `objectacl: ""` in the registry config.

Prior to using this configuration, I was hitting this error on push:

```
"POST /v2/xxxxx/yyyyyy/pause/blobs/uploads/ HTTP/1.1" 500 275 "" "containerd/2.2.1+unknown"
zzzzzzz registry time="2026-03-19T15:29:36.213562358Z" level=error msg="response completed with error"
err.code=unknown err.detail="s3aws: AccessControlListNotSupported: The bucket does not allow ACLs\n\tstatus code: 400
```
