### PR TITLE
storage: skip redundant Close() in blobWriter.Cancel

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -99,9 +99,12 @@ func (bw *blobWriter) Cancel(ctx context.Context) error {
 		return err
 	}
 
-	if err := bw.Close(); err != nil {
-		dcontext.GetLogger(ctx).Errorf("error closing blobwriter: %s", err)
-	}
+	// fileWriter.Cancel already closed the underlying writer; invoking
+	// Close again is redundant and structurally errors on the closed FD
+	// (logging a misleading "error closing blobwriter" line on every
+	// successful cancel). storeHashState — the only side effect of
+	// bw.Close beyond fileWriter.Close — is irrelevant on the cancel
+	// path: a cancelled upload cannot be resumed.
 
 	return bw.removeResources(ctx)
 }


### PR DESCRIPTION
## Summary

`blobWriter.Cancel` currently invokes `fileWriter.Cancel` followed by `bw.Close`. The `fileWriter.Cancel` implementation closes the underlying file descriptor (and, in the filesystem driver, sets `fw.closed=true`), so the subsequent `bw.Close → fileWriter.Close` call is structurally guaranteed to fail:

- filesystem driver `fileWriter.Close` short-circuits with `fmt.Errorf("already closed")` when `fw.closed` is true.
- On older paths where `fw.closed` was not set by Cancel, `Close` falls through to `fw.file.Sync()` on the closed FD and returns `os.PathError` `"sync ...: file already closed"`.

Either way, every successful Cancel produces one spurious `level=error msg="error closing blobwriter: ..."` log line, which is misleading (the cancel succeeded) and noisy in deployments serving clients that frequently cancel uploads — for example, push tools that probe with a cross-repo mount and abandon the resulting upload session when mount is not applicable. `go-containerregistry`-based clients (crane, regclient, kaniko's cancel path) exhibit this pattern routinely.

## Rationale for dropping the call entirely

`storeHashState` — the only state-mutating side effect of `bw.Close` beyond `fileWriter.Close` — is irrelevant on the cancel path: a cancelled upload cannot be resumed, so the persisted hash state would never be read. `Cancel`'s `removeResources` call below deletes the upload directory anyway. The `bw.Close` call has no observable effect other than producing the misleading log line.

After this change, cleanup becomes `fileWriter.Cancel → removeResources`, with no spurious log.

## Reproducer

Against a running registry (any version that has this code path):

```sh
# Start an upload session
loc=$(curl -sI -X POST "http://<registry>/v2/<repo>/blobs/uploads/" | awk -F' ' '/^Location:/ {print $2}' | tr -d '\r')

# Immediately cancel it (Offset=0; no bytes ever PATCHed)
curl -sI -X DELETE "$loc"
```

**Before:**
```
level=error msg="error closing blobwriter: already closed" ... http.request.method=DELETE http.request.uri="/v2/<repo>/blobs/uploads/<uuid>" ...
```
(or `sync /var/lib/registry/.../data: file already closed` on the older filesystem-driver path)

**After:** zero such lines. HTTP responses unchanged: `202 Accepted` on POST, `204 No Content` on DELETE.

## Test plan

- [x] Manual reproducer: synthetic POST `/uploads/` + immediate DELETE — verified 0 error log lines post-fix vs 1 per cancel pre-fix.
- [x] In-place storage compatibility: a v2.8.3-era filesystem volume (`/var/lib/registry`) is read cleanly by the patched binary; existing manifests pull correctly with the OCI Accept header, `/v2/_catalog` enumerates without error.
- [x] Concurrent kaniko CI workload: HEAD-probe-then-upload flow continues to work; no regression in the standard `BLOB_UNKNOWN`/`MANIFEST_UNKNOWN` 404 negative-probe path.
- [ ] CI checks (this PR).