### PR TITLE
fix(storage): bounds-check the file basename in PurgeUploads Walk callback

### DIFF
--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -71,7 +71,12 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	err = driver.Walk(ctx, root, func(fileInfo storageDriver.FileInfo) error {
 		filePath := fileInfo.Path()
 		_, file := path.Split(filePath)
-		if file[0] == '_' {
+		// path.Split returns file == "" for paths that end in "/" (a
+		// bare directory such as the bucket root when S3 reports an
+		// empty Key / common prefix). Indexing file[0] then panics
+		// with 'index out of range [0] with length 0' and takes the
+		// whole PurgeUploads goroutine down (#4713).
+		if len(file) > 0 && file[0] == '_' {
 			// Reserved directory
 			inUploadDir = (file == "_uploads")
 


### PR DESCRIPTION
## What

Fixes #4713.

PurgeUploads' `Walk` callback split the visited path with `path.Split` and then indexed `file[0]` immediately. `path.Split` returns an empty basename for paths that end in a trailing slash - in practice this happens when an S3 driver surfaces a bare directory (common prefix) with an empty Key. Indexing a zero-length string panics with `index out of range [0] with length 0` and takes down the whole PurgeUploads goroutine, as seen in the report's trace (`purgeuploads.go:73` → `s3.go:1023`).

## Fix

Guard the length before touching `file[0]` so a trailing-slash / empty-basename entry is skipped as 'not a reserved directory' - matching what the branch was trying to do anyway. Runtime behaviour for every non-empty entry is unchanged; only the zero-length edge case stops crashing.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l registry/storage/purgeuploads.go`: clean
- `go vet ./registry/storage/...`: clean
- `go test -count=1 -run TestPurge ./registry/storage/`: pass

Closes #4713