### PR TITLE
feat(s3): parse and strictly validate redirectendpoint on driver initialization

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -18,6 +18,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `secretkey`  | no   | Your AWS Secret Key. If you use [IAM roles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), omit to fetch temporary credentials from IAM. |
 | `region` |  yes  | The AWS region in which your bucket exists. |
 | `regionendpoint` | no | Endpoint for S3 compatible storage services (Minio, etc). |
+| `redirectendpoint` | no | The public-facing endpoint used exclusively for generating presigned redirect URLs for object downloads. |
 | `forcepathstyle` | no | To enable path-style addressing when the value is set to `true`. The default is `false`. |
 | `bucket`  | yes | The bucket name in which you want to store the registry's data. |
 | `encrypt`  | no | Specifies whether the registry stores the image in encrypted format or not. A boolean value. The default is `false`. |
@@ -46,6 +47,9 @@ Amazon S3 or S3 compatible services for object storage.
 `region`: The name of the aws region in which you would like to store objects (for example `us-east-1`). For a list of regions, see [Regions, Availability Zones, and Local Zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
 
 `regionendpoint`: (optional) Endpoint URL for S3 compatible APIs, from version 3+ it's required to be used with `forcepathstyle: true`. Given the `regionendpoint` overrides the API host domain, forcing the path style is necessary, see [more about](https://github.com/distribution/distribution/issues/4528). **This option should not be provided when using Amazon S3.**
+
+`redirectendpoint`: (optional) A public-facing S3 or CDN endpoint URL used exclusively for generating presigned redirect URLs for object downloads. This is useful in architectures where image uploads travel over an isolated internal network endpoint (`regionendpoint`), while image downloads are routed through a separate, accelerated public endpoint. Must include a valid scheme (`http://` or `https://`) and host, and cannot contain a base path or query parameters. Note that replacing the host only works seamlessly for path-style addressing, effectively requiring `forcepathstyle: true` if using custom non-S3 domains.
+
 
 `forcepathstyle`: (optional) Force path style for S3 compatible APIs. Some manufacturers only support force path style, while others only support DNS based bucket routing. Amazon S3 supports both. The value of this parameter applies, regardless of the region settings.
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -117,6 +118,7 @@ type DriverParameters struct {
 	Accelerate                  bool
 	UseFIPSEndpoint             bool
 	LogLevel                    aws.LogLevelType
+	RedirectEndpoint            string
 }
 
 func init() {
@@ -165,6 +167,7 @@ type driver struct {
 	RootDirectory               string
 	StorageClass                string
 	ObjectACL                   string
+	RedirectEndpoint            *url.URL
 	pool                        *sync.Pool
 }
 
@@ -335,6 +338,11 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		return nil, err
 	}
 
+	redirectEndpoint := parameters["redirectendpoint"]
+	if redirectEndpoint == nil {
+		redirectEndpoint = ""
+	}
+
 	params := DriverParameters{
 		AccessKey:                   fmt.Sprint(accessKey),
 		SecretKey:                   fmt.Sprint(secretKey),
@@ -360,6 +368,7 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		Accelerate:                  accelerateBool,
 		UseFIPSEndpoint:             useFIPSEndpointBool,
 		LogLevel:                    getS3LogLevelFromParam(parameters["loglevel"]),
+		RedirectEndpoint:            fmt.Sprint(redirectEndpoint),
 	}
 
 	return New(ctx, params)
@@ -535,6 +544,29 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		pool: &sync.Pool{
 			New: func() any { return &bytes.Buffer{} },
 		},
+	}
+
+	if params.RedirectEndpoint != "" {
+		u, err := url.Parse(params.RedirectEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse redirectendpoint: %w", err)
+		}
+		if u.Scheme == "" {
+			return nil, fmt.Errorf("no scheme specified for redirectendpoint")
+		}
+		if u.Host == "" {
+			return nil, fmt.Errorf("no host specified for redirectendpoint")
+		}
+		// Edge Case: Reject trailing paths (e.g., /cdn/v1) because the hot path ignores them
+		if u.Path != "" && u.Path != "/" {
+			return nil, fmt.Errorf("redirectendpoint cannot contain a base path: %s", u.Path)
+		}
+		// Edge Case: Reject query parameters because they break AWS SigV4 signatures
+		if u.RawQuery != "" {
+			return nil, fmt.Errorf("redirectendpoint cannot contain query parameters")
+		}
+
+		d.RedirectEndpoint = u
 	}
 
 	return &Driver{
@@ -1039,6 +1071,13 @@ func (d *driver) RedirectURL(r *http.Request, path string) (string, error) {
 		})
 	default:
 		return "", nil
+	}
+
+	// If a public redirect endpoint is configured, use it for the signed URL
+	// This allows using a different public endpoint for downloads with signed URLs
+	if d.RedirectEndpoint != nil && req.HTTPRequest != nil {
+		req.HTTPRequest.URL.Host = d.RedirectEndpoint.Host
+		req.HTTPRequest.URL.Scheme = d.RedirectEndpoint.Scheme
 	}
 
 	return req.Presign(expiresIn)


### PR DESCRIPTION
### Description
This PR addresses maintainer feedback regarding how the `redirectendpoint` parameter is handled in the AWS S3 storage driver. 

Instead of parsing the configuration string on every single download request inside `URLFor`, parsing and validation now happen exactly once during driver initialization inside `New()`. The internal struct field type has been updated to `*url.URL` to get rid of string parsing overhead and unnecessary allocations.

### Changes Implemented
* **Initialization Validation (`registry/storage/driver/s3-aws/s3.go`)**: Added strict validation rules during driver initialization. The driver will now fail fast on startup if the `redirectendpoint` contains a custom base path (`u.Path`) or any query parameters (`u.RawQuery`). This prevents silent configuration mismatches and avoids corrupting AWS SigV4 request signatures.
* **Hot Path Cleanup**: Removed a redundant `req != nil` guard inside `URLFor` since the framework guarantees the request is non-nil for GET/HEAD methods at this stage.
* **Documentation (`docs/content/storage-drivers/s3.md`)**: Documented the parameter alphabetically in the main summary table and the detailed prose sections, explicitly noting that using a custom redirect domain requires setting `forcepathstyle: true`.

### Files Changed
* `docs/content/storage-drivers/s3.md`
* `registry/storage/driver/s3-aws/s3.go`

#### Example of how this feature works:

For Ceph S3 (RGW) or MinIO combined with Kubernetes Ingress resources or other clustered environments, there are typically two ways to access the S3 endpoint.

The first is an internal Service, that exposes an internal HTTP endpoint (e.g., http://ceph-rgw.rook.svc.cluster.local). The second is an external HTTPS endpoint (e.g., https://s3-ceph.domain.tld) through an Ingress, terminated by HAProxy, Envoy, NGINX, etc.

Without separate endpoints, we are currently forced to either use (1) REGISTRY_STORAGE_REDIRECT_DISABLED=true and just use http://ceph-rgw.rook.svc.cluster.local for both uploads (faster and doesn't pass through the Ingress twice) and downloads (all downloads pass through Distribution and thus bottlenecked by the instance), or use (2) https://s3-ceph.domain.tld for both uploads (bottlenecked because the blob data goes through the Ingress twice) and downloads (fastest and least resource-intensive due to the redirect).

This feature solves this issue of choosing only one of the two flawed options by using the internal fast endpoint (http://ceph-rgw.rook.svc.cluster.local) for uploads and using the redirect to the external S3 endpoint (https://s3-ceph.domain.tld) for downloads, getting the best of both worlds.