### PR TITLE
fix: validate blob cache hits against backend storage

### DIFF
--- a/registry/storage/cache/cache_test.go
+++ b/registry/storage/cache/cache_test.go
@@ -90,6 +90,56 @@ func TestCacheError(t *testing.T) {
 	}
 }
 
+func TestCacheStaleClearAfterGC(t *testing.T) {
+	cache := newTestStatter()
+	backend := newTestStatter()
+	st := NewCachedBlobStatter(cache, backend)
+	ctx := context.Background()
+
+	dgst := digest.Digest("dontvalidate")
+	desc := v1.Descriptor{
+		Digest: dgst,
+	}
+
+	// Populate both cache and backend with a descriptor.
+	if err := cache.SetDescriptor(ctx, dgst, desc); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.SetDescriptor(ctx, dgst, desc); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity check: Stat should succeed while both agree.
+	actual, err := st.Stat(ctx, dgst)
+	if err != nil {
+		t.Fatalf("unexpected error on stat with warm cache: %v", err)
+	}
+	if actual.Digest != desc.Digest {
+		t.Fatalf("unexpected descriptor %v, expected %v", actual, desc)
+	}
+
+	// Simulate garbage collection removing the blob from backend storage
+	// while the in-process cache retains the stale entry.
+	delete(backend.sets, dgst)
+
+	// Stat should now detect the stale entry and return ErrBlobUnknown.
+	_, err = st.Stat(ctx, dgst)
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("expected ErrBlobUnknown after GC, got: %v", err)
+	}
+
+	// The stale cache entry should have been cleared.
+	if _, ok := cache.sets[dgst]; ok {
+		t.Fatal("expected stale cache entry to be cleared")
+	}
+
+	// A subsequent Stat should also return ErrBlobUnknown (no stale hit).
+	_, err = st.Stat(ctx, dgst)
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("expected ErrBlobUnknown on second call, got: %v", err)
+	}
+}
+
 func newTestStatter() *testStatter {
 	return &testStatter{
 		stats: []digest.Digest{},
@@ -128,5 +178,9 @@ func (s *testStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, des
 }
 
 func (s *testStatter) Clear(ctx context.Context, dgst digest.Digest) error {
-	return s.err
+	if s.err != nil {
+		return s.err
+	}
+	delete(s.sets, dgst)
+	return nil
 }

--- a/registry/storage/cache/cachedblobdescriptorstore.go
+++ b/registry/storage/cache/cachedblobdescriptorstore.go
@@ -18,10 +18,12 @@ type cachedBlobStatter struct {
 var (
 	// cacheRequestCount is the number of total cache requests received.
 	cacheRequestCount = prometheus.StorageNamespace.NewCounter("cache_requests", "The number of cache request received")
-	// cacheRequestCount is the number of total cache requests received.
+	// cacheHitCount is the number of total cache requests that were a hit.
 	cacheHitCount = prometheus.StorageNamespace.NewCounter("cache_hits", "The number of cache request received")
 	// cacheErrorCount is the number of cache request errors.
 	cacheErrorCount = prometheus.StorageNamespace.NewCounter("cache_errors", "The number of cache request errors")
+	// cacheStaleClearCount is the number of stale cache entries cleared after backend validation.
+	cacheStaleClearCount = prometheus.StorageNamespace.NewCounter("cache_stale_clears", "The number of stale cache entries cleared after backend miss")
 )
 
 // NewCachedBlobStatter creates a new statter which prefers a cache and
@@ -40,6 +42,22 @@ func (cbds *cachedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (v1
 	desc, cacheErr := cbds.cache.Stat(ctx, dgst)
 	if cacheErr == nil {
 		cacheHitCount.Inc(1)
+
+		// Verify the blob still exists on the backend. A separate GC process
+		// may have deleted the blob from storage without being able to clear
+		// the in-process cache. Without this check, clients are told the
+		// layer already exists and skip uploading, leading to pull failures.
+		if _, err := cbds.backend.Stat(ctx, dgst); err != nil {
+			if err == distribution.ErrBlobUnknown {
+				if clearErr := cbds.cache.Clear(ctx, dgst); clearErr != nil {
+					dcontext.GetLoggerWithField(ctx, "blob", dgst).WithError(clearErr).Error("error clearing stale cache entry")
+				}
+				cacheStaleClearCount.Inc(1)
+				return v1.Descriptor{}, err
+			}
+			dcontext.GetLoggerWithField(ctx, "blob", dgst).WithError(err).Error("error from backend validating cache hit")
+		}
+
 		return desc, nil
 	}
 


### PR DESCRIPTION
## Summary

The in-memory blob descriptor cache can hold stale entries after garbage collection removes blobs from disk. Since GC runs as a separate CLI process (`registry garbage-collect`), it cannot clear the in-process cache of a running registry. This causes:

1. `docker push` to skip uploading layers (reporting "Layer already exists")
2. `docker pull` to fail with `short read: unexpected EOF`

After a cache hit, this PR adds a backend `Stat()` call to verify the blob still exists on storage. If the backend reports `ErrBlobUnknown`, the stale cache entry is cleared and the error is returned so the client re-uploads the layer.

## Changes

- `registry/storage/cache/cachedblobdescriptorstore.go`: After a cache hit in `Stat()`, validate against the backend. If the blob is missing, clear the stale cache entry and return `ErrBlobUnknown`. Added `cache_stale_clears` prometheus counter for observability. Fixed a copy-paste typo in the `cacheHitCount` comment.
- `registry/storage/cache/cache_test.go`: Added `TestCacheStaleClearAfterGC` that simulates GC removing a blob from the backend while the cache retains a stale entry, and verifies the stale entry is detected and cleared. Fixed `testStatter.Clear()` to actually delete entries from its map.

## Design considerations

- **Performance**: Every cache hit now incurs a backend `Stat()`. This is a metadata-only check (no data read) and is the same call that already happens on a cache miss. For registries where GC is infrequent, the extra call is negligible. For high-throughput registries concerned about the overhead, disabling the blob descriptor cache (`blobdescriptor: none`) is already the recommended approach.
- **Transient errors**: If the backend returns an error other than `ErrBlobUnknown` (e.g., a transient storage issue), the cached descriptor is still returned. Only confirmed-missing blobs trigger cache invalidation.

Fixes #1803