### PR TITLE
feat: implement OCI Distribution Spec v1.1 referrers API

### DIFF
--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1140,8 +1140,9 @@ The error codes encountered via the API are enumerated in the following table:
  `BLOB_UPLOAD_INVALID` | blob upload invalid | The blob upload encountered an error and can no longer proceed.
  `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned.
  `DIGEST_INVALID` | provided digest did not match uploaded content | When a blob is uploaded, the registry will check that the content matches the digest provided by the client. The error may include a detail structure with the key "digest", including the invalid digest string. This error may also be returned when a manifest includes an invalid layer digest.
- `MANIFEST_BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a manifest blob is  unknown to the registry.
+ `MANIFEST_BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a manifest blob is unknown to the registry.
  `MANIFEST_INVALID` | manifest invalid | During upload, manifests undergo several checks ensuring validity. If those checks fail, this error may be returned, unless a more specific error is included. The detail will contain information the failed validation.
+ `MANIFEST_NOT_ACCEPTABLE` | manifest does not match Accept header | This is returned if the manifest known to the registry has a different mediaType then the client's Accept header.
  `MANIFEST_UNKNOWN` | manifest unknown | This error is returned when the manifest, identified by name and tag is unknown to the repository.
  `MANIFEST_UNVERIFIED` | manifest failed signature verification | During manifest upload, if the manifest fails signature verification, this error will be returned.
  `NAME_INVALID` | invalid repository name | Invalid repository name encountered either during manifest validation or any API operation.

--- a/docs/content/spec/api.md
+++ b/docs/content/spec/api.md
@@ -1126,6 +1126,7 @@ A list of methods and URIs are covered in the table below:
 | PATCH | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Upload a chunk of data for the specified upload. |
 | PUT | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Complete the upload specified by `uuid`, optionally appending the body as the final chunk. |
 | DELETE | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Cancel outstanding upload processes, releasing associated resources. If this is not called, the unfinished uploads will eventually timeout. |
+| GET | `/v2/<name>/referrers/<digest>` | Referrers | Return an index of manifests that have the specified subject digest. |
 | GET | `/v2/_catalog` | Catalog | Retrieve a sorted, json list of repositories available in the registry. |
 
 The detail for each endpoint is covered in the following sections.
@@ -4951,6 +4952,14 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
+
+### Referrers
+
+List referrers for a given manifest digest, per OCI Distribution Spec v1.1.
+
+#### GET Referrers
+
+Return an index of manifests that have the specified subject digest.
 
 ### Catalog
 

--- a/manifest/ocischema/index_test.go
+++ b/manifest/ocischema/index_test.go
@@ -85,7 +85,7 @@ func makeTestOCIImageIndex(t *testing.T, mediaType string) ([]v1.Descriptor, *De
 		"com.example.locale":           "en_GB",
 	}
 
-	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, annotations, mediaType)
+	deserialized, err := fromDescriptorsWithMediaType(manifestDescriptors, nil, annotations, mediaType)
 	if err != nil {
 		t.Fatalf("error creating DeserializedManifestList: %v", err)
 	}

--- a/manifest/ocischema/manifest.go
+++ b/manifest/ocischema/manifest.go
@@ -67,7 +67,7 @@ type Manifest struct {
 	Layers []v1.Descriptor `json:"layers"`
 
 	// Subject is the descriptor of a manifest referred to by this manifest.
-	Subject *distribution.Descriptor `json:"subject,omitempty"`
+	Subject *v1.Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the image manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -3,9 +3,10 @@ package ocischema
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/distribution/distribution/v3/manifest/schema2"
 	"reflect"
 	"testing"
+
+	"github.com/distribution/distribution/v3/manifest/schema2"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"

--- a/manifest/ocischema/manifest_test.go
+++ b/manifest/ocischema/manifest_test.go
@@ -42,7 +42,7 @@ const expectedManifestSerialization = `{
 }`
 
 var (
-	emptyJsonDescriptor = distribution.Descriptor{
+	emptyJSONDescriptor = distribution.Descriptor{
 		MediaType: v1.DescriptorEmptyJSON.MediaType,
 		Size:      v1.DescriptorEmptyJSON.Size,
 		Digest:    v1.DescriptorEmptyJSON.Digest,
@@ -331,7 +331,7 @@ func TestArtifactManifest(t *testing.T) {
 					SchemaVersion: 2,
 				},
 				ArtifactType: "application/vnd.example.catgif",
-				Config:       emptyJsonDescriptor,
+				Config:       emptyJSONDescriptor,
 				Layers: []distribution.Descriptor{
 					{
 						MediaType: "image/gif",
@@ -348,7 +348,7 @@ func TestArtifactManifest(t *testing.T) {
 				Versioned: specs.Versioned{
 					SchemaVersion: 2,
 				},
-				Config: emptyJsonDescriptor, // This MUST have an artifactType
+				Config: emptyJSONDescriptor, // This MUST have an artifactType
 				Layers: []distribution.Descriptor{
 					{
 						MediaType: "image/gif",
@@ -365,9 +365,9 @@ func TestArtifactManifest(t *testing.T) {
 					SchemaVersion: 2.,
 				},
 				ArtifactType: "application/vnd.example.comment",
-				Config:       emptyJsonDescriptor,
+				Config:       emptyJSONDescriptor,
 				Layers: []distribution.Descriptor{
-					emptyJsonDescriptor,
+					emptyJSONDescriptor,
 				},
 				Annotations: map[string]string{
 					"com.example.data": "payload",
@@ -382,9 +382,9 @@ func TestArtifactManifest(t *testing.T) {
 					SchemaVersion: 2,
 				},
 				ArtifactType: "application/vnd.example.comment",
-				Config:       emptyJsonDescriptor,
+				Config:       emptyJSONDescriptor,
 				Layers: []distribution.Descriptor{
-					emptyJsonDescriptor,
+					emptyJSONDescriptor,
 				},
 				Subject: &distribution.Descriptor{
 					MediaType: v1.MediaTypeImageManifest,
@@ -404,9 +404,9 @@ func TestArtifactManifest(t *testing.T) {
 					SchemaVersion: 2,
 				},
 				ArtifactType: "application/vnd.example.comment",
-				Config:       emptyJsonDescriptor,
+				Config:       emptyJSONDescriptor,
 				Layers: []distribution.Descriptor{
-					emptyJsonDescriptor,
+					emptyJSONDescriptor,
 				},
 				Subject: &distribution.Descriptor{
 					MediaType: v1.MediaTypeImageLayerGzip, // The subject is a manifest
@@ -425,9 +425,9 @@ func TestArtifactManifest(t *testing.T) {
 					SchemaVersion: 2,
 				},
 				ArtifactType: "application/vnd.example.comment",
-				Config:       emptyJsonDescriptor,
+				Config:       emptyJSONDescriptor,
 				Layers: []distribution.Descriptor{
-					emptyJsonDescriptor,
+					emptyJSONDescriptor,
 				},
 				Subject: &distribution.Descriptor{
 					MediaType: schema2.MediaTypeManifest,

--- a/manifests.go
+++ b/manifests.go
@@ -27,6 +27,18 @@ type Manifest interface {
 	Payload() (mediaType string, payload []byte, err error)
 }
 
+// Referrer represents a Manifest which can refer to a subject.
+type Referrer interface {
+	// Subject returns a pointer to a Descriptor representing the manifest which
+	// this manifest refers to or nil if this manifest does not refer to a
+	// subject.
+	Subject() *Descriptor
+
+	// Type returns the type of the referrer if there is one, otherwise it
+	// returns empty string
+	Type() string
+}
+
 // ManifestService describes operations on manifests.
 type ManifestService interface {
 	// Exists returns true if the manifest exists.
@@ -66,6 +78,12 @@ func ManifestMediaTypes() (mediaTypes []string) {
 		}
 	}
 	return
+}
+
+// ManifestMediaTypeSupported returns true if the given mediaType is supported.
+func ManifestMediaTypeSupported(mediaType string) bool {
+	_, ok := mappings[mediaType]
+	return ok
 }
 
 // UnmarshalFunc implements manifest unmarshalling a given MediaType

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -178,7 +178,7 @@ var (
 	ErrorCodeManifestBlobUnknown = register(errGroup, ErrorDescriptor{
 		Value:   "MANIFEST_BLOB_UNKNOWN",
 		Message: "blob unknown to registry",
-		Description: `This error may be returned when a manifest blob is 
+		Description: `This error may be returned when a manifest blob is
 		unknown to the registry.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})
@@ -223,6 +223,16 @@ var (
 		to return) is not an integer, "n" is negative or "n" is bigger than
 		the maximum allowed.`,
 		HTTPStatusCode: http.StatusBadRequest,
+	})
+
+	// ErrorCodeManifestNotAcceptable is returned when the manifest found is not
+	// acceptable according to the client's Accept header
+	ErrorCodeManifestNotAcceptable = register(errGroup, ErrorDescriptor{
+		Value:   "MANIFEST_NOT_ACCEPTABLE",
+		Message: "manifest does not match Accept header",
+		Description: `This is returned if the manifest known to the registry
+		has a different mediaType then the client's Accept header.`,
+		HTTPStatusCode: http.StatusNotAcceptable,
 	})
 )
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -1537,6 +1537,18 @@ var routeDescriptors = []RouteDescriptor{
 		},
 	},
 	{
+		Name:        RouteNameReferrers,
+		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/referrers/{digest:" + digest.DigestRegexp.String() + "}",
+		Entity:      "Referrers",
+		Description: "List referrers for a given manifest digest, per OCI Distribution Spec v1.1.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      http.MethodGet,
+				Description: "Return an index of manifests that have the specified subject digest.",
+			},
+		},
+	},
+	{
 		Name:        RouteNameCatalog,
 		Path:        "/v2/_catalog",
 		Entity:      "Catalog",

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -12,6 +12,7 @@ const (
 	RouteNameBase            = "base"
 	RouteNameManifest        = "manifest"
 	RouteNameTags            = "tags"
+	RouteNameReferrers       = "referrers"
 	RouteNameBlob            = "blob"
 	RouteNameBlobUpload      = "blob-upload"
 	RouteNameBlobUploadChunk = "blob-upload-chunk"

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -3343,3 +3343,168 @@ func pushScratch(t *testing.T, testEnv *testEnv, repo reference.Named) {
 	url, _ := startPushLayer(t, testEnv, repo)
 	pushLayer(t, testEnv.builder, repo, v1.DescriptorEmptyJSON.Digest, url, bytes.NewBuffer(v1.DescriptorEmptyJSON.Data))
 }
+
+func TestReferrersAPI(t *testing.T) {
+	testEnv := newTestEnv(t, true)
+	defer testEnv.Shutdown()
+
+	repo, err := reference.WithName("test/referrers")
+	if err != nil {
+		t.Fatalf("failed to make repo: %s", err)
+	}
+
+	// 1. Create a subject manifest (a normal image manifest).
+	args := testManifestAPISchema2(t, testEnv, repo, "subject-tag")
+	_, subjectPayload, err := args.manifest.Payload()
+	if err != nil {
+		t.Fatalf("failed to get subject payload: %s", err)
+	}
+	subjectDigest := digest.FromBytes(subjectPayload)
+
+	// 2. Push an OCI artifact manifest that references the subject.
+	pushScratch(t, testEnv, repo)
+	artifactManifest, err := ocischema.FromStruct(ocischema.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    v1.MediaTypeImageManifest,
+		ArtifactType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		Config:       emptyJsonDescriptor,
+		Subject: &distribution.Descriptor{
+			MediaType: v1.MediaTypeImageManifest,
+			Digest:    subjectDigest,
+			Size:      int64(len(subjectPayload)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create artifact manifest: %s", err)
+	}
+
+	_, artifactPayload, err := artifactManifest.Payload()
+	if err != nil {
+		t.Fatalf("failed to get artifact payload: %s", err)
+	}
+	artifactDigest := digest.FromBytes(artifactPayload)
+
+	artifactRef, err := reference.WithDigest(repo, artifactDigest)
+	if err != nil {
+		t.Fatalf("failed to make reference: %s", err)
+	}
+	manifestURL, err := testEnv.builder.BuildManifestURL(artifactRef)
+	if err != nil {
+		t.Fatalf("failed to build manifest URL: %s", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, manifestURL, bytes.NewReader(artifactPayload))
+	if err != nil {
+		t.Fatalf("failed to create PUT request: %s", err)
+	}
+	req.Header.Set("Content-Type", v1.MediaTypeImageManifest)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to PUT artifact manifest: %s", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("unexpected status for artifact PUT: %d, expected %d", res.StatusCode, http.StatusCreated)
+	}
+
+	// 3. Query the referrers endpoint.
+	referrersURL := fmt.Sprintf("%s/v2/%s/referrers/%s", testEnv.server.URL, repo.Name(), subjectDigest)
+	resp, err := http.Get(referrersURL)
+	if err != nil {
+		t.Fatalf("failed to GET referrers: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("unexpected status for referrers GET: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != v1.MediaTypeImageIndex {
+		t.Errorf("unexpected Content-Type: %q, expected %q", ct, v1.MediaTypeImageIndex)
+	}
+
+	var index v1.Index
+	if err := json.NewDecoder(resp.Body).Decode(&index); err != nil {
+		t.Fatalf("failed to decode referrers response: %s", err)
+	}
+
+	if index.SchemaVersion != 2 {
+		t.Errorf("unexpected schemaVersion: %d", index.SchemaVersion)
+	}
+	if index.MediaType != v1.MediaTypeImageIndex {
+		t.Errorf("unexpected mediaType: %q", index.MediaType)
+	}
+	if len(index.Manifests) != 1 {
+		t.Fatalf("expected 1 referrer, got %d", len(index.Manifests))
+	}
+	if index.Manifests[0].Digest != artifactDigest {
+		t.Errorf("referrer digest mismatch: got %s, expected %s", index.Manifests[0].Digest, artifactDigest)
+	}
+	if index.Manifests[0].ArtifactType != "application/vnd.dev.sigstore.bundle.v0.3+json" {
+		t.Errorf("referrer artifactType mismatch: got %q", index.Manifests[0].ArtifactType)
+	}
+	if index.Manifests[0].MediaType != v1.MediaTypeImageManifest {
+		t.Errorf("referrer mediaType mismatch: got %q, expected %q", index.Manifests[0].MediaType, v1.MediaTypeImageManifest)
+	}
+
+	// 4. Test artifactType filtering — matching filter.
+	filteredURL := referrersURL + "?artifactType=" + url.QueryEscape("application/vnd.dev.sigstore.bundle.v0.3+json")
+	resp, err = http.Get(filteredURL)
+	if err != nil {
+		t.Fatalf("failed to GET filtered referrers: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status for filtered referrers GET: %d", resp.StatusCode)
+	}
+	if resp.Header.Get("OCI-Filters-Applied") != "artifactType" {
+		t.Errorf("expected OCI-Filters-Applied header, got %q", resp.Header.Get("OCI-Filters-Applied"))
+	}
+
+	var filteredIndex v1.Index
+	if err := json.NewDecoder(resp.Body).Decode(&filteredIndex); err != nil {
+		t.Fatalf("failed to decode filtered response: %s", err)
+	}
+	if len(filteredIndex.Manifests) != 1 {
+		t.Fatalf("expected 1 filtered referrer, got %d", len(filteredIndex.Manifests))
+	}
+
+	// 5. Test artifactType filtering — non-matching filter.
+	noMatchURL := referrersURL + "?artifactType=application/vnd.example.nope"
+	resp, err = http.Get(noMatchURL)
+	if err != nil {
+		t.Fatalf("failed to GET non-matching referrers: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status for non-matching referrers GET: %d", resp.StatusCode)
+	}
+
+	var emptyIndex v1.Index
+	if err := json.NewDecoder(resp.Body).Decode(&emptyIndex); err != nil {
+		t.Fatalf("failed to decode empty response: %s", err)
+	}
+	if len(emptyIndex.Manifests) != 0 {
+		t.Errorf("expected 0 referrers for non-matching filter, got %d", len(emptyIndex.Manifests))
+	}
+
+	// 6. Test referrers for a digest with no referrers — should return empty index.
+	noRefURL := fmt.Sprintf("%s/v2/%s/referrers/%s", testEnv.server.URL, repo.Name(), artifactDigest)
+	resp, err = http.Get(noRefURL)
+	if err != nil {
+		t.Fatalf("failed to GET referrers for non-subject: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status for no-referrers GET: %d", resp.StatusCode)
+	}
+
+	var noRefIndex v1.Index
+	if err := json.NewDecoder(resp.Body).Decode(&noRefIndex); err != nil {
+		t.Fatalf("failed to decode no-referrers response: %s", err)
+	}
+	if len(noRefIndex.Manifests) != 0 {
+		t.Errorf("expected 0 referrers, got %d", len(noRefIndex.Manifests))
+	}
+}

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -44,7 +44,7 @@ var (
 	headerConfig = http.Header{
 		"X-Content-Type-Options": []string{"nosniff"},
 	}
-	emptyJsonDescriptor = distribution.Descriptor{
+	emptyJSONDescriptor = distribution.Descriptor{
 		MediaType: v1.DescriptorEmptyJSON.MediaType,
 		Size:      v1.DescriptorEmptyJSON.Size,
 		Digest:    v1.DescriptorEmptyJSON.Digest,
@@ -2896,7 +2896,7 @@ func TestArtifactManifest(t *testing.T) {
 				manifest, err := ocischema.FromStruct(ocischema.Manifest{
 					Versioned:    specs.Versioned{SchemaVersion: 2},
 					ArtifactType: "application/vnd.example.sbom.v1",
-					Config:       emptyJsonDescriptor,
+					Config:       emptyJSONDescriptor,
 					Subject: &distribution.Descriptor{
 						MediaType: args.mediaType,
 						Digest:    args.dgst,
@@ -3200,7 +3200,7 @@ func TestArtifactManifestValidation(t *testing.T) {
 		"layers_must_exist": {
 			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
 				pushScratch(t, testEnv, repo)
-				return emptyJsonDescriptor
+				return emptyJSONDescriptor
 			},
 			layers: func(t *testing.T, te *testEnv, n reference.Named) []distribution.Descriptor {
 				// a layer which has not been uploaded
@@ -3240,7 +3240,7 @@ func TestArtifactManifestValidation(t *testing.T) {
 		},
 		"config_must_exist": {
 			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
-				return emptyJsonDescriptor // not uploaded
+				return emptyJSONDescriptor // not uploaded
 			},
 			layers: func(t *testing.T, testEnv *testEnv, repo reference.Named) []distribution.Descriptor {
 				layers := int64(10)
@@ -3265,7 +3265,7 @@ func TestArtifactManifestValidation(t *testing.T) {
 		"valid_blobs": {
 			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
 				pushScratch(t, testEnv, repo)
-				return emptyJsonDescriptor
+				return emptyJSONDescriptor
 			},
 			layers: func(t *testing.T, testEnv *testEnv, repo reference.Named) []distribution.Descriptor {
 				layers := int64(10)
@@ -3367,7 +3367,7 @@ func TestReferrersAPI(t *testing.T) {
 		Versioned:    specs.Versioned{SchemaVersion: 2},
 		MediaType:    v1.MediaTypeImageManifest,
 		ArtifactType: "application/vnd.dev.sigstore.bundle.v0.3+json",
-		Config:       emptyJsonDescriptor,
+		Config:       emptyJSONDescriptor,
 		Subject: &distribution.Descriptor{
 			MediaType: v1.MediaTypeImageManifest,
 			Digest:    subjectDigest,

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/distribution/distribution/v3/manifest/ocischema"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -38,9 +40,16 @@ import (
 	hookstest "github.com/sirupsen/logrus/hooks/test"
 )
 
-var headerConfig = http.Header{
-	"X-Content-Type-Options": []string{"nosniff"},
-}
+var (
+	headerConfig = http.Header{
+		"X-Content-Type-Options": []string{"nosniff"},
+	}
+	emptyJsonDescriptor = distribution.Descriptor{
+		MediaType: v1.DescriptorEmptyJSON.MediaType,
+		Size:      v1.DescriptorEmptyJSON.Size,
+		Digest:    v1.DescriptorEmptyJSON.Digest,
+	}
+)
 
 const (
 	// digestSha256EmptyTar is the canonical sha256 digest of empty data
@@ -2865,4 +2874,464 @@ func TestProxyManifestGetByTag(t *testing.T) {
 	checkHeaders(t, resp, http.Header{
 		"Docker-Content-Digest": []string{newDigest.String()},
 	})
+}
+
+func TestArtifactManifest(t *testing.T) {
+	for name, test := range map[string]struct {
+		manifest      func(*testing.T, *testEnv, reference.Named) distribution.Manifest
+		deleteSubject bool
+	}{
+		// The link is made when the subject already exists and is kept if the
+		// subject is deleted
+		"subject_exists": {
+			manifest: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Manifest {
+				args := testManifestAPISchema2(t, testEnv, repo, "schema2tag")
+				_, payload, err := args.manifest.Payload()
+				if err != nil {
+					t.Fatalf("Failed to get subject payload: %s", err)
+				}
+
+				pushScratch(t, testEnv, repo)
+
+				manifest, err := ocischema.FromStruct(ocischema.Manifest{
+					Versioned:    specs.Versioned{SchemaVersion: 2},
+					ArtifactType: "application/vnd.example.sbom.v1",
+					Config:       emptyJsonDescriptor,
+					Subject: &distribution.Descriptor{
+						MediaType: args.mediaType,
+						Digest:    args.dgst,
+						Size:      int64(len(payload)),
+					},
+				})
+				if err != nil {
+					t.Fatalf("Failed to create manifest: %s", err)
+				}
+				return manifest
+			},
+			deleteSubject: true,
+		},
+		// When an OCI Image Manifest with a subject field is PUT before its
+		// subject, the subject's referrers link will be made in advance.
+		"image_manifest_with_subject": {
+			manifest: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Manifest {
+				config, configDigest, err := testutil.CreateRandomTarFile()
+				if err != nil {
+					t.Fatalf("Failed to create test blob: %s", err)
+				}
+				url, _ := startPushLayer(t, testEnv, repo)
+				pushLayer(t, testEnv.builder, repo, configDigest, url, config)
+				manifest, err := ocischema.FromStruct(ocischema.Manifest{
+					Versioned: specs.Versioned{SchemaVersion: 2},
+					Config: distribution.Descriptor{
+						MediaType: v1.MediaTypeImageConfig,
+						Digest:    configDigest,
+					},
+					Subject: &distribution.Descriptor{
+						MediaType: v1.MediaTypeImageManifest,
+						Digest:    "sha256:ebe054f08821294feee7bc442014fdd38b4836d83781d8ba99d38eb50d0c9d85",
+						Size:      99,
+					},
+				})
+				if err != nil {
+					t.Fatalf("Failed to create manifest: %s", err)
+				}
+				return manifest
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testEnv := newTestEnv(t, true)
+			defer testEnv.Shutdown()
+
+			repo, err := reference.WithName("myrepo/myimage")
+			if err != nil {
+				t.Fatalf("failed to make repo: %s", err)
+			}
+
+			manifest := test.manifest(t, testEnv, repo)
+
+			contentType, payload, err := manifest.Payload()
+			if err != nil {
+				t.Fatalf("Failed to get raw manifest: %s", err)
+			}
+			ref, err := reference.WithDigest(repo, digest.FromBytes(payload))
+			if err != nil {
+				t.Fatalf("failed to make reference: %s", err)
+			}
+
+			manifestURL, err := testEnv.builder.BuildManifestURL(ref)
+			if err != nil {
+				t.Fatalf("Failed to build manifest URL: %s", err)
+			}
+
+			req, err := http.NewRequest(http.MethodPut, manifestURL, bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("Failed to create artifact PUT request: %s", err)
+			}
+			req.Header.Set("Content-Type", contentType)
+
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to PUT manifest: %s", err)
+			}
+			if res.StatusCode != http.StatusCreated {
+				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
+			}
+			if res.Header.Get("Docker-Content-Digest") != ref.Digest().String() {
+				t.Errorf("Incorrect Docker-Content-Digest header: %q, expected %q", res.Header.Get("Docker-Content-Digest"), ref.Digest().String())
+			}
+
+			// TODO(brackendawson): We should now try to get referrers for the subject
+			// (which should also eventually exist for that to work), but those APIs
+			// don't exist yet so for now just check the link was made.
+			referrer, ok := manifest.(distribution.Referrer)
+			if !ok {
+				t.Fatalf("Manifest should implement distribution.Referrer: %T", manifest)
+			}
+			link, err := testEnv.app.driver.GetContent(context.Background(), fmt.Sprintf("/docker/registry/v2/repositories/%s/_manifests/revisions/sha256/%s/_referrers/_%s/sha256/%s/link",
+				repo.Name(), referrer.Subject().Digest.Hex(), url.QueryEscape(referrer.Type()), ref.Digest().Hex()))
+			if err != nil {
+				t.Fatalf("Failed to get expected referrers link from subject with error: %s", err)
+			}
+			if string(link) != ref.Digest().String() {
+				t.Errorf("Subject's referrers link has incorrect content:\n%s\nexpected:\n%s", string(link), ref.Digest().String())
+			}
+
+			// When an artifact manifest has been PUT it can be retrieved with GET.
+			location := res.Header.Get("Location")
+			req, err = http.NewRequest(http.MethodGet, location, nil)
+			if err != nil {
+				t.Fatalf("Failed to create artifact GET request: %s", err)
+			}
+
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to GET manifest: %s", err)
+			}
+			if res.StatusCode != http.StatusNotAcceptable {
+				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotAcceptable)
+			}
+
+			req.Header.Set("Accept", contentType)
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to GET manifest: %s", err)
+			}
+			if res.StatusCode != http.StatusOK {
+				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusOK)
+			}
+			if res.Header.Get("Content-Type") != contentType {
+				t.Errorf("Incorrect mediaType for manifest GET: %q, expected: %q", res.Header.Get("Content-Type"), contentType)
+			}
+			gotManifest, err := io.ReadAll(res.Body)
+			if err != nil {
+				t.Fatalf("Failed to read manifest GET body: %s", err)
+			}
+			if !reflect.DeepEqual(gotManifest, payload) {
+				t.Errorf("Pulled manifest does not match pushed manifest, got:\n%s\nexpected:\n%s", string(gotManifest), string(payload))
+			}
+
+			if test.deleteSubject {
+				// When a subject is deleted, it's referrers link remains
+				subjectRef, err := reference.WithDigest(repo, referrer.Subject().Digest)
+				if err != nil {
+					t.Fatalf("Failed to build subject reference: %s", err)
+				}
+				subjectURL, err := testEnv.builder.BuildManifestURL(subjectRef)
+				if err != nil {
+					t.Errorf("Failed to build subject URL: %s", err)
+				}
+
+				req, err := http.NewRequest(http.MethodDelete, subjectURL, nil)
+				if err != nil {
+					t.Fatalf("Failed to create subject DELETE request: %s", err)
+				}
+				res, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("Failed to DELETE subject: %s", err)
+				}
+				if res.StatusCode != http.StatusAccepted {
+					t.Fatalf("Incorrect status code for subject DELETE: %s", err)
+				}
+
+				// TODO(brackendawson): We should now try to get referrers for the subject
+				// (which should also eventually exist for that to work), but those APIs
+				// don't exist yet so for now just check the link still exists.
+				link, err := testEnv.app.driver.GetContent(context.Background(), fmt.Sprintf("/docker/registry/v2/repositories/%s/_manifests/revisions/sha256/%s/_referrers/_%s/sha256/%s/link",
+					repo.Name(), referrer.Subject().Digest.Hex(), url.QueryEscape(referrer.Type()), ref.Digest().Hex()))
+				if err != nil {
+					t.Fatalf("Failed to get expected referrers link from subject with error: %s", err)
+				}
+				if string(link) != ref.Digest().String() {
+					t.Errorf("Subject's referrers link has incorrect content:\n%s\nexpected:\n%s", string(link), ref.Digest().String())
+				}
+			}
+
+			// When an artifact manifest is DELETEd then it will not be found if you GET
+			// it. Its subject's referrer link will be left dangling.
+			req, err = http.NewRequest(http.MethodDelete, location, nil)
+			if err != nil {
+				t.Fatalf("Failed to create artifact DELETE request: %s", err)
+			}
+
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to DELETE manifest: %s", err)
+			}
+			if res.StatusCode != http.StatusAccepted {
+				t.Fatalf("Incorrect status code for manifest DELETE: %d, expected: %d", res.StatusCode, http.StatusAccepted)
+			}
+
+			req, err = http.NewRequest(http.MethodGet, location, nil)
+			if err != nil {
+				t.Fatalf("Failed to create artifact GET request: %s", err)
+			}
+			req.Header.Set("Accept", v1.MediaTypeImageManifest)
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to GET manifest: %s", err)
+			}
+			if res.StatusCode != http.StatusNotFound {
+				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotFound)
+			}
+		})
+	}
+}
+
+func TestDockerManifestWithSubject(t *testing.T) {
+	// When a docker image manifest containing a "subject" field is uploaded
+	// then no referrer links are made for that invalid subject.
+	testEnv := newTestEnv(t, true)
+	defer testEnv.Shutdown()
+
+	repo, err := reference.WithName("test/repo")
+	if err != nil {
+		t.Fatalf("Failed to build repo: %s", err)
+	}
+
+	config, configDigest, err := testutil.CreateRandomTarFile()
+	if err != nil {
+		t.Fatalf("Failed to make config blob: %s", err)
+	}
+	url, _ := startPushLayer(t, testEnv, repo)
+	pushLayer(t, testEnv.builder, repo, configDigest, url, config)
+	layer, layerDigest, err := testutil.CreateRandomTarFile()
+	if err != nil {
+		t.Fatalf("Failed to make layer blob: %s", err)
+	}
+	url, _ = startPushLayer(t, testEnv, repo)
+	pushLayer(t, testEnv.builder, repo, layerDigest, url, layer)
+
+	manifest, err := schema2.FromStruct(schema2.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: schema2.MediaTypeManifest,
+		Config: distribution.Descriptor{
+			MediaType: schema2.MediaTypeImageConfig,
+			Digest:    configDigest,
+			Size:      testutil.MustSeekerLen(config),
+		},
+		Layers: []distribution.Descriptor{
+			{
+				MediaType: schema2.MediaTypeLayer,
+				Digest:    layerDigest,
+				Size:      testutil.MustSeekerLen(layer),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to make base manifest: %s", err)
+	}
+	var manifestFields map[string]interface{}
+	_, payload, err := manifest.Payload()
+	if err != nil {
+		t.Fatalf("Failed to get base manifest payload: %s", err)
+	}
+	if err = json.Unmarshal(payload, &manifestFields); err != nil {
+		t.Fatalf("Failed to unmarshal base manifest: %s", err)
+	}
+	manifestFields["subject"] = distribution.Descriptor{
+		MediaType: schema2.MediaTypeManifest,
+		Digest:    "sha256:118011bef6c697f7107cc0d788664a0f8c7d0316ce8d17673634155f5ecdba39",
+		Size:      56,
+	}
+	rawManifest, _ := json.Marshal(manifestFields)
+	if err = manifest.UnmarshalJSON(rawManifest); err != nil {
+		t.Fatalf("Failed to re-build manifest: %s", err)
+	}
+
+	ref, err := reference.WithTag(repo, "latest")
+	if err != nil {
+		t.Fatalf("Failed to build reference: %s", err)
+	}
+	if url, err = testEnv.builder.BuildManifestURL(ref); err != nil {
+		t.Fatalf("Failed to build manifest url: %s", err)
+	}
+	res := putManifest(t, "putting manifest", url, schema2.MediaTypeManifest, manifest)
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("Incorrect status code from manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
+	}
+
+	// TODO(brackendawson): We should now try to get referrers for the subject
+	// (which should also eventually exist for that to work), but those APIs
+	// don't exist yet so for now just check the link was not made.
+	_, err = testEnv.app.driver.Stat(context.Background(), fmt.Sprintf("/docker/registry/v2/repositories/%s/_manifests/revisions/sha256/%s/_referrers",
+		repo.Name(), res.Header.Get("Docker-Content-Digest")))
+	var expectedErr storagedriver.InvalidPathError
+	if !errors.As(err, &expectedErr) {
+		t.Fatalf("Should have got invalid path error for referrer directory: %s", err)
+	}
+}
+
+func TestArtifactManifestValidation(t *testing.T) {
+	for name, test := range map[string]struct {
+		config   func(*testing.T, *testEnv, reference.Named) distribution.Descriptor
+		layers   func(*testing.T, *testEnv, reference.Named) []distribution.Descriptor
+		wantCode int
+	}{
+		"layers_must_exist": {
+			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
+				pushScratch(t, testEnv, repo)
+				return emptyJsonDescriptor
+			},
+			layers: func(t *testing.T, te *testEnv, n reference.Named) []distribution.Descriptor {
+				// a layer which has not been uploaded
+				return []distribution.Descriptor{
+					{
+						MediaType: v1.MediaTypeImageLayer,
+						Digest:    "sha256:7688b6ef52555962d008fff894223582c484517cea7da49ee67800adc7fc8866",
+						Size:      56,
+					},
+				}
+			},
+			wantCode: 400,
+		},
+		"config_must_be_set": {
+			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
+				return distribution.Descriptor{} // zero value
+			},
+			layers: func(t *testing.T, testEnv *testEnv, repo reference.Named) []distribution.Descriptor {
+				layers := int64(10)
+				digests := make([]distribution.Descriptor, layers)
+				for i := int64(0); i < layers; i++ {
+					rs, digest, err := testutil.CreateRandomTarFile()
+					if err != nil {
+						t.Fatalf("Failed to create test blob: %s", err)
+					}
+					url, _ := startPushLayer(t, testEnv, repo)
+					pushLayer(t, testEnv.builder, repo, digest, url, rs)
+					digests[i] = distribution.Descriptor{
+						MediaType: v1.MediaTypeImageLayer,
+						Digest:    digest,
+						Size:      testutil.MustSeekerLen(rs),
+					}
+				}
+				return digests
+			},
+			wantCode: 400,
+		},
+		"config_must_exist": {
+			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
+				return emptyJsonDescriptor // not uploaded
+			},
+			layers: func(t *testing.T, testEnv *testEnv, repo reference.Named) []distribution.Descriptor {
+				layers := int64(10)
+				digests := make([]distribution.Descriptor, layers)
+				for i := int64(0); i < layers; i++ {
+					rs, digest, err := testutil.CreateRandomTarFile()
+					if err != nil {
+						t.Fatalf("Failed to create test blob: %s", err)
+					}
+					url, _ := startPushLayer(t, testEnv, repo)
+					pushLayer(t, testEnv.builder, repo, digest, url, rs)
+					digests[i] = distribution.Descriptor{
+						MediaType: v1.MediaTypeImageLayer,
+						Digest:    digest,
+						Size:      testutil.MustSeekerLen(rs),
+					}
+				}
+				return digests
+			},
+			wantCode: 400,
+		},
+		"valid_blobs": {
+			config: func(t *testing.T, testEnv *testEnv, repo reference.Named) distribution.Descriptor {
+				pushScratch(t, testEnv, repo)
+				return emptyJsonDescriptor
+			},
+			layers: func(t *testing.T, testEnv *testEnv, repo reference.Named) []distribution.Descriptor {
+				layers := int64(10)
+				digests := make([]distribution.Descriptor, layers)
+				for i := int64(0); i < layers; i++ {
+					rs, digest, err := testutil.CreateRandomTarFile()
+					if err != nil {
+						t.Fatalf("Failed to create test blob: %s", err)
+					}
+					url, _ := startPushLayer(t, testEnv, repo)
+					pushLayer(t, testEnv.builder, repo, digest, url, rs)
+					digests[i] = distribution.Descriptor{
+						MediaType: v1.MediaTypeImageLayer,
+						Digest:    digest,
+						Size:      testutil.MustSeekerLen(rs),
+					}
+				}
+				return digests
+			},
+			wantCode: 201,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testEnv := newTestEnv(t, true)
+			defer testEnv.Shutdown()
+
+			repo, err := reference.WithName("myrepo/myimage")
+			if err != nil {
+				t.Fatalf("failed to make repo: %s", err)
+			}
+
+			manifest, err := ocischema.FromStruct(ocischema.Manifest{
+				Versioned:    specs.Versioned{SchemaVersion: 2},
+				Config:       test.config(t, testEnv, repo),
+				ArtifactType: "application/vnd.example.sbom.v1",
+				Layers:       test.layers(t, testEnv, repo),
+			})
+			if err != nil {
+				t.Fatalf("Failed to make manifest: %s", err)
+			}
+
+			contentType, payload, err := manifest.Payload()
+			if err != nil {
+				t.Fatalf("Failed to get raw manifest: %s", err)
+			}
+			ref, err := reference.WithDigest(repo, digest.FromBytes(payload))
+			if err != nil {
+				t.Fatalf("failed to make reference: %s", err)
+			}
+
+			manifestURL, err := testEnv.builder.BuildManifestURL(ref)
+			if err != nil {
+				t.Fatalf("Failed to build manifest URL: %s", err)
+			}
+
+			req, err := http.NewRequest(http.MethodPut, manifestURL, bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("Failed to create artifact PUT request: %s", err)
+			}
+			req.Header.Set("Content-Type", contentType)
+
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to PUT manifest: %s", err)
+			}
+			if res.StatusCode != test.wantCode {
+				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, test.wantCode)
+			}
+		})
+	}
+}
+
+func pushScratch(t *testing.T, testEnv *testEnv, repo reference.Named) {
+	url, _ := startPushLayer(t, testEnv, repo)
+	pushLayer(t, testEnv.builder, repo, v1.DescriptorEmptyJSON.Digest, url, bytes.NewBuffer(v1.DescriptorEmptyJSON.Data))
 }

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/distribution/distribution/v3/manifest/ocischema"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/distribution/distribution/v3/manifest/ocischema"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/configuration"
@@ -2974,6 +2974,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to PUT manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusCreated {
 				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
 			}
@@ -3008,6 +3009,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusNotAcceptable {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotAcceptable)
 			}
@@ -3017,6 +3019,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusOK)
 			}
@@ -3050,6 +3053,7 @@ func TestArtifactManifest(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to DELETE subject: %s", err)
 				}
+				defer res.Body.Close()
 				if res.StatusCode != http.StatusAccepted {
 					t.Fatalf("Incorrect status code for subject DELETE: %s", err)
 				}
@@ -3078,6 +3082,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to DELETE manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusAccepted {
 				t.Fatalf("Incorrect status code for manifest DELETE: %d, expected: %d", res.StatusCode, http.StatusAccepted)
 			}
@@ -3091,6 +3096,7 @@ func TestArtifactManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to GET manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusNotFound {
 				t.Fatalf("Incorrect status code for manifest GET: %d, expected: %d", res.StatusCode, http.StatusNotFound)
 			}
@@ -3172,6 +3178,7 @@ func TestDockerManifestWithSubject(t *testing.T) {
 	if res.StatusCode != http.StatusCreated {
 		t.Fatalf("Incorrect status code from manifest PUT: %d, expected: %d", res.StatusCode, http.StatusCreated)
 	}
+	defer res.Body.Close()
 
 	// TODO(brackendawson): We should now try to get referrers for the subject
 	// (which should also eventually exist for that to work), but those APIs
@@ -3324,6 +3331,7 @@ func TestArtifactManifestValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to PUT manifest: %s", err)
 			}
+			defer res.Body.Close()
 			if res.StatusCode != test.wantCode {
 				t.Fatalf("Incorrect status code for manifest PUT: %d, expected: %d", res.StatusCode, test.wantCode)
 			}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -106,6 +106,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	app.register(v2.RouteNameManifest, manifestDispatcher)
 	app.register(v2.RouteNameCatalog, catalogDispatcher)
 	app.register(v2.RouteNameTags, tagsDispatcher)
+	app.register(v2.RouteNameReferrers, referrersDispatcher)
 	app.register(v2.RouteNameBlob, blobDispatcher)
 	app.register(v2.RouteNameBlobUpload, blobUploadDispatcher)
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -163,11 +163,11 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if manifestType == ociSchema && !supports[ociSchema] {
-		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestUnknown.WithMessage("OCI manifest found, but accept header does not support OCI manifests"))
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestNotAcceptable.WithMessage("OCI manifest found, but accept header does not support OCI manifests"))
 		return
 	}
 	if manifestType == ociImageIndexSchema && !supports[ociImageIndexSchema] {
-		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestUnknown.WithMessage("OCI index found, but accept header does not support OCI indexes"))
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeManifestNotAcceptable.WithMessage("OCI index found, but accept header does not support OCI indexes"))
 		return
 	}
 

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/image-spec/specs-go"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// referrersDispatcher constructs the referrers handler.
+func referrersDispatcher(ctx *Context, r *http.Request) http.Handler {
+	referrersHandler := &referrersHandler{
+		Context: ctx,
+	}
+
+	return handlers.MethodHandler{
+		http.MethodGet: http.HandlerFunc(referrersHandler.GetReferrers),
+	}
+}
+
+// referrersHandler handles requests for the referrers of a manifest digest.
+type referrersHandler struct {
+	*Context
+}
+
+// GetReferrers returns an OCI image index listing manifests that reference
+// the given subject digest. Supports optional ?artifactType= filtering per
+// the OCI Distribution Spec v1.1.
+func (rh *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) {
+	dgst, err := getDigest(rh)
+	if err != nil {
+		rh.Errors = append(rh.Errors, errcode.ErrorCodeDigestInvalid.WithDetail(err))
+		return
+	}
+
+	// Get the artifact type filter if provided.
+	artifactType := r.URL.Query().Get("artifactType")
+
+	// Build a ReferenceService from the storage driver.
+	refService := storage.NewReferenceEnumerator(rh.App.driver, rh.Repository)
+
+	descriptors, err := refService.Referrers(rh, dgst, artifactType)
+	if err != nil {
+		switch err := err.(type) {
+		case distribution.ErrRepositoryUnknown:
+			rh.Errors = append(rh.Errors, errcode.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": rh.Repository.Named().Name()}))
+		case errcode.Error:
+			rh.Errors = append(rh.Errors, err)
+		default:
+			rh.Errors = append(rh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	// Ensure we return an empty array, not null.
+	if descriptors == nil {
+		descriptors = []v1.Descriptor{}
+	}
+
+	// Build the OCI Image Index response per the spec.
+	index := v1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageIndex,
+		Manifests: descriptors,
+	}
+
+	w.Header().Set("Content-Type", v1.MediaTypeImageIndex)
+
+	// Per OCI spec, include the applied filter in the response header.
+	if artifactType != "" {
+		w.Header().Set("OCI-Filters-Applied", "artifactType")
+	}
+
+	if err := json.NewEncoder(w).Encode(index); err != nil {
+		rh.Errors = append(rh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+	}
+}

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -134,9 +134,9 @@ type FileWriter interface {
 // PathRegexp is the regular expression which each file path must match. A
 // file path is absolute, beginning with a slash and containing a positive
 // number of path components separated by slashes, where each component is
-// restricted to alphanumeric characters or a period, underscore, or
-// hyphen.
-var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+$`)
+// restricted to alphanumeric characters or a period, underscore, hyphen or
+// percent.
+var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._%-]+)+$`)
 
 // ErrUnsupportedMethod may be returned in the case where a StorageDriver implementation does not support an optional method.
 type ErrUnsupportedMethod struct {

--- a/registry/storage/ocimanifesthandler_test.go
+++ b/registry/storage/ocimanifesthandler_test.go
@@ -36,7 +36,7 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 	nonDistributableLayer := v1.Descriptor{
 		Digest:    "sha256:463435349086340864309863409683460843608348608934092322395278926a",
 		Size:      6323,
-		MediaType: v1.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // ignore A1019: v1.MediaTypeImageLayerNonDistributableGzip is deprecated: Non-distributable layers are deprecated, and not recommended for future use
+		MediaType: v1.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // Ignore SA1019 v1.MediaTypeImageLayerNonDistributable is deprecated, it is used for backwards compatibility
 	}
 
 	emptyLayer := v1.Descriptor{

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 
@@ -113,6 +114,10 @@ const (
 //	blobsPathSpec:                  <root>/v2/blobs/
 //	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
 //	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//
+//	Artifacts:
+//
+//	subjectReferrerPathSpec         <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<subject hex digest>/_referrers/_<artifactType>/<algorithm>/<referrer hex digest>/link
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -250,6 +255,19 @@ func pathFor(spec pathSpec) (string, error) {
 		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "hashstates", string(v.alg), offset)...), nil
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
+	case subjectReferrerLinkPathSpec:
+		manifestPath, err := pathFor(manifestRevisionPathSpec{name: v.name, revision: v.subject})
+		if err != nil {
+			return "", err
+		}
+
+		artifactType := "_" + url.QueryEscape(v.mediaType)
+		components, err := digestPathComponents(v.referrer, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(manifestPath, "_referrers", artifactType, path.Join(components...), "link"), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)
@@ -449,6 +467,17 @@ func (uploadHashStatePathSpec) pathSpec() {}
 type repositoriesRootPathSpec struct{}
 
 func (repositoriesRootPathSpec) pathSpec() {}
+
+// subjectReferrerLinkPathSpec returns the describes the link of a subject to
+// its referrers
+type subjectReferrerLinkPathSpec struct {
+	name      string
+	referrer  digest.Digest
+	subject   digest.Digest
+	mediaType string
+}
+
+func (subjectReferrerLinkPathSpec) pathSpec() {}
 
 // digestPathComponents provides a consistent path breakdown for a given
 // digest. For a generic digest, it will be as follows:

--- a/registry/storage/references.go
+++ b/registry/storage/references.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
+)
+
+// ReferenceService is a service to manage internal links from subjects back to
+// their referrers.
+type ReferenceService interface {
+	// Link creates a link from a subject back to a referrer
+	Link(ctx context.Context, mediaType string, referrer, subject digest.Digest) error
+}
+
+type referenceHandler struct {
+	*blobStore
+	repository distribution.Repository
+	pathFn     func(name, mediaType string, reference, artifact_subject_must_be_manifest digest.Digest) (string, error)
+}
+
+func (r *referenceHandler) Link(ctx context.Context, artifactType string, referrer, subject digest.Digest) error {
+	path, err := r.pathFn(r.repository.Named().Name(), artifactType, referrer, subject)
+	if err != nil {
+		return err
+	}
+
+	return r.blobStore.link(ctx, path, referrer)
+}
+
+// subjectReferrerLinkPath provides the path to the subject's referrer link
+func subjectReferrerLinkPath(name, mediaType string, referrer, subject digest.Digest) (string, error) {
+	return pathFor(subjectReferrerLinkPathSpec{name: name, mediaType: mediaType, referrer: referrer, subject: subject})
+}

--- a/registry/storage/references.go
+++ b/registry/storage/references.go
@@ -2,16 +2,34 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
 
 	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+// ReferrerResult represents a single referrer linked to a subject.
+type ReferrerResult struct {
+	Digest       digest.Digest
+	ArtifactType string
+}
 
 // ReferenceService is a service to manage internal links from subjects back to
 // their referrers.
 type ReferenceService interface {
 	// Link creates a link from a subject back to a referrer
 	Link(ctx context.Context, mediaType string, referrer, subject digest.Digest) error
+
+	// Referrers returns the descriptors of all manifests that reference the
+	// given subject digest. If artifactType is non-empty, results are filtered
+	// to only that type.
+	Referrers(ctx context.Context, subject digest.Digest, artifactType string) ([]v1.Descriptor, error)
 }
 
 type referenceHandler struct {
@@ -27,6 +45,193 @@ func (r *referenceHandler) Link(ctx context.Context, artifactType string, referr
 	}
 
 	return r.blobStore.link(ctx, path, referrer)
+}
+
+// Referrers enumerates the _referrers directory for the given subject and
+// returns a descriptor for each linked manifest. The storage layout is:
+//
+//	<repo>/_manifests/revisions/<subject-alg>/<subject-hex>/_referrers/_<artifactType>/<ref-alg>/<ref-hex>/link
+func (r *referenceHandler) Referrers(ctx context.Context, subject digest.Digest, artifactType string) ([]v1.Descriptor, error) {
+	name := r.repository.Named().Name()
+
+	// Build the base path: <repo>/_manifests/revisions/<subject>/_referrers/
+	manifestPath, err := pathFor(manifestRevisionPathSpec{name: name, revision: subject})
+	if err != nil {
+		return nil, err
+	}
+	referrersRoot := path.Join(manifestPath, "_referrers")
+
+	// List artifact type directories under _referrers/
+	typeDirs, err := r.blobStore.driver.List(ctx, referrersRoot)
+	if err != nil {
+		// If the directory doesn't exist, there are no referrers.
+		if isPathNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing referrers: %w", err)
+	}
+
+	var descriptors []v1.Descriptor
+
+	for _, typeDir := range typeDirs {
+		dirName := path.Base(typeDir)
+		if !strings.HasPrefix(dirName, "_") {
+			continue
+		}
+
+		// Decode the artifact type: strip leading "_" and URL-unescape
+		decodedType, err := url.QueryUnescape(dirName[1:])
+		if err != nil {
+			continue
+		}
+
+		// Filter by artifactType if requested
+		if artifactType != "" && decodedType != artifactType {
+			continue
+		}
+
+		// Walk the algorithm directories under this type dir to find link files.
+		err = enumerateReferrerLinks(ctx, r.blobStore, typeDir, decodedType, &descriptors)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return descriptors, nil
+}
+
+// enumerateReferrerLinks walks <typeDir>/<algorithm>/<hex>/link entries and
+// builds descriptors for each referrer found.
+func enumerateReferrerLinks(ctx context.Context, bs *blobStore, typeDir, artifactType string, descriptors *[]v1.Descriptor) error {
+	// List algorithm directories (e.g., "sha256")
+	algDirs, err := bs.driver.List(ctx, typeDir)
+	if err != nil {
+		if isPathNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, algDir := range algDirs {
+		alg := path.Base(algDir)
+
+		// List hex digest directories
+		hexDirs, err := bs.driver.List(ctx, algDir)
+		if err != nil {
+			if isPathNotFound(err) {
+				continue
+			}
+			return err
+		}
+
+		for _, hexDir := range hexDirs {
+			hex := path.Base(hexDir)
+			linkPath := path.Join(hexDir, "link")
+
+			referrerDigest, err := bs.readlink(ctx, linkPath)
+			if err != nil {
+				if isPathNotFound(err) {
+					continue
+				}
+				return err
+			}
+
+			// Verify consistency
+			expected := digest.NewDigestFromEncoded(digest.Algorithm(alg), hex)
+			if referrerDigest != expected {
+				continue
+			}
+
+			// Stat the blob to get size
+			desc, err := bs.statter.Stat(ctx, referrerDigest)
+			if err != nil {
+				// Referrer blob may have been deleted; skip it
+				continue
+			}
+
+			// Read the manifest to extract mediaType and annotations
+			// per the OCI Distribution Spec referrers response requirements.
+			enrichDescriptorFromManifest(ctx, bs, referrerDigest, &desc, artifactType)
+
+			*descriptors = append(*descriptors, desc)
+		}
+	}
+
+	return nil
+}
+
+// manifestEnvelope is a minimal struct for extracting mediaType, artifactType,
+// annotations, and config.mediaType from a stored manifest without fully
+// deserializing it.
+type manifestEnvelope struct {
+	MediaType    string            `json:"mediaType,omitempty"`
+	ArtifactType string            `json:"artifactType,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	Config       *v1.Descriptor    `json:"config,omitempty"`
+}
+
+// enrichDescriptorFromManifest reads the raw manifest blob and populates the
+// descriptor's MediaType, ArtifactType, and Annotations per the OCI
+// Distribution Spec referrers response requirements.
+func enrichDescriptorFromManifest(ctx context.Context, bs *blobStore, dgst digest.Digest, desc *v1.Descriptor, storedArtifactType string) {
+	blobPath, err := pathFor(blobDataPathSpec{digest: dgst})
+	if err != nil {
+		desc.ArtifactType = storedArtifactType
+		return
+	}
+
+	content, err := bs.driver.GetContent(ctx, blobPath)
+	if err != nil {
+		desc.ArtifactType = storedArtifactType
+		return
+	}
+
+	var env manifestEnvelope
+	if err := json.Unmarshal(content, &env); err != nil {
+		desc.ArtifactType = storedArtifactType
+		return
+	}
+
+	if env.MediaType != "" {
+		desc.MediaType = env.MediaType
+	}
+	if env.Annotations != nil {
+		desc.Annotations = env.Annotations
+	}
+
+	// ArtifactType: use manifest's artifactType, fall back to config.mediaType,
+	// then fall back to the stored directory name.
+	switch {
+	case env.ArtifactType != "":
+		desc.ArtifactType = env.ArtifactType
+	case env.Config != nil && env.Config.MediaType != "" && env.Config.MediaType != v1.MediaTypeEmptyJSON:
+		desc.ArtifactType = env.Config.MediaType
+	default:
+		desc.ArtifactType = storedArtifactType
+	}
+}
+
+// isPathNotFound returns true if the error indicates the path does not exist.
+func isPathNotFound(err error) bool {
+	switch err.(type) {
+	case driver.PathNotFoundError:
+		return true
+	}
+	return false
+}
+
+// NewReferenceEnumerator creates a ReferenceService that can enumerate
+// referrers for a given repository using the storage driver directly.
+func NewReferenceEnumerator(d driver.StorageDriver, repo distribution.Repository) ReferenceService {
+	bs := &blobStore{
+		driver:  d,
+		statter: &blobStatter{driver: d},
+	}
+	return &referenceHandler{
+		blobStore:  bs,
+		repository: repo,
+		pathFn:     subjectReferrerLinkPath,
+	}
 }
 
 // subjectReferrerLinkPath provides the path to the subject's referrer link

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -305,6 +305,11 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 			repository:   repo,
 			blobStore:    blobStore,
 			manifestURLs: repo.registry.manifestURLs,
+			references: &referenceHandler{
+				blobStore:  repo.blobStore,
+				repository: repo,
+				pathFn:     subjectReferrerLinkPath,
+			},
 		},
 		ocischemaIndexHandler: &ocischemaIndexHandler{
 			manifestListHandler: manifestListHandler,

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -114,3 +114,29 @@ func UploadBlobs(repository distribution.Repository, layers map[digest.Digest]io
 	}
 	return nil
 }
+
+// SeekerLen returns the apparent size of s
+func SeekerLen(s io.Seeker) (int64, error) {
+	offset, err := s.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read initial offset: %w", err)
+	}
+	size, err := s.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read size: %w", err)
+	}
+	_, err = s.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, fmt.Errorf("failed to restore initial offset: %w", err)
+	}
+	return size, nil
+}
+
+// MustSeekerLen returns the apparent size of s or panics
+func MustSeekerLen(s io.Seeker) int64 {
+	size, err := SeekerLen(s)
+	if err != nil {
+		panic(err)
+	}
+	return size
+}


### PR DESCRIPTION
## Summary

Implements the OCI Distribution Spec v1.1 referrers API (`GET /v2/{name}/referrers/{digest}`), completing the work started in #3834 and #4483.

This builds on the storage-layer subject linking by @brackendawson and @alistair (cherry-picked from #4483) and adds the read-side endpoint that was left as TODO.

### What's included

**From #4483 (storage layer — @brackendawson, @alistair):**
- Parse `subject` and `artifactType` fields on OCI manifest and index PUT
- Create referrer link files on the filesystem under `_referrers/`
- Validate `subject.mediaType` is a manifest type

**New (referrers API endpoint):**
- Register `GET /v2/{name}/referrers/{digest}` route
- Return an OCI Image Index (`application/vnd.oci.image.index.v1+json`) with descriptors for all manifests referencing the subject
- Enrich each descriptor with `mediaType`, `artifactType`, and `annotations` from the manifest blob per spec
- Resolve `artifactType` per spec: manifest field → `config.mediaType` fallback
- Support `?artifactType=` query parameter filtering with `OCI-Filters-Applied` response header
- Return empty index (not 404) when no referrers exist
- Enumerate referrer links from the filesystem storage layout

### Tests

- `TestReferrersAPI` — end-to-end test covering:
  - Push subject manifest, push artifact manifest with subject reference
  - Query referrers (unfiltered) — verify digest, mediaType, artifactType
  - Query with matching artifactType filter — verify filtering + header
  - Query with non-matching filter — verify empty result
  - Query for digest with no referrers — verify empty index
- All existing tests pass (handlers, storage, manifest suites)

### Spec references

- [OCI Distribution Spec v1.1 — Listing Referrers](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers)
- Closes #3716

### Related PRs

- #3834 — original storage-layer implementation by @brackendawson
- #4483 — rebased + index support by @alistair