### PR TITLE
chore(build): Bump go version to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go:
           - 1.25.x
-          - 1.26.1
+          - 1.26.2
         target:
           - test-coverage
           - test-s3-storage

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # GO_VERSION sets the version of the golang base image to use.
 # It must be a supported tag in the docker.io/library/golang image repository.
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/docs.Dockerfile
+++ b/dockerfiles/docs.Dockerfile
@@ -2,7 +2,7 @@
 
 # GO_VERSION sets the version of the golang base image to use.
 # It must be a supported tag in the docker.io/library/golang image repository.
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/git.Dockerfile
+++ b/dockerfiles/git.Dockerfile
@@ -2,7 +2,7 @@
 
 # GO_VERSION sets the version of the golang base image to use.
 # It must be a supported tag in the docker.io/library/golang image repository.
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/lint.Dockerfile
+++ b/dockerfiles/lint.Dockerfile
@@ -2,7 +2,7 @@
 
 # GO_VERSION sets the version of the golang base image to use.
 # It must be a supported tag in the docker.io/library/golang image repository.
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/vendor.Dockerfile
+++ b/dockerfiles/vendor.Dockerfile
@@ -2,7 +2,7 @@
 
 # GO_VERSION sets the version of the golang base image to use.
 # It must be a supported tag in the docker.io/library/golang image repository.
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository


### PR DESCRIPTION
PTAL @thaJeztah 

There are [sec vulns present in the latest image](https://hub.docker.com/repository/docker/distribution/distribution/tags/edge/sha256-6498cc60e938a4752d164705d81ee402a3ea04ee40b78ab381a89ce77a289a8b) due to an outdated Go version