### PR TITLE
Add custom parameters "urlexpiry" and "expirywindow" for the S3 driver.

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -37,6 +37,8 @@ Amazon S3 or S3 compatible services for object storage.
 | `usefipsendpoint` | no | Use AWS FIPS endpoints for S3 API operations. |
 | `objectacl`  | no | The S3 Canned ACL for objects. The default value is "private". |
 | `loglevel`  | no | The log level for the S3 client. The default value is `off`. |
+| `urlexpiry` | no | The duration for which pre-signed URLs are valid. Accepts Go duration format. The default is `20m`. |
+| `expirywindow` | no | The time window before IAM credentials expire at which the driver will refresh them. Accepts Go duration format. The default is `5m`. |
 
 > **Note** You can provide empty strings for your access and secret keys to run the driver
 > on an ec2 instance and handles authentication with the instance's credentials. If you
@@ -82,6 +84,10 @@ Amazon S3 or S3 compatible services for object storage.
 `objectacl`: (optional) The canned object ACL to be applied to each registry object. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your objects. Other valid options are available in the [AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 
 `loglevel`: (optional) Valid values are: `off` (default), `debug`, `debugwithsigning`, `debugwithhttpbody`, `debugwithrequestretries`, `debugwithrequesterrors` and `debugwitheventstreambody`. See the [AWS SDK for Go API reference](https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType) for details.
+
+`urlexpiry`: (optional) The expiry duration for pre-signed S3 redirect URLs. When the registry redirects a pull request to S3, it generates a pre-signed URL with this expiry time. Accepts Go duration format (e.g., `20m`, `30m`, `1h`). Defaults to `20m`. Increase this value if clients experience URL expiration errors during large image pulls over slow connections.
+
+`expirywindow`: (optional) The time window before IAM role credentials expire at which the driver will proactively refresh them. This helps avoid S3 `400 Bad Request` errors caused by credentials expiring mid-request, especially when using pre-signed URLs. Accepts Go duration format (e.g., `5m`, `10m`). Defaults to `5m`. Increase this value if you observe intermittent token expiration errors on EC2 instances using IAM roles.
 
 ## S3 permission scopes
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -31,6 +32,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -116,6 +120,13 @@ type DriverParameters struct {
 	Accelerate                  bool
 	UseFIPSEndpoint             bool
 	LogLevel                    aws.LogLevelType
+	// ExpiryWindow configures how early the IAM credentials will be refreshed
+	// before they expire, in minutes. Defaults to 5 minutes.
+	// A value of 0 disables early refresh.
+	ExpiryWindow time.Duration
+	// URLExpiry configures the expiry duration of presigned URLs, in minutes.
+	// Defaults to 20 minutes.
+	URLExpiry time.Duration
 }
 
 func init() {
@@ -164,6 +175,7 @@ type driver struct {
 	RootDirectory               string
 	StorageClass                string
 	ObjectACL                   string
+	URLExpiry                   time.Duration
 	pool                        *sync.Pool
 }
 
@@ -341,6 +353,16 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		return nil, err
 	}
 
+	expiryWindowMins, err := getParameterAsInteger[int64](parameters, "expirywindow", 5, 0, math.MaxInt64)
+	if err != nil {
+		return nil, err
+	}
+
+	urlExpiryMins, err := getParameterAsInteger[int64](parameters, "urlexpiry", 20, 1, math.MaxInt64)
+	if err != nil {
+		return nil, err
+	}
+
 	params := DriverParameters{
 		AccessKey:                   fmt.Sprint(accessKey),
 		SecretKey:                   fmt.Sprint(secretKey),
@@ -366,6 +388,8 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		Accelerate:                  accelerateBool,
 		UseFIPSEndpoint:             useFIPSEndpointBool,
 		LogLevel:                    getS3LogLevelFromParam(parameters["loglevel"]),
+		ExpiryWindow:                time.Duration(expiryWindowMins) * time.Minute,
+		URLExpiry:                   time.Duration(urlExpiryMins) * time.Minute,
 	}
 
 	return New(ctx, params)
@@ -500,6 +524,26 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		return nil, fmt.Errorf("failed to create new session with aws config: %v", err)
 	}
 
+	// When using IAM role credentials (no static keys provided), override the
+	// credential chain with the configured ExpiryWindow so tokens are refreshed
+	// before they expire. This avoids S3 400 errors caused by expired tokens.
+	expiryWindow := params.ExpiryWindow
+	if expiryWindow <= 0 {
+		expiryWindow = 5 * time.Minute
+	}
+
+	if params.AccessKey == "" && params.SecretKey == "" {
+		remoteProvider := newRemoteCredProvider(*sess.Config, sess.Handlers, expiryWindow)
+		sess.Config.Credentials = credentials.NewCredentials(&credentials.ChainProvider{
+			VerboseErrors: aws.BoolValue(sess.Config.CredentialsChainVerboseErrors),
+			Providers: []credentials.Provider{
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+				remoteProvider,
+			},
+		})
+	}
+
 	if params.UserAgent != "" {
 		sess.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler(params.UserAgent))
 	}
@@ -526,6 +570,11 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 	// 	}
 	// }
 
+	urlExpiry := params.URLExpiry
+	if urlExpiry <= 0 {
+		urlExpiry = 20 * time.Minute
+	}
+
 	d := &driver{
 		S3:                          s3obj,
 		Bucket:                      params.Bucket,
@@ -538,6 +587,7 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		RootDirectory:               params.RootDirectory,
 		StorageClass:                params.StorageClass,
 		ObjectACL:                   params.ObjectACL,
+		URLExpiry:                   urlExpiry,
 		pool: &sync.Pool{
 			New: func() any { return &bytes.Buffer{} },
 		},
@@ -1028,8 +1078,6 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 
 // RedirectURL returns a URL which may be used to retrieve the content stored at the given path.
 func (d *driver) RedirectURL(r *http.Request, path string) (string, error) {
-	expiresIn := 20 * time.Minute
-
 	var req *request.Request
 
 	switch r.Method {
@@ -1047,7 +1095,7 @@ func (d *driver) RedirectURL(r *http.Request, path string) (string, error) {
 		return "", nil
 	}
 
-	return req.Presign(expiresIn)
+	return req.Presign(d.URLExpiry)
 }
 
 // Walk traverses a filesystem defined within driver, starting
@@ -1561,4 +1609,35 @@ func (w *writer) done() error {
 		return fmt.Errorf("already cancelled")
 	}
 	return nil
+}
+
+// newRemoteCredProvider returns a credentials provider for remote endpoints
+// (EC2 IAM role or ECS/EKS container credentials) with a custom ExpiryWindow.
+func newRemoteCredProvider(cfg aws.Config, handlers request.Handlers, expiryWindow time.Duration) credentials.Provider {
+	if u := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"); len(u) > 0 {
+		return endpointcreds.NewProviderClient(cfg, handlers, u,
+			func(p *endpointcreds.Provider) {
+				p.ExpiryWindow = expiryWindow
+			},
+		)
+	}
+
+	if uri := os.Getenv("AWS_ECS_CONTAINER_METADATA_URI_V4"); len(uri) > 0 {
+		u := fmt.Sprintf("%s%s", "http://169.254.170.2", uri)
+		return endpointcreds.NewProviderClient(cfg, handlers, u,
+			func(p *endpointcreds.Provider) {
+				p.ExpiryWindow = expiryWindow
+			},
+		)
+	}
+
+	resolver := cfg.EndpointResolver
+	if resolver == nil {
+		resolver = endpoints.DefaultResolver()
+	}
+	e, _ := resolver.EndpointFor(ec2metadata.ServiceName, "")
+	return &ec2rolecreds.EC2RoleProvider{
+		Client:       ec2metadata.NewClient(cfg, handlers, e.URL, e.SigningRegion),
+		ExpiryWindow: expiryWindow,
+	}
 }

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"path/filepath"
+	"path"
 	"slices"
 	"sort"
 	"strconv"
@@ -1254,7 +1254,7 @@ func directoryDiff(prev, current string) []string {
 
 	parent := current
 	for {
-		parent = filepath.Dir(parent)
+		parent = path.Dir(parent)
 		if parent == "/" || parent == prev || strings.HasPrefix(prev+"/", parent+"/") {
 			break
 		}


### PR DESCRIPTION
Fixes #4175

## Problem

When using IAM role credentials on EC2, the S3 driver uses a hardcoded
5-minute `ExpiryWindow` for credential refresh, and a hardcoded 20-minute
presigned URL expiry. This can cause 400 Bad Request errors from S3 when
downloading large layers over slow networks.

## Changes

- Add `expirywindow` parameter (integer, minutes, default: 5) to configure
  how early IAM credentials are refreshed before expiry. Only applies when
  using IAM role (no static accesskey/secretkey configured).
- Add `urlexpiry` parameter (integer, minutes, default: 20) to configure
  the expiry duration of presigned redirect URLs.

## Example configuration

storage:
  s3:
    region: us-east-1
    bucket: my-bucket
    expirywindow: 20
    urlexpiry: 60
