### PR TITLE
[release/2.8] Backport CVE-2026-33540 and CVE-2026-35172 fixes

### DIFF
--- a/reference/reference_deprecated.go
+++ b/reference/reference_deprecated.go
@@ -119,7 +119,7 @@ func Path(named reference.Named) (name string) {
 //
 // Deprecated: Use [reference.Domain] or [reference.Path].
 func SplitHostname(named reference.Named) (string, string) {
-	return reference.SplitHostname(named)
+	return reference.Domain(named), reference.Path(named)
 }
 
 // Parse parses s and returns a syntactically valid Reference.

--- a/registry/client/auth/challenge/authchallenge_test.go
+++ b/registry/client/auth/challenge/authchallenge_test.go
@@ -125,3 +125,44 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	}()
 	s.Wait()
 }
+
+func TestFilteringManager(t *testing.T) {
+	t.Parallel()
+
+	base := NewSimpleManager()
+	manager := NewFilteringManager(base, func(c Challenge) bool {
+		return c.Parameters["service"] == "keep.example.com"
+	})
+
+	endpoint, err := url.Parse("https://registry.example.com/v2/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &http.Response{
+		Request: &http.Request{
+			URL: endpoint,
+		},
+		Header:     make(http.Header),
+		StatusCode: http.StatusUnauthorized,
+	}
+	resp.Header.Add("WWW-Authenticate", `Bearer realm="https://auth.example.com/token",service="keep.example.com"`)
+	resp.Header.Add("WWW-Authenticate", `Bearer realm="https://evil.example.net/token",service="drop.example.net"`)
+
+	if err := manager.AddResponse(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	challenges, err := manager.GetChallenges(*endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(challenges) != 1 {
+		t.Fatalf("unexpected challenge count: got %d want 1", len(challenges))
+	}
+
+	if got := challenges[0].Parameters["service"]; got != "keep.example.com" {
+		t.Fatalf("unexpected surviving challenge service: %q", got)
+	}
+}

--- a/registry/client/auth/challenge/filteringmanager.go
+++ b/registry/client/auth/challenge/filteringmanager.go
@@ -1,0 +1,46 @@
+package challenge
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// FilteringManager decorates another Manager and drops challenges that do not
+// satisfy the configured predicate.
+type FilteringManager struct {
+	base Manager
+	keep func(Challenge) bool
+}
+
+// NewFilteringManager returns a Manager that delegates storage to base and
+// filters challenges on reads. If keep is nil, the base manager is returned.
+func NewFilteringManager(base Manager, keep func(Challenge) bool) Manager {
+	if keep == nil {
+		return base
+	}
+
+	return FilteringManager{
+		base: base,
+		keep: keep,
+	}
+}
+
+func (m FilteringManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
+	challenges, err := m.base.GetChallenges(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]Challenge, 0, len(challenges))
+	for _, c := range challenges {
+		if m.keep(c) {
+			filtered = append(filtered, c)
+		}
+	}
+
+	return filtered, nil
+}
+
+func (m FilteringManager) AddResponse(resp *http.Response) error {
+	return m.base.AddResponse(resp)
+}

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
+	"golang.org/x/net/publicsuffix"
 )
 
 const challengeHeader = "Docker-Distribution-Api-Version"
@@ -57,6 +59,11 @@ func configureAuth(username, password, remoteURL string) (auth.CredentialStore, 
 func getAuthURLs(remoteURL string) ([]string, error) {
 	authURLs := []string{}
 
+	remote, err := url.Parse(remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := http.Get(remoteURL + "/v2/")
 	if err != nil {
 		return nil, err
@@ -64,12 +71,55 @@ func getAuthURLs(remoteURL string) ([]string, error) {
 	defer resp.Body.Close()
 
 	for _, c := range challenge.ResponseChallenges(resp) {
-		if strings.EqualFold(c.Scheme, "bearer") {
+		if strings.EqualFold(c.Scheme, "bearer") && realmAllowed(remote, c.Parameters["realm"]) {
 			authURLs = append(authURLs, c.Parameters["realm"])
 		}
 	}
 
 	return authURLs, nil
+}
+
+func realmAllowed(remote *url.URL, realm string) bool {
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return false
+	}
+	if realmURL.Host == "" || remote == nil || remote.Host == "" {
+		return false
+	}
+
+	if strings.EqualFold(remote.Host, realmURL.Host) {
+		return true
+	}
+
+	remoteHost := strings.ToLower(remote.Hostname())
+	realmHost := strings.ToLower(realmURL.Hostname())
+	if remoteHost == "" || realmHost == "" {
+		return false
+	}
+
+	if isLiteralOrLocal(remoteHost) || isLiteralOrLocal(realmHost) {
+		return false
+	}
+
+	return strings.EqualFold(registrableDomain(remoteHost), registrableDomain(realmHost))
+}
+
+func isLiteralOrLocal(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	return net.ParseIP(host) != nil
+}
+
+func registrableDomain(host string) string {
+	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		return ""
+	}
+
+	return domain
 }
 
 func ping(manager challenge.Manager, endpoint, versionHeader string) error {

--- a/registry/proxy/proxyauth_test.go
+++ b/registry/proxy/proxyauth_test.go
@@ -1,0 +1,136 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/docker/distribution/registry/client/auth/challenge"
+)
+
+func TestConfigureAuthAllowsSameAuthorityRealm(t *testing.T) {
+	t.Parallel()
+
+	var serverURL string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s/token",service="test-service"`, serverURL))
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+	serverURL = upstream.URL
+
+	tokenCreds, err := configureAuth("user", "pass", upstream.URL)
+	if err != nil {
+		t.Fatalf("configureAuth: %v", err)
+	}
+
+	realmURL, err := url.Parse(serverURL + "/token")
+	if err != nil {
+		t.Fatalf("parse realm: %v", err)
+	}
+
+	username, password := tokenCreds.Basic(realmURL)
+	if username != "user" || password != "pass" {
+		t.Fatalf("unexpected credentials for trusted realm: got (%q, %q)", username, password)
+	}
+}
+
+func TestConfigureAuthRejectsLoopbackRealmOnDifferentAuthority(t *testing.T) {
+	t.Parallel()
+
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(evil.Close)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s/token",service="test-service"`, evil.URL))
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+
+	tokenCreds, err := configureAuth("user", "pass", upstream.URL)
+	if err != nil {
+		t.Fatalf("configureAuth: %v", err)
+	}
+
+	realmURL, err := url.Parse(evil.URL + "/token")
+	if err != nil {
+		t.Fatalf("parse realm: %v", err)
+	}
+
+	username, password := tokenCreds.Basic(realmURL)
+	if username != "" || password != "" {
+		t.Fatalf("unexpected credentials for off-origin realm: got (%q, %q)", username, password)
+	}
+}
+
+func TestRealmAllowedForDockerHubStyleAuthService(t *testing.T) {
+	t.Parallel()
+
+	remoteURL, err := url.Parse("https://registry-1.docker.io")
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+
+	if !realmAllowed(remoteURL, "https://auth.docker.io/token") {
+		t.Fatal("expected docker hub auth realm to remain allowed")
+	}
+}
+
+func TestRealmFilteringChallengeManagerDropsOffOriginBearer(t *testing.T) {
+	t.Parallel()
+
+	remoteURL, err := url.Parse("https://registry.example.com")
+	if err != nil {
+		t.Fatalf("parse remote url: %v", err)
+	}
+
+	endpoint, err := url.Parse("https://registry.example.com/v2/")
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
+	}
+
+	resp := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     make(http.Header),
+		Request:    &http.Request{URL: endpoint},
+	}
+	resp.Header.Add("Www-Authenticate", `Bearer realm="https://auth.example.com/token",service="registry.example.com"`)
+	resp.Header.Add("Www-Authenticate", `Bearer realm="https://evil.example.net/token",service="registry.example.com"`)
+
+	manager := challenge.NewFilteringManager(challenge.NewSimpleManager(), func(c challenge.Challenge) bool {
+		return !strings.EqualFold(c.Scheme, "bearer") || realmAllowed(remoteURL, c.Parameters["realm"])
+	})
+	if err := manager.AddResponse(resp); err != nil {
+		t.Fatalf("add response: %v", err)
+	}
+
+	challenges, err := manager.GetChallenges(*endpoint)
+	if err != nil {
+		t.Fatalf("get challenges: %v", err)
+	}
+
+	if len(challenges) != 1 {
+		t.Fatalf("unexpected challenge count: got %d want 1", len(challenges))
+	}
+	if challenges[0].Scheme != "bearer" {
+		t.Fatalf("unexpected surviving challenge: %+v", challenges[0])
+	}
+	if challenges[0].Parameters["realm"] != "https://auth.example.com/token" {
+		t.Fatalf("unexpected surviving realm: %q", challenges[0].Parameters["realm"])
+	}
+}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/distribution/reference"
@@ -208,7 +209,9 @@ func (r *remoteAuthChallenger) credentialStore() auth.CredentialStore {
 }
 
 func (r *remoteAuthChallenger) challengeManager() challenge.Manager {
-	return r.cm
+	return challenge.NewFilteringManager(r.cm, func(c challenge.Challenge) bool {
+		return !strings.EqualFold(c.Scheme, "bearer") || realmAllowed(&r.remoteURL, c.Parameters["realm"])
+	})
 }
 
 // tryEstablishChallenges will attempt to get a challenge type for the upstream if none currently exist

--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -210,7 +210,21 @@ func (rsrbds *repositoryScopedRedisBlobDescriptorService) Clear(ctx context.Cont
 		return distribution.ErrBlobUnknown
 	}
 
-	return rsrbds.upstream.Clear(ctx, dgst)
+	// Remove the repository-scoped membership and descriptor metadata in one transaction.
+	if _, err := conn.Do("MULTI"); err != nil {
+		return err
+	}
+	if _, err := conn.Do("SREM", rsrbds.repositoryBlobSetKey(rsrbds.repo), dgst); err != nil {
+		return err
+	}
+	if _, err := conn.Do("DEL", rsrbds.blobDescriptorHashKey(dgst)); err != nil {
+		return err
+	}
+	if _, err := conn.Do("HDEL", rsrbds.upstream.blobDescriptorHashKey(dgst), "digest", "size", "mediatype"); err != nil {
+		return err
+	}
+	_, err = conn.Do("EXEC")
+	return err
 }
 
 func (rsrbds *repositoryScopedRedisBlobDescriptorService) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {

--- a/registry/storage/cache/redis/redis_test.go
+++ b/registry/storage/cache/redis/redis_test.go
@@ -1,13 +1,16 @@
 package redis
 
 import (
+	"context"
 	"flag"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/storage/cache/cachecheck"
 	"github.com/garyburd/redigo/redis"
+	"github.com/opencontainers/go-digest"
 )
 
 var redisAddr string
@@ -19,17 +22,100 @@ func init() {
 // TestRedisLayerInfoCache exercises a live redis instance using the cache
 // implementation.
 func TestRedisBlobDescriptorCacheProvider(t *testing.T) {
+	pool := mustRedisPool(t)
+
+	// Clear the database
+	conn := pool.Get()
+	if _, err := conn.Do("FLUSHDB"); err != nil {
+		t.Fatalf("unexpected error flushing redis db: %v", err)
+	}
+	conn.Close()
+
+	cachecheck.CheckBlobDescriptorCache(t, NewRedisBlobDescriptorCacheProvider(pool))
+}
+
+// TestRepositoryScopedClearRevokesRepositoryMembership ensures Clear removes
+// repository-scoped membership so a peer repository warm-up cannot re-enable
+// stale access in the cleared repository.
+func TestRepositoryScopedClearRevokesRepositoryMembership(t *testing.T) {
+	pool := mustRedisPool(t)
+	flushRedisDB(t, pool)
+
+	ctx := context.Background()
+	cache := &redisBlobDescriptorService{pool: pool}
+	repoA := &repositoryScopedRedisBlobDescriptorService{repo: "foo/repo-a", upstream: cache}
+	repoB := &repositoryScopedRedisBlobDescriptorService{repo: "foo/repo-b", upstream: cache}
+
+	dgst := digest.FromString("stale-membership-regression")
+	desc := distribution.Descriptor{
+		Digest:    dgst,
+		Size:      1337,
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+	}
+
+	if err := repoA.SetDescriptor(ctx, dgst, desc); err != nil {
+		t.Fatalf("unexpected error setting descriptor for repo a: %v", err)
+	}
+	if err := repoB.SetDescriptor(ctx, dgst, desc); err != nil {
+		t.Fatalf("unexpected error setting descriptor for repo b: %v", err)
+	}
+	if _, err := repoA.Stat(ctx, dgst); err != nil {
+		t.Fatalf("unexpected error statting descriptor for repo a before clear: %v", err)
+	}
+
+	if err := repoA.Clear(ctx, dgst); err != nil {
+		t.Fatalf("unexpected error clearing descriptor for repo a: %v", err)
+	}
+	if _, err := repoA.Stat(ctx, dgst); err != distribution.ErrBlobUnknown {
+		t.Fatalf("expected repo a stat after clear to return ErrBlobUnknown, got: %v", err)
+	}
+
+	// Simulate another repository repopulating the shared descriptor hash.
+	if err := repoB.SetDescriptor(ctx, dgst, desc); err != nil {
+		t.Fatalf("unexpected error warming descriptor for repo b: %v", err)
+	}
+	if _, err := repoB.Stat(ctx, dgst); err != nil {
+		t.Fatalf("unexpected error statting descriptor for repo b after warm: %v", err)
+	}
+	if _, err := repoA.Stat(ctx, dgst); err != distribution.ErrBlobUnknown {
+		t.Fatalf("expected repo a stat after peer warm to return ErrBlobUnknown, got: %v", err)
+	}
+
+	conn := pool.Get()
+	defer conn.Close()
+
+	member, err := redis.Bool(conn.Do("SISMEMBER", repoA.repositoryBlobSetKey(repoA.repo), dgst))
+	if err != nil {
+		t.Fatalf("unexpected error checking repo a membership: %v", err)
+	}
+	if member {
+		t.Fatal("expected repo a membership to be removed during clear")
+	}
+
+	exists, err := redis.Int(conn.Do("EXISTS", repoA.blobDescriptorHashKey(dgst)))
+	if err != nil {
+		t.Fatalf("unexpected error checking repo a descriptor hash: %v", err)
+	}
+	if exists != 0 {
+		t.Fatal("expected repo a descriptor hash to be removed during clear")
+	}
+}
+
+// mustRedisPool creates a redis pool for integration tests or skips when no
+// redis endpoint is configured.
+func mustRedisPool(t *testing.T) *redis.Pool {
+	t.Helper()
+
 	if redisAddr == "" {
-		// fallback to an environement variable
+		// fallback to an environment variable
 		redisAddr = os.Getenv("TEST_REGISTRY_STORAGE_CACHE_REDIS_ADDR")
 	}
 
 	if redisAddr == "" {
-		// skip if still not set
 		t.Skip("please set -test.registry.storage.cache.redis.addr to test layer info cache against redis")
 	}
 
-	pool := &redis.Pool{
+	return &redis.Pool{
 		Dial: func() (redis.Conn, error) {
 			return redis.Dial("tcp", redisAddr)
 		},
@@ -41,13 +127,16 @@ func TestRedisBlobDescriptorCacheProvider(t *testing.T) {
 		},
 		Wait: false, // if a connection is not available, proceed without cache.
 	}
+}
 
-	// Clear the database
+// flushRedisDB clears redis before each integration test to isolate test data.
+func flushRedisDB(t *testing.T, pool *redis.Pool) {
+	t.Helper()
+
 	conn := pool.Get()
+	defer conn.Close()
+
 	if _, err := conn.Do("FLUSHDB"); err != nil {
 		t.Fatalf("unexpected error flushing redis db: %v", err)
 	}
-	conn.Close()
-
-	cachecheck.CheckBlobDescriptorCache(t, NewRedisBlobDescriptorCacheProvider(pool))
 }


### PR DESCRIPTION
Backport security fixes from v3 to release/2.8:\n- CVE-2026-33540\n- CVE-2026-35172\n\nAlso includes a v2-compatible redis regression test for repo-scoped descriptor revocation behavior.