### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/internal/client/transport/http_reader.go
+++ b/internal/client/transport/http_reader.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -256,8 +257,8 @@ func (hrs *HTTPReadSeeker) reader() (_ io.Reader, retErr error) {
 		encoding := strings.FieldsFunc(resp.Header.Get("Content-Encoding"), func(r rune) bool {
 			return unicode.IsSpace(r) || r == ','
 		})
-		for i := len(encoding) - 1; i >= 0; i-- {
-			algorithm := strings.ToLower(encoding[i])
+		for _, v := range slices.Backward(encoding) {
+			algorithm := strings.ToLower(v)
 			switch algorithm {
 			case "zstd":
 				r, err := zstd.NewReader(body)

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -767,8 +768,8 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 		// docs: Objects will be iterated over lexicographically by name.
 		// This means we don't have to reverse order the slice; we can
 		// range over the keys slice in reverse order
-		for i := len(keys) - 1; i >= 0; i-- {
-			key := keys[i]
+		for _, v := range slices.Backward(keys) {
+			key := v
 			err := d.bucket.Object(key).Delete(ctx)
 			// GCS only guarantees eventual consistency, so listAll might return
 			// paths that no longer exist. If this happens, just ignore any not

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -115,8 +116,8 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 // directory for all upload files
 func uuidFromPath(path string) (string, bool) {
 	components := strings.Split(path, "/")
-	for i := len(components) - 1; i >= 0; i-- {
-		if u, err := uuid.Parse(components[i]); err == nil {
+	for i, v := range slices.Backward(components) {
+		if u, err := uuid.Parse(v); err == nil {
 			return u.String(), i == len(components)-1
 		}
 	}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899