### PR TITLE
fix(proxy): ref-count shared blobs and refresh TTL on cache hit

### DIFF
--- a/docs/content/about/configuration.md
+++ b/docs/content/about/configuration.md
@@ -1269,6 +1269,15 @@ is unsupported.
 | `remoteurl`| yes     | The URL for the repository on Docker Hub.             |
 | `ttl`      | no      | Expire proxy cache configured in "storage" after this time. Cache 168h(7 days) by default, set to 0 to disable cache expiration, The suffix is one of `ns`, `us`, `ms`, `s`, `m`, or `h`. If you specify a value but omit the suffix, the value is interpreted as a number of nanoseconds. |
 
+The cache TTL counts from the most recent access: every successful cache hit
+refreshes the timer, so frequently-pulled blobs do not expire while traffic
+continues. When a TTL elapses the per-repository cache entry is dropped, but
+the underlying blob file is only vacuumed once no other repository (in the
+scheduler state or in the on-disk link tree) still references the digest.
+Orphan link files discovered on the storage tree at startup — for example
+state inherited from an older binary or an unclean shutdown — are picked up
+and rescheduled with the configured TTL.
+
 To enable pulling private repositories (e.g. `batman/robin`), specify one of the
 following authentication methods for the pull-through cache to authenticate with
 the upstream registry via the [v2 Distribution registry authentication

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -80,6 +80,24 @@ func (pbs *proxyBlobStore) serveLocal(ctx context.Context, w http.ResponseWriter
 	return true, pbs.localStore.ServeBlob(ctx, w, r, dgst)
 }
 
+// refreshSchedulerOnCacheHit re-arms the per-(repo,digest) scheduler entry
+// after a successful cache hit so that hot blobs do not expire on their
+// original TTL. Failures are logged and swallowed: the client response has
+// already been written and a missed refresh only shortens the cache TTL.
+func (pbs *proxyBlobStore) refreshSchedulerOnCacheHit(ctx context.Context, dgst digest.Digest) {
+	if pbs.scheduler == nil || pbs.ttl == nil {
+		return
+	}
+	blobRef, err := reference.WithDigest(pbs.repositoryName, dgst)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("Error creating reference for cache-hit touch: %s", err)
+		return
+	}
+	if err := pbs.scheduler.AddBlob(blobRef, *pbs.ttl); err != nil {
+		dcontext.GetLogger(ctx).Errorf("Error refreshing scheduler entry on cache hit for %s: %s", blobRef, err)
+	}
+}
+
 func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {
 	served, err := pbs.serveLocal(ctx, w, r, dgst)
 	if err != nil {
@@ -92,13 +110,7 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 		// blobs do not expire on the original TTL. Failures here are
 		// logged but do not fail the response — the bytes have already
 		// been written to the client.
-		if pbs.scheduler != nil && pbs.ttl != nil {
-			if blobRef, refErr := reference.WithDigest(pbs.repositoryName, dgst); refErr != nil {
-				dcontext.GetLogger(ctx).Errorf("Error creating reference for cache-hit touch: %s", refErr)
-			} else if addErr := pbs.scheduler.AddBlob(blobRef, *pbs.ttl); addErr != nil {
-				dcontext.GetLogger(ctx).Errorf("Error refreshing scheduler entry on cache hit for %s: %s", blobRef, addErr)
-			}
-		}
+		pbs.refreshSchedulerOnCacheHit(ctx, dgst)
 		return nil
 	}
 

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -88,6 +88,17 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 	}
 
 	if served {
+		// Cache hit: refresh the scheduler entry so frequently-accessed
+		// blobs do not expire on the original TTL. Failures here are
+		// logged but do not fail the response — the bytes have already
+		// been written to the client.
+		if pbs.scheduler != nil && pbs.ttl != nil {
+			if blobRef, refErr := reference.WithDigest(pbs.repositoryName, dgst); refErr != nil {
+				dcontext.GetLogger(ctx).Errorf("Error creating reference for cache-hit touch: %s", refErr)
+			} else if addErr := pbs.scheduler.AddBlob(blobRef, *pbs.ttl); addErr != nil {
+				dcontext.GetLogger(ctx).Errorf("Error refreshing scheduler entry on cache hit for %s: %s", blobRef, addErr)
+			}
+		}
 		return nil
 	}
 

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -530,3 +530,92 @@ func testProxyStoreServe(t *testing.T, te *testEnv, numClients int) {
 		t.Fatalf("unexpected remote stats: %#v", remoteStats)
 	}
 }
+
+// TestProxyStoreServeBlobTouchesScheduler asserts that a cache hit refreshes
+// the scheduler entry so a hot blob does not expire on its first-pull TTL.
+// We register a short TTL, hit ServeBlob repeatedly with gaps shorter than
+// that TTL but whose sum exceeds it, and verify the expiry callback never
+// fires within the observation window. Without the touch this would expire
+// after the first TTL elapses.
+func TestProxyStoreServeBlobTouchesScheduler(t *testing.T) {
+	ctx := context.Background()
+
+	nameRef, err := reference.WithName("touch/hot")
+	if err != nil {
+		t.Fatalf("WithName: %v", err)
+	}
+
+	drv := inmemory.New()
+	reg, err := storage.NewRegistry(ctx, drv,
+		storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider(memory.UnlimitedSize)),
+		storage.EnableRedirect, storage.DisableDigestResumption)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	repo, err := reg.Repository(ctx, nameRef)
+	if err != nil {
+		t.Fatalf("Repository: %v", err)
+	}
+
+	// Put a blob into the local store so serveLocal returns served=true.
+	blob := []byte("touch-on-hit payload")
+	desc, err := repo.Blobs(ctx).Put(ctx, "", blob)
+	if err != nil {
+		t.Fatalf("local Put: %v", err)
+	}
+
+	var fired int32
+	var firedMu sync.Mutex
+	s := scheduler.New(ctx, drv, "/scheduler-touch.json")
+	s.OnBlobExpire(func(ref reference.Reference) error {
+		firedMu.Lock()
+		fired++
+		firedMu.Unlock()
+		return nil
+	})
+	if err := s.Start(); err != nil {
+		t.Fatalf("scheduler Start: %v", err)
+	}
+	defer s.Stop()
+
+	ttl := 100 * time.Millisecond
+	pbs := &proxyBlobStore{
+		repositoryName: nameRef,
+		localStore:     repo.Blobs(ctx),
+		remoteStore:    repo.Blobs(ctx), // unused on cache hits
+		scheduler:      s,
+		ttl:            &ttl,
+		authChallenger: &mockChallenger{},
+	}
+
+	canonical, err := reference.WithDigest(nameRef, desc.Digest)
+	if err != nil {
+		t.Fatalf("WithDigest: %v", err)
+	}
+	if err := s.AddBlob(canonical, ttl); err != nil {
+		t.Fatalf("seed AddBlob: %v", err)
+	}
+
+	// Three ServeBlob calls separated by 60 ms (each well under the 100 ms
+	// TTL). Total elapsed time across all calls is 180 ms — without touch,
+	// the entry would have expired around the 100 ms mark, firing the
+	// callback at least once.
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pbs.ServeBlob(ctx, w, r, desc.Digest); err != nil {
+			t.Fatalf("ServeBlob call %d: %v", i+1, err)
+		}
+		time.Sleep(60 * time.Millisecond)
+	}
+
+	firedMu.Lock()
+	got := fired
+	firedMu.Unlock()
+	if got != 0 {
+		t.Fatalf("expiry callback fired %d times during repeated cache hits; touch did not refresh the timer", got)
+	}
+}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -311,10 +311,16 @@ func (pr *proxiedRepository) Tags(ctx context.Context) distribution.TagService {
 // than racing; only then it deletes the per-repository link (clearing the
 // descriptor cache for the expiring repo). The shared blob file is
 // vacuumed only when no other scheduled entry is still live for the
-// digest and no other on-disk link still references it — by the time the
-// last serialised eviction runs, every prior link has been deleted and
-// every prior entry has been dropped, so that callback observes "no
-// surviving references" and reclaims the blob.
+// digest — by the time the last serialised eviction runs, every prior
+// link has been deleted and every prior entry has been dropped, so that
+// callback observes "no surviving references" and reclaims the blob.
+//
+// Before bootstrap reconcile finishes, the scheduler may not yet know
+// about orphan on-disk links left over from prior unclean shutdowns, so
+// an extra on-disk walk runs as a safety net. Once s.Reconciled() flips
+// true the scheduler is authoritative and the walk is skipped — that
+// keeps the steady-state eviction cheap even on S3, where a recursive
+// LIST is expensive.
 // Split out from the OnBlobExpire closure so it can be unit-tested without
 // constructing a full HTTP-backed proxyingRegistry.
 func evictBlob(ctx context.Context, registry distribution.Namespace, drv driver.StorageDriver, v storage.Vacuum, s *scheduler.TTLExpirationScheduler, r reference.Canonical) error {
@@ -331,23 +337,31 @@ func evictBlob(ctx context.Context, registry distribution.Namespace, drv driver.
 		return err
 	}
 
-	expiringKey := r.String()
-	if s.HasOtherReferencesToDigest(expiringKey, r.Digest()) {
+	// Atomically drop our own scheduler entry and check whether any
+	// sibling entry still references this digest. Doing both under one
+	// scheduler lock acquisition prevents the mutual-skip race that
+	// otherwise appears when N timers for the same digest fire in the
+	// same instant: each callback removes itself before observing the
+	// remainder, so the callers naturally form a serial chain in which
+	// only the last one sees an empty map and proceeds to vacuum.
+	if !s.ClaimVacuum(r.String(), r.Digest()) {
 		dcontext.GetLogger(ctx).Infof(
 			"skipping blob vacuum for %s: another scheduled entry still references the digest",
 			r.Digest())
 		return nil
 	}
 
-	hasLink, err := anyRepoHasBlobLink(ctx, drv, r.Digest())
-	if err != nil {
-		return fmt.Errorf("checking surviving blob links for %s: %w", r.Digest(), err)
-	}
-	if hasLink {
-		dcontext.GetLogger(ctx).Infof(
-			"skipping blob vacuum for %s: a repository link still references the digest on disk",
-			r.Digest())
-		return nil
+	if !s.Reconciled() {
+		hasLink, err := anyRepoHasBlobLink(ctx, drv, r.Digest())
+		if err != nil {
+			return fmt.Errorf("checking surviving blob links for %s: %w", r.Digest(), err)
+		}
+		if hasLink {
+			dcontext.GetLogger(ctx).Infof(
+				"skipping blob vacuum for %s: a repository link still references the digest on disk (pre-reconcile)",
+				r.Digest())
+			return nil
+		}
 	}
 
 	return v.RemoveBlob(r.Digest().String())

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -2,14 +2,17 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/configuration"
@@ -66,31 +69,11 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	if ttl != nil {
 		s = scheduler.New(ctx, driver, "/scheduler-state.json")
 		s.OnBlobExpire(func(ref reference.Reference) error {
-			var r reference.Canonical
-			var ok bool
-			if r, ok = ref.(reference.Canonical); !ok {
+			r, ok := ref.(reference.Canonical)
+			if !ok {
 				return fmt.Errorf("unexpected reference type : %T", ref)
 			}
-
-			repo, err := registry.Repository(ctx, r)
-			if err != nil {
-				return err
-			}
-
-			blobs := repo.Blobs(ctx)
-
-			// Clear the repository reference and descriptor caches
-			err = blobs.Delete(ctx, r.Digest())
-			if err != nil {
-				return err
-			}
-
-			err = v.RemoveBlob(r.Digest().String())
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return evictBlob(ctx, registry, driver, v, s, r)
 		})
 
 		s.OnManifestExpire(func(ref reference.Reference) error {
@@ -115,6 +98,8 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 			}
 			return nil
 		})
+
+		s.OnReconcile(reconcileFromStorage(ctx, driver, *ttl))
 
 		err = s.Start()
 		if err != nil {
@@ -318,4 +303,221 @@ func (pr *proxiedRepository) Named() reference.Named {
 
 func (pr *proxiedRepository) Tags(ctx context.Context) distribution.TagService {
 	return pr.tags
+}
+
+// evictBlob handles a scheduled blob expiry for repo@digest in r. It
+// acquires the scheduler's per-digest eviction lock first so that
+// concurrent expiries for the same digest run one after the other rather
+// than racing; only then it deletes the per-repository link (clearing the
+// descriptor cache for the expiring repo). The shared blob file is
+// vacuumed only when no other scheduled entry is still live for the
+// digest and no other on-disk link still references it — by the time the
+// last serialised eviction runs, every prior link has been deleted and
+// every prior entry has been dropped, so that callback observes "no
+// surviving references" and reclaims the blob.
+// Split out from the OnBlobExpire closure so it can be unit-tested without
+// constructing a full HTTP-backed proxyingRegistry.
+func evictBlob(ctx context.Context, registry distribution.Namespace, drv driver.StorageDriver, v storage.Vacuum, s *scheduler.TTLExpirationScheduler, r reference.Canonical) error {
+	evictMu := s.EvictionLock(r.Digest())
+	evictMu.Lock()
+	defer evictMu.Unlock()
+
+	repo, err := registry.Repository(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	if err := repo.Blobs(ctx).Delete(ctx, r.Digest()); err != nil {
+		return err
+	}
+
+	expiringKey := r.String()
+	if s.HasOtherReferencesToDigest(expiringKey, r.Digest()) {
+		dcontext.GetLogger(ctx).Infof(
+			"skipping blob vacuum for %s: another scheduled entry still references the digest",
+			r.Digest())
+		return nil
+	}
+
+	hasLink, err := anyRepoHasBlobLink(ctx, drv, r.Digest())
+	if err != nil {
+		return fmt.Errorf("checking surviving blob links for %s: %w", r.Digest(), err)
+	}
+	if hasLink {
+		dcontext.GetLogger(ctx).Infof(
+			"skipping blob vacuum for %s: a repository link still references the digest on disk",
+			r.Digest())
+		return nil
+	}
+
+	return v.RemoveBlob(r.Digest().String())
+}
+
+// errStopWalk is a sentinel returned from the Walk callback to stop the
+// traversal on the first matching link file. Drivers may wrap the
+// returned error so the surviving result is conveyed through a separate
+// found flag captured in the closure, not via errors.Is.
+var errStopWalk = errors.New("stop walk")
+
+// anyRepoHasBlobLink reports whether any repository in storage holds a
+// layer link pointing at dgst. It walks the repositories tree directly via
+// the storage driver so it can find orphan link files that would not be
+// reported by Namespace.Repositories (which requires the per-repo
+// `_manifests` marker directory to exist). Pruning skips every subtree
+// that cannot contain a match, so the typical cost is one descent per
+// repository.
+func anyRepoHasBlobLink(ctx context.Context, drv driver.StorageDriver, dgst digest.Digest) (bool, error) {
+	root := storage.RepositoriesRootPath()
+	alg := string(dgst.Algorithm())
+	hex := dgst.Encoded()
+	matchSuffix := "/_layers/" + alg + "/" + hex + "/link"
+
+	var found bool
+	err := drv.Walk(ctx, root, func(info driver.FileInfo) error {
+		p := info.Path()
+		if info.IsDir() {
+			switch path.Base(p) {
+			case "_manifests", "_uploads":
+				return driver.ErrSkipDir
+			}
+			// Inside `_layers`, the layout is <alg>/<hex>/. Prune any
+			// algorithm or digest hex that does not match the target.
+			if idx := strings.LastIndex(p, "/_layers/"); idx >= 0 {
+				sub := p[idx+len("/_layers/"):]
+				segs := strings.Split(sub, "/")
+				switch len(segs) {
+				case 1:
+					if segs[0] != alg {
+						return driver.ErrSkipDir
+					}
+				case 2:
+					if segs[0] != alg || segs[1] != hex {
+						return driver.ErrSkipDir
+					}
+				}
+			}
+			return nil
+		}
+		if strings.HasSuffix(p, matchSuffix) {
+			found = true
+			return errStopWalk
+		}
+		return nil
+	})
+	if found {
+		return true, nil
+	}
+	if err != nil {
+		if errors.As(err, &driver.PathNotFoundError{}) {
+			return false, nil
+		}
+		return false, fmt.Errorf("walking %s: %w", root, err)
+	}
+	return false, nil
+}
+
+// reconcileFromStorage returns a scheduler.Reconciler that walks the
+// repositories tree once, discovers blob and manifest link files that have
+// no entry in the scheduler, and schedules them with ttl. Designed to
+// recover from prior unclean shutdowns and from state written by binaries
+// that did not maintain the scheduler index for all on-disk links.
+func reconcileFromStorage(ctx context.Context, drv driver.StorageDriver, ttl time.Duration) scheduler.Reconciler {
+	return func(s *scheduler.TTLExpirationScheduler) error {
+		root := storage.RepositoriesRootPath()
+		var blobCount, manifestCount int
+		walkErr := drv.Walk(ctx, root, func(info driver.FileInfo) error {
+			if info.IsDir() {
+				return nil
+			}
+			repo, kind, dgst, ok := parseRepoLinkPath(root, info.Path())
+			if !ok {
+				return nil
+			}
+			named, err := reference.WithName(repo)
+			if err != nil {
+				dcontext.GetLogger(ctx).Debugf("reconcile: invalid repository name %q: %v", repo, err)
+				return nil
+			}
+			canonical, err := reference.WithDigest(named, dgst)
+			if err != nil {
+				dcontext.GetLogger(ctx).Debugf("reconcile: cannot canonicalize %s@%s: %v", repo, dgst, err)
+				return nil
+			}
+			switch kind {
+			case linkKindBlob:
+				added, addErr := s.AddBlobIfAbsent(canonical, ttl)
+				if addErr != nil {
+					dcontext.GetLogger(ctx).Warnf("reconcile: AddBlobIfAbsent %s failed: %v", canonical, addErr)
+					return nil
+				}
+				if added {
+					blobCount++
+				}
+			case linkKindManifest:
+				added, addErr := s.AddManifestIfAbsent(canonical, ttl)
+				if addErr != nil {
+					dcontext.GetLogger(ctx).Warnf("reconcile: AddManifestIfAbsent %s failed: %v", canonical, addErr)
+					return nil
+				}
+				if added {
+					manifestCount++
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			if errors.As(walkErr, &driver.PathNotFoundError{}) {
+				return nil
+			}
+			return fmt.Errorf("walking %s: %w", root, walkErr)
+		}
+		dcontext.GetLogger(ctx).Infof(
+			"scheduler bootstrap reconcile: discovered %d orphan blob links, %d orphan manifest links",
+			blobCount, manifestCount)
+		return nil
+	}
+}
+
+const (
+	linkKindBlob     = "blob"
+	linkKindManifest = "manifest"
+
+	layersInfix    = "/_layers/"
+	manifestsInfix = "/_manifests/revisions/"
+	linkSuffix     = "/link"
+)
+
+// parseRepoLinkPath extracts (repository name, link kind, digest) from a
+// driver path rooted at root, returning ok=false for anything that is not
+// a recognised layer or manifest revision link file. Repository names
+// cannot contain "_layers" or "_manifests" as a path component (the
+// reference grammar forbids leading underscores), so the infix search is
+// unambiguous.
+func parseRepoLinkPath(root, p string) (repo string, kind string, dgst digest.Digest, ok bool) {
+	prefix := root + "/"
+	if !strings.HasPrefix(p, prefix) || !strings.HasSuffix(p, linkSuffix) {
+		return "", "", "", false
+	}
+	sub := p[len(prefix):]
+
+	if idx := strings.Index(sub, layersInfix); idx >= 0 {
+		return parseAlgHex(sub[:idx], sub[idx+len(layersInfix):], linkKindBlob)
+	}
+	if idx := strings.Index(sub, manifestsInfix); idx >= 0 {
+		return parseAlgHex(sub[:idx], sub[idx+len(manifestsInfix):], linkKindManifest)
+	}
+	return "", "", "", false
+}
+
+func parseAlgHex(repo, rest, kind string) (string, string, digest.Digest, bool) {
+	// rest must be exactly "<algorithm>/<encoded>/link"
+	parts := strings.Split(rest, "/")
+	if len(parts) != 3 || parts[2] != "link" {
+		return "", "", "", false
+	}
+	d := digest.NewDigestFromEncoded(digest.Algorithm(parts[0]), parts[1])
+	if err := d.Validate(); err != nil {
+		return "", "", "", false
+	}
+	return repo, kind, d, true
 }

--- a/registry/proxy/proxyregistry_test.go
+++ b/registry/proxy/proxyregistry_test.go
@@ -1,7 +1,18 @@
 package proxy
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+
+	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 )
 
 func TestProxyingRegistryCloseWithoutScheduler(t *testing.T) {
@@ -14,4 +25,448 @@ func TestProxyingRegistryCloseWithoutScheduler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Close() returned unexpected error: %v", err)
 	}
+}
+
+func mkDigest(t *testing.T, seed int) digest.Digest {
+	t.Helper()
+	return digest.Digest("sha256:" + fmt.Sprintf("%064d", seed))
+}
+
+func mkCanonical(t *testing.T, repo string, dgst digest.Digest) reference.Canonical {
+	t.Helper()
+	named, err := reference.WithName(repo)
+	if err != nil {
+		t.Fatalf("WithName(%q): %v", repo, err)
+	}
+	c, err := reference.WithDigest(named, dgst)
+	if err != nil {
+		t.Fatalf("WithDigest: %v", err)
+	}
+	return c
+}
+
+// putLink writes a link file at the path produced by storage.BlobLinkPath
+// (or storage.ManifestRevisionLinkPath when manifest=true). The byte
+// payload mimics the production format (the digest text) but the eviction
+// logic only cares about file existence.
+func putLink(t *testing.T, ctx context.Context, drv driver.StorageDriver, repo string, dgst digest.Digest, manifest bool) {
+	t.Helper()
+	var p string
+	var err error
+	if manifest {
+		p, err = storage.ManifestRevisionLinkPath(repo, dgst)
+	} else {
+		p, err = storage.BlobLinkPath(repo, dgst)
+	}
+	if err != nil {
+		t.Fatalf("link path: %v", err)
+	}
+	if err := drv.PutContent(ctx, p, []byte(dgst.String())); err != nil {
+		t.Fatalf("PutContent %s: %v", p, err)
+	}
+}
+
+func TestAnyRepoHasBlobLink_EmptyRegistry(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	got, err := anyRepoHasBlobLink(ctx, drv, mkDigest(t, 1))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatalf("empty registry must report no link; got true")
+	}
+}
+
+func TestAnyRepoHasBlobLink_HitAndMiss(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 42)
+	putLink(t, ctx, drv, "team/widget", d, false)
+
+	got, err := anyRepoHasBlobLink(ctx, drv, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatalf("link exists; want true, got false")
+	}
+
+	got, err = anyRepoHasBlobLink(ctx, drv, mkDigest(t, 999))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatalf("unrelated digest; want false, got true")
+	}
+}
+
+// Models the production worst case (one digest referenced by ten repos)
+// and asserts the slow-path stops on the first match instead of scanning
+// the full catalog.
+func TestAnyRepoHasBlobLink_TenRefsStopOnFirstMatch(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 7)
+	for i := 0; i < 10; i++ {
+		putLink(t, ctx, drv, fmt.Sprintf("mirror/repo-%02d", i), d, false)
+	}
+
+	got, err := anyRepoHasBlobLink(ctx, drv, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatalf("ten link copies exist; want true")
+	}
+}
+
+func TestParseRepoLinkPath(t *testing.T) {
+	root := storage.RepositoriesRootPath()
+	d := mkDigest(t, 5)
+	hex := d.Encoded()
+
+	cases := []struct {
+		name     string
+		path     string
+		wantOK   bool
+		wantRepo string
+		wantKind string
+	}{
+		{
+			name:     "blob link",
+			path:     fmt.Sprintf("%s/library/alpine/_layers/sha256/%s/link", root, hex),
+			wantOK:   true,
+			wantRepo: "library/alpine",
+			wantKind: linkKindBlob,
+		},
+		{
+			name:     "manifest link",
+			path:     fmt.Sprintf("%s/library/alpine/_manifests/revisions/sha256/%s/link", root, hex),
+			wantOK:   true,
+			wantRepo: "library/alpine",
+			wantKind: linkKindManifest,
+		},
+		{
+			name:   "wrong suffix",
+			path:   fmt.Sprintf("%s/library/alpine/_layers/sha256/%s/data", root, hex),
+			wantOK: false,
+		},
+		{
+			name:   "extra path segment after digest",
+			path:   fmt.Sprintf("%s/library/alpine/_layers/sha256/%s/extra/link", root, hex),
+			wantOK: false,
+		},
+		{
+			name:   "outside repositories root",
+			path:   fmt.Sprintf("/docker/registry/v2/blobs/sha256/%s/data", hex[:2]+"/"+hex),
+			wantOK: false,
+		},
+		{
+			name:   "invalid hex length",
+			path:   fmt.Sprintf("%s/library/alpine/_layers/sha256/abc/link", root),
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, kind, _, ok := parseRepoLinkPath(root, tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v; want %v (path=%s)", ok, tc.wantOK, tc.path)
+			}
+			if !ok {
+				return
+			}
+			if repo != tc.wantRepo {
+				t.Errorf("repo = %q; want %q", repo, tc.wantRepo)
+			}
+			if kind != tc.wantKind {
+				t.Errorf("kind = %q; want %q", kind, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestReconcileFromStorage_DiscoversOrphans(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	dBlob := mkDigest(t, 1)
+	dManifest := mkDigest(t, 2)
+	putLink(t, ctx, drv, "team/svc", dBlob, false)
+	putLink(t, ctx, drv, "team/svc", dManifest, true)
+
+	s := scheduler.New(ctx, drv, "/ttl-reconcile")
+	s.OnReconcile(reconcileFromStorage(ctx, drv, time.Hour))
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// Reconcile runs synchronously inside Start.
+	wantBlob := mkCanonical(t, "team/svc", dBlob).String()
+	wantManifest := mkCanonical(t, "team/svc", dManifest).String()
+
+	if !s.HasOtherReferencesToDigest("never", dBlob) {
+		t.Fatalf("expected scheduler entry for blob %s after reconcile", wantBlob)
+	}
+	if !s.HasOtherReferencesToDigest("never", dManifest) {
+		t.Fatalf("expected scheduler entry for manifest %s after reconcile", wantManifest)
+	}
+}
+
+func TestReconcileFromStorage_NoOpWhenInSync(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 3)
+	putLink(t, ctx, drv, "team/svc", d, false)
+
+	s := scheduler.New(ctx, drv, "/ttl-noop")
+	// Pre-populate scheduler so the link is already known.
+	preRef := mkCanonical(t, "team/svc", d)
+	added, ranOnce := false, false
+	s.OnReconcile(func(s *scheduler.TTLExpirationScheduler) error {
+		ranOnce = true
+		var err error
+		added, err = reconcileAddProbe(s, preRef, time.Hour)
+		return err
+	})
+
+	// Seed the entry by hand using AddBlobIfAbsent before Start would be
+	// natural, but Start is what loads state; instead, seed via state.
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	if !ranOnce {
+		t.Fatal("custom reconciler did not run")
+	}
+	if !added {
+		t.Fatal("seed AddBlobIfAbsent should report added=true (entry was new)")
+	}
+
+	// Re-run reconcileFromStorage manually; it must NOT create a duplicate.
+	rec := reconcileFromStorage(ctx, drv, time.Hour)
+	if err := rec(s); err != nil {
+		t.Fatalf("second reconcile failed: %v", err)
+	}
+	// Still exactly one entry for the digest (HasOtherReferencesToDigest
+	// excludes preRef, so it must report false).
+	if s.HasOtherReferencesToDigest(preRef.String(), d) {
+		t.Fatalf("reconcile duplicated a scheduler entry")
+	}
+}
+
+// reconcileAddProbe is a thin test helper for AddBlobIfAbsent so the test
+// reads naturally (the production code path uses the same call site).
+func reconcileAddProbe(s *scheduler.TTLExpirationScheduler, r reference.Canonical, ttl time.Duration) (bool, error) {
+	return s.AddBlobIfAbsent(r, ttl)
+}
+
+func TestReconcileFromStorage_NoRepositoriesTree(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New() // empty driver — no /docker/registry/v2/repositories
+
+	s := scheduler.New(ctx, drv, "/ttl-empty")
+	s.OnReconcile(reconcileFromStorage(ctx, drv, time.Hour))
+	if err := s.Start(); err != nil {
+		t.Fatalf("reconcile on empty driver must not fail Start: %v", err)
+	}
+	defer s.Stop()
+}
+
+// startSchedulerWithEvict wires evictBlob as OnBlobExpire callback —
+// mirrors what NewRegistryPullThroughCache does, minus the HTTP plumbing.
+// Returns the scheduler and a channel that receives one event per
+// callback completion so the tests can wait deterministically.
+func startSchedulerWithEvict(t *testing.T, ctx context.Context, drv driver.StorageDriver, statePath string) (*scheduler.TTLExpirationScheduler, <-chan error) {
+	t.Helper()
+	reg, err := storage.NewRegistry(ctx, drv, storage.EnableDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := storage.NewVacuum(ctx, drv)
+
+	done := make(chan error, 16)
+	s := scheduler.New(ctx, drv, statePath)
+	s.OnBlobExpire(func(ref reference.Reference) error {
+		r, ok := ref.(reference.Canonical)
+		if !ok {
+			done <- fmt.Errorf("non-canonical reference: %T", ref)
+			return nil
+		}
+		err := evictBlob(ctx, reg, drv, v, s, r)
+		done <- err
+		return err
+	})
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	return s, done
+}
+
+func waitForExpiries(t *testing.T, done <-chan error, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("OnBlobExpire #%d returned error: %v", i+1, err)
+			}
+		case <-deadline:
+			t.Fatalf("only received %d/%d expiries within %s", i, n, timeout)
+		}
+	}
+}
+
+func TestEvictBlob_SingleRef_VacuumsBlob(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 11)
+	repoName := "single/ref"
+	putBlobBytes(t, ctx, drv, d, "hello-single")
+	putLink(t, ctx, drv, repoName, d, false)
+
+	s, done := startSchedulerWithEvict(t, ctx, drv, "/ttl-evict-single")
+	defer s.Stop()
+
+	r := mkCanonical(t, repoName, d)
+	if err := s.AddBlob(r, 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	waitForExpiries(t, done, 1, 2*time.Second)
+
+	if blobStillThere(t, ctx, drv, d) {
+		t.Fatalf("blob file must be removed for single-ref evict")
+	}
+}
+
+func TestEvictBlob_MultiRef_PreservesBlobViaFastPath(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 21)
+	putBlobBytes(t, ctx, drv, d, "hello-multi")
+	putLink(t, ctx, drv, "team/a", d, false)
+	putLink(t, ctx, drv, "team/b", d, false)
+
+	s, done := startSchedulerWithEvict(t, ctx, drv, "/ttl-evict-multi")
+	defer s.Stop()
+
+	rA := mkCanonical(t, "team/a", d)
+	rB := mkCanonical(t, "team/b", d)
+	if err := s.AddBlob(rA, 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddBlob(rB, 300*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	// After the first timer fires, rB is still scheduled — fast path keeps
+	// the blob alive.
+	waitForExpiries(t, done, 1, 2*time.Second)
+	if !blobStillThere(t, ctx, drv, d) {
+		t.Fatalf("blob removed after first expiry while second ref still scheduled")
+	}
+
+	// After the second timer fires, no scheduled entry and no on-disk link
+	// remain — slow path returns false, blob is vacuumed.
+	waitForExpiries(t, done, 1, 2*time.Second)
+	if blobStillThere(t, ctx, drv, d) {
+		t.Fatalf("blob must be removed once last ref expires")
+	}
+}
+
+// Regression for the N-concurrent-expiry race: many repos share one digest,
+// every per-repo timer fires almost simultaneously. Without the vacuum
+// claim each callback would clear its own link, see the others still in
+// the scheduler map and skip the vacuum, leaving the shared blob orphaned.
+func TestEvictBlob_ConcurrentExpiriesDoNotLeak(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	const repoCount = 10
+	d := mkDigest(t, 41)
+	putBlobBytes(t, ctx, drv, d, "hello-concurrent")
+	for i := 0; i < repoCount; i++ {
+		putLink(t, ctx, drv, fmt.Sprintf("mirror/team-%02d", i), d, false)
+	}
+
+	s, done := startSchedulerWithEvict(t, ctx, drv, "/ttl-evict-concurrent")
+	defer s.Stop()
+
+	// Same very-short TTL for every repo so all timers fire in the same
+	// narrow window — exactly the post-restart pattern from production.
+	for i := 0; i < repoCount; i++ {
+		ref := mkCanonical(t, fmt.Sprintf("mirror/team-%02d", i), d)
+		if err := s.AddBlob(ref, 30*time.Millisecond); err != nil {
+			t.Fatalf("AddBlob %d: %v", i, err)
+		}
+	}
+
+	waitForExpiries(t, done, repoCount, 5*time.Second)
+
+	if blobStillThere(t, ctx, drv, d) {
+		t.Fatalf("shared blob remained on disk after all %d references expired (leak)", repoCount)
+	}
+}
+
+func TestEvictBlob_SlowPathDetectsLinkOnDisk(t *testing.T) {
+	ctx := context.Background()
+	drv := inmemory.New()
+
+	d := mkDigest(t, 31)
+	putBlobBytes(t, ctx, drv, d, "hello-slow")
+	// Two links on disk, but only the first is registered with the
+	// scheduler — the second simulates an orphan link the bootstrap
+	// reconcile would normally pick up, while also exercising the slow
+	// path here in isolation.
+	putLink(t, ctx, drv, "team/scheduled", d, false)
+	putLink(t, ctx, drv, "team/orphan", d, false)
+
+	s, done := startSchedulerWithEvict(t, ctx, drv, "/ttl-evict-slow")
+	defer s.Stop()
+
+	rSched := mkCanonical(t, "team/scheduled", d)
+	if err := s.AddBlob(rSched, 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	waitForExpiries(t, done, 1, 2*time.Second)
+
+	if !blobStillThere(t, ctx, drv, d) {
+		t.Fatalf("slow path should have detected the orphan link and preserved the blob")
+	}
+}
+
+func putBlobBytes(t *testing.T, ctx context.Context, drv driver.StorageDriver, dgst digest.Digest, content string) {
+	t.Helper()
+	// Mirror the on-disk layout: /docker/registry/v2/blobs/<alg>/<2>/<hex>/data
+	hex := dgst.Encoded()
+	p := fmt.Sprintf("/docker/registry/v2/blobs/%s/%s/%s/data", dgst.Algorithm(), hex[:2], hex)
+	if err := drv.PutContent(ctx, p, []byte(content)); err != nil {
+		t.Fatalf("PutContent blob: %v", err)
+	}
+}
+
+func blobStillThere(t *testing.T, ctx context.Context, drv driver.StorageDriver, dgst digest.Digest) bool {
+	t.Helper()
+	hex := dgst.Encoded()
+	p := fmt.Sprintf("/docker/registry/v2/blobs/%s/%s/%s/data", dgst.Algorithm(), hex[:2], hex)
+	_, err := drv.Stat(ctx, p)
+	if err == nil {
+		return true
+	}
+	if _, ok := err.(driver.PathNotFoundError); ok {
+		return false
+	}
+	t.Fatalf("Stat blob: %v", err)
+	return false
 }

--- a/registry/proxy/proxyregistry_test.go
+++ b/registry/proxy/proxyregistry_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -207,7 +208,10 @@ func TestReconcileFromStorage_DiscoversOrphans(t *testing.T) {
 	}
 	defer s.Stop()
 
-	// Reconcile runs synchronously inside Start.
+	// Reconcile runs in a background goroutine; wait for it to finish
+	// before sampling the scheduler state.
+	waitForReconciled(t, s, 2*time.Second)
+
 	wantBlob := mkCanonical(t, "team/svc", dBlob).String()
 	wantManifest := mkCanonical(t, "team/svc", dManifest).String()
 
@@ -217,6 +221,20 @@ func TestReconcileFromStorage_DiscoversOrphans(t *testing.T) {
 	if !s.HasOtherReferencesToDigest("never", dManifest) {
 		t.Fatalf("expected scheduler entry for manifest %s after reconcile", wantManifest)
 	}
+}
+
+// waitForReconciled polls Reconciled() with a short interval until the
+// reconcile goroutine finishes or timeout elapses.
+func waitForReconciled(t *testing.T, s *scheduler.TTLExpirationScheduler, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s.Reconciled() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("scheduler did not finish reconcile within %s", timeout)
 }
 
 func TestReconcileFromStorage_NoOpWhenInSync(t *testing.T) {
@@ -229,11 +247,11 @@ func TestReconcileFromStorage_NoOpWhenInSync(t *testing.T) {
 	s := scheduler.New(ctx, drv, "/ttl-noop")
 	// Pre-populate scheduler so the link is already known.
 	preRef := mkCanonical(t, "team/svc", d)
-	added, ranOnce := false, false
+	var added, ranOnce atomic.Bool
 	s.OnReconcile(func(s *scheduler.TTLExpirationScheduler) error {
-		ranOnce = true
-		var err error
-		added, err = reconcileAddProbe(s, preRef, time.Hour)
+		ranOnce.Store(true)
+		got, err := reconcileAddProbe(s, preRef, time.Hour)
+		added.Store(got)
 		return err
 	})
 
@@ -244,10 +262,12 @@ func TestReconcileFromStorage_NoOpWhenInSync(t *testing.T) {
 	}
 	defer s.Stop()
 
-	if !ranOnce {
+	waitForReconciled(t, s, 2*time.Second)
+
+	if !ranOnce.Load() {
 		t.Fatal("custom reconciler did not run")
 	}
-	if !added {
+	if !added.Load() {
 		t.Fatal("seed AddBlobIfAbsent should report added=true (entry was new)")
 	}
 
@@ -286,6 +306,14 @@ func TestReconcileFromStorage_NoRepositoriesTree(t *testing.T) {
 // Returns the scheduler and a channel that receives one event per
 // callback completion so the tests can wait deterministically.
 func startSchedulerWithEvict(t *testing.T, ctx context.Context, drv driver.StorageDriver, statePath string) (*scheduler.TTLExpirationScheduler, <-chan error) {
+	return startSchedulerWithEvictAndReconcile(t, ctx, drv, statePath, nil)
+}
+
+// startSchedulerWithEvictAndReconcile is like startSchedulerWithEvict
+// but lets the caller install an OnReconcile hook. Useful for tests
+// that need to control whether the scheduler is in its pre- or
+// post-reconcile state when an eviction fires.
+func startSchedulerWithEvictAndReconcile(t *testing.T, ctx context.Context, drv driver.StorageDriver, statePath string, rec scheduler.Reconciler) (*scheduler.TTLExpirationScheduler, <-chan error) {
 	t.Helper()
 	reg, err := storage.NewRegistry(ctx, drv, storage.EnableDelete)
 	if err != nil {
@@ -295,6 +323,9 @@ func startSchedulerWithEvict(t *testing.T, ctx context.Context, drv driver.Stora
 
 	done := make(chan error, 16)
 	s := scheduler.New(ctx, drv, statePath)
+	if rec != nil {
+		s.OnReconcile(rec)
+	}
 	s.OnBlobExpire(func(ref reference.Reference) error {
 		r, ok := ref.(reference.Canonical)
 		if !ok {
@@ -428,11 +459,20 @@ func TestEvictBlob_SlowPathDetectsLinkOnDisk(t *testing.T) {
 	// Two links on disk, but only the first is registered with the
 	// scheduler — the second simulates an orphan link the bootstrap
 	// reconcile would normally pick up, while also exercising the slow
-	// path here in isolation.
+	// path here in isolation. The slow on-disk walk only fires before
+	// reconcile has finished, so this test wires a reconciler that
+	// blocks until the eviction has already run, keeping the scheduler
+	// in the pre-reconcile state for the duration of the test.
 	putLink(t, ctx, drv, "team/scheduled", d, false)
 	putLink(t, ctx, drv, "team/orphan", d, false)
 
-	s, done := startSchedulerWithEvict(t, ctx, drv, "/ttl-evict-slow")
+	releaseReconcile := make(chan struct{})
+	s, done := startSchedulerWithEvictAndReconcile(t, ctx, drv, "/ttl-evict-slow",
+		func(*scheduler.TTLExpirationScheduler) error {
+			<-releaseReconcile
+			return nil
+		})
+	defer close(releaseReconcile)
 	defer s.Stop()
 
 	rSched := mkCanonical(t, "team/scheduled", d)

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -2,10 +2,12 @@ package scheduler
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
@@ -27,6 +29,14 @@ const (
 	entryTypeBlob = iota
 	entryTypeManifest
 	indexSaveFrequency = 5 * time.Second
+
+	// evictLockStripes bounds the per-digest eviction lock pool. Digests
+	// are hashed (taking the first byte of the encoded hex) into one of
+	// these stripes; collisions only over-serialise unrelated digests and
+	// never cause a correctness issue. 256 keeps the table tiny while
+	// reducing contention to a negligible level for realistic working
+	// sets.
+	evictLockStripes = 256
 )
 
 // schedulerEntry represents an entry in the scheduler
@@ -49,6 +59,7 @@ func New(ctx context.Context, driver driver.StorageDriver, path string) *TTLExpi
 		stopped:         true,
 		doneChan:        make(chan struct{}),
 		saveTimer:       time.NewTicker(indexSaveFrequency),
+		evictLocks:      new([evictLockStripes]sync.Mutex),
 	}
 }
 
@@ -77,8 +88,18 @@ type TTLExpirationScheduler struct {
 	// map until the in-flight callback returns) or the other in-flight
 	// links on disk, conclude "another ref exists", and skip the vacuum —
 	// leaking the blob with no scheduler entry left to recover it.
-	// Concurrency across *different* digests stays parallel.
-	evictLocks sync.Map // digest.Digest -> *sync.Mutex
+	// Concurrency across *different* digests stays parallel. The pool is
+	// a fixed-size striped lock table (see evictLockStripes) so memory
+	// stays bounded regardless of how many distinct digests are seen over
+	// the lifetime of the scheduler.
+	evictLocks *[evictLockStripes]sync.Mutex
+
+	// reconciled flips to true once the bootstrap reconcile goroutine has
+	// finished registering every on-disk link with the scheduler. After
+	// that point the scheduler entries are the authoritative reference
+	// count for shared blobs and the on-disk link walk in evictBlob can
+	// be skipped.
+	reconciled atomic.Bool
 
 	indexDirty bool
 	saveTimer  *time.Ticker
@@ -141,8 +162,8 @@ func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical
 // AddBlobIfAbsent schedules a blob cleanup only when no entry exists for
 // blobRef. Used by bootstrap reconcile to register orphan links found on
 // disk without overwriting state already loaded from scheduler-state.json.
-// Returns added=true when a new entry was created.
-func (ttles *TTLExpirationScheduler) AddBlobIfAbsent(blobRef reference.Canonical, ttl time.Duration) (added bool, err error) {
+// Returns true when a new entry was created.
+func (ttles *TTLExpirationScheduler) AddBlobIfAbsent(blobRef reference.Canonical, ttl time.Duration) (bool, error) {
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -159,7 +180,7 @@ func (ttles *TTLExpirationScheduler) AddBlobIfAbsent(blobRef reference.Canonical
 
 // AddManifestIfAbsent schedules a manifest cleanup only when no entry
 // exists for manifestRef. See AddBlobIfAbsent.
-func (ttles *TTLExpirationScheduler) AddManifestIfAbsent(manifestRef reference.Canonical, ttl time.Duration) (added bool, err error) {
+func (ttles *TTLExpirationScheduler) AddManifestIfAbsent(manifestRef reference.Canonical, ttl time.Duration) (bool, error) {
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -174,43 +195,87 @@ func (ttles *TTLExpirationScheduler) AddManifestIfAbsent(manifestRef reference.C
 	return true, nil
 }
 
-// EvictionLock returns a per-digest mutex used to serialise OnBlobExpire
+// EvictionLock returns a striped mutex used to serialise OnBlobExpire
 // processing across all repositories sharing dgst. The proxy callback
 // acquires this lock for the full delete-link / ref-count / vacuum
 // sequence so that concurrent expiries for the same digest do not race
-// each other into a blob leak. The lock is allocated on first use and
-// retained for the lifetime of the scheduler — one entry per unique
-// digest the scheduler has ever vacuumed, which is bounded by the
-// working set and small in practice.
+// each other into a blob leak. Digests are hashed into a fixed-size
+// table (evictLockStripes); two digests hashing to the same stripe are
+// over-serialised but never deadlock or lose correctness. Memory is
+// O(evictLockStripes), independent of how many digests are seen.
 func (ttles *TTLExpirationScheduler) EvictionLock(dgst digest.Digest) *sync.Mutex {
-	if m, ok := ttles.evictLocks.Load(dgst); ok {
-		return m.(*sync.Mutex)
-	}
-	actual, _ := ttles.evictLocks.LoadOrStore(dgst, &sync.Mutex{})
-	return actual.(*sync.Mutex)
+	return &ttles.evictLocks[stripeIndex(dgst)]
 }
 
-// HasOtherReferencesToDigest reports whether any scheduled entry other than
-// excludeKey targets dgst AND is still live (its Expiry is in the future).
-// Entries whose timer has already fired but whose callback has not yet
-// returned are excluded — they are on the path to vacuum themselves and
-// must not be treated as a live reference, or the fast path turns into a
-// mutual-skip deadlock during a concurrent expiry burst.
+// Reconciled reports whether bootstrap reconcile has finished registering
+// every on-disk link with the scheduler. Once true, the scheduler's
+// entries map is the authoritative reference count for shared blobs and
+// callers may skip any compensating on-disk scans.
+func (ttles *TTLExpirationScheduler) Reconciled() bool {
+	return ttles.reconciled.Load()
+}
+
+// stripeIndex picks a stripe for dgst by taking the first byte of the
+// encoded portion as a hex pair. Digest encodings are always hex, so
+// this distributes evenly across the 256 stripes; non-conforming inputs
+// fall back to stripe 0 (still correct, just slightly more contention).
+func stripeIndex(dgst digest.Digest) uint8 {
+	enc := dgst.Encoded()
+	if len(enc) < 2 {
+		return 0
+	}
+	b, err := hex.DecodeString(enc[:2])
+	if err != nil || len(b) == 0 {
+		return 0
+	}
+	return b[0]
+}
+
+// HasOtherReferencesToDigest reports whether any scheduled entry other
+// than excludeKey targets dgst. Presence in the entries map is the
+// authoritative signal: an entry only leaves the map once it has been
+// processed (via ClaimVacuum from the eviction callback or via the
+// scheduler's timer cleanup), so an entry whose timer has fired but
+// whose callback has not yet run still counts as a live reference. This
+// is intended as a read-only query; eviction code paths should call
+// ClaimVacuum so the remove-self and check-others happen atomically.
 func (ttles *TTLExpirationScheduler) HasOtherReferencesToDigest(excludeKey string, dgst digest.Digest) bool {
-	now := time.Now()
 	ttles.Lock()
 	defer ttles.Unlock()
+	return ttles.hasOtherRefsLocked(excludeKey, dgst)
+}
 
+// ClaimVacuum atomically removes the entry keyed by selfKey and reports
+// whether the caller may safely vacuum the shared blob for dgst (true
+// means no other scheduled entry references the digest). The eviction
+// callback must hold the per-digest EvictionLock when calling this so
+// the remove-self / check-siblings pair stays consistent against
+// concurrent expiries for the same digest. Atomic remove-then-check is
+// what prevents the mutual-skip race during a concurrent expiry burst:
+// once an entry has been claimed it cannot be observed by a later
+// caller, so callers naturally form a single chain in which only the
+// last one sees an empty map and proceeds to vacuum.
+func (ttles *TTLExpirationScheduler) ClaimVacuum(selfKey string, dgst digest.Digest) bool {
+	ttles.Lock()
+	defer ttles.Unlock()
+	if _, ok := ttles.entries[selfKey]; ok {
+		delete(ttles.entries, selfKey)
+		ttles.indexDirty = true
+	}
+	return !ttles.hasOtherRefsLocked(selfKey, dgst)
+}
+
+// hasOtherRefsLocked must be called with ttles.Mutex held. It scans the
+// entries map for any reference to dgst other than excludeKey.
+// Canonical reference.String() is "<name>@<digest>"; the suffix match
+// uses the last '@' because repository names may contain ':' but not
+// '@'.
+func (ttles *TTLExpirationScheduler) hasOtherRefsLocked(excludeKey string, dgst digest.Digest) bool {
 	suffix := dgst.String()
-	for key, entry := range ttles.entries {
+	for key := range ttles.entries {
 		if key == excludeKey {
 			continue
 		}
-		if !entry.Expiry.After(now) {
-			continue
-		}
-		// Canonical reference.String() is "<name>@<digest>"; split on the
-		// last '@' because repository names may contain ':' but not '@'.
 		idx := strings.LastIndexByte(key, '@')
 		if idx < 0 {
 			continue
@@ -249,13 +314,21 @@ func (ttles *TTLExpirationScheduler) Start() error {
 	reconciler := ttles.onReconcile
 	ttles.Unlock()
 
-	// Reconcile runs after the mutex is released so its I/O does not widen
-	// the critical section. It publishes via AddBlobIfAbsent /
-	// AddManifestIfAbsent, which take the lock per-entry.
-	if reconciler != nil {
-		if err := reconciler(ttles); err != nil {
-			dcontext.GetLogger(ttles.ctx).Warnf("scheduler bootstrap reconcile failed (continuing): %v", err)
-		}
+	// Reconcile runs in a goroutine so the (potentially slow on object
+	// storage) full repositories walk does not block registry startup. It
+	// publishes discoveries via AddBlobIfAbsent / AddManifestIfAbsent,
+	// which take the lock per-entry. Until the goroutine flips reconciled
+	// to true, evictBlob falls back to its on-disk safety walk so
+	// orphan links not yet registered cannot be vacuumed prematurely.
+	if reconciler == nil {
+		ttles.reconciled.Store(true)
+	} else {
+		go func() {
+			if err := reconciler(ttles); err != nil {
+				dcontext.GetLogger(ttles.ctx).Warnf("scheduler bootstrap reconcile failed (continuing): %v", err)
+			}
+			ttles.reconciled.Store(true)
+		}()
 	}
 
 	// Start a ticker to periodically save the entries index

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 )
+
+// Reconciler discovers references that should be tracked by the scheduler but
+// are absent from its in-memory state (e.g. orphan on-disk links produced by
+// an unclean shutdown or by an older binary). Implementations publish results
+// through the scheduler's AddBlobIfAbsent / AddManifestIfAbsent methods.
+type Reconciler func(s *TTLExpirationScheduler) error
 
 // onTTLExpiryFunc is called when a repository's TTL expires
 type expiryFunc func(reference.Reference) error
@@ -59,6 +67,18 @@ type TTLExpirationScheduler struct {
 
 	onBlobExpire     expiryFunc
 	onManifestExpire expiryFunc
+	onReconcile      Reconciler
+
+	// evictLocks serialises OnBlobExpire processing per digest so that N
+	// timers firing in the same instant for N repos sharing one digest
+	// execute their full delete-link / check-refs / maybe-vacuum cycle one
+	// after the other instead of racing. Without serialisation each
+	// callback would clear its link, see the other entries (still in the
+	// map until the in-flight callback returns) or the other in-flight
+	// links on disk, conclude "another ref exists", and skip the vacuum —
+	// leaking the blob with no scheduler entry left to recover it.
+	// Concurrency across *different* digests stays parallel.
+	evictLocks sync.Map // digest.Digest -> *sync.Mutex
 
 	indexDirty bool
 	saveTimer  *time.Ticker
@@ -79,6 +99,17 @@ func (ttles *TTLExpirationScheduler) OnManifestExpire(f expiryFunc) {
 	defer ttles.Unlock()
 
 	ttles.onManifestExpire = f
+}
+
+// OnReconcile registers a one-shot reconciler invoked from Start after the
+// persisted state has been loaded. The reconciler runs without holding the
+// scheduler mutex and publishes discoveries through AddBlobIfAbsent /
+// AddManifestIfAbsent. Must be called before Start.
+func (ttles *TTLExpirationScheduler) OnReconcile(r Reconciler) {
+	ttles.Lock()
+	defer ttles.Unlock()
+
+	ttles.onReconcile = r
 }
 
 // AddBlob schedules a blob cleanup after ttl expires
@@ -107,26 +138,124 @@ func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical
 	return nil
 }
 
-// Start starts the scheduler
-func (ttles *TTLExpirationScheduler) Start() error {
+// AddBlobIfAbsent schedules a blob cleanup only when no entry exists for
+// blobRef. Used by bootstrap reconcile to register orphan links found on
+// disk without overwriting state already loaded from scheduler-state.json.
+// Returns added=true when a new entry was created.
+func (ttles *TTLExpirationScheduler) AddBlobIfAbsent(blobRef reference.Canonical, ttl time.Duration) (added bool, err error) {
 	ttles.Lock()
 	defer ttles.Unlock()
 
-	err := ttles.readState()
-	if err != nil {
+	if ttles.stopped {
+		return false, fmt.Errorf("scheduler not started")
+	}
+
+	if _, present := ttles.entries[blobRef.String()]; present {
+		return false, nil
+	}
+	ttles.add(blobRef, ttl, entryTypeBlob)
+	return true, nil
+}
+
+// AddManifestIfAbsent schedules a manifest cleanup only when no entry
+// exists for manifestRef. See AddBlobIfAbsent.
+func (ttles *TTLExpirationScheduler) AddManifestIfAbsent(manifestRef reference.Canonical, ttl time.Duration) (added bool, err error) {
+	ttles.Lock()
+	defer ttles.Unlock()
+
+	if ttles.stopped {
+		return false, fmt.Errorf("scheduler not started")
+	}
+
+	if _, present := ttles.entries[manifestRef.String()]; present {
+		return false, nil
+	}
+	ttles.add(manifestRef, ttl, entryTypeManifest)
+	return true, nil
+}
+
+// EvictionLock returns a per-digest mutex used to serialise OnBlobExpire
+// processing across all repositories sharing dgst. The proxy callback
+// acquires this lock for the full delete-link / ref-count / vacuum
+// sequence so that concurrent expiries for the same digest do not race
+// each other into a blob leak. The lock is allocated on first use and
+// retained for the lifetime of the scheduler — one entry per unique
+// digest the scheduler has ever vacuumed, which is bounded by the
+// working set and small in practice.
+func (ttles *TTLExpirationScheduler) EvictionLock(dgst digest.Digest) *sync.Mutex {
+	if m, ok := ttles.evictLocks.Load(dgst); ok {
+		return m.(*sync.Mutex)
+	}
+	actual, _ := ttles.evictLocks.LoadOrStore(dgst, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
+
+// HasOtherReferencesToDigest reports whether any scheduled entry other than
+// excludeKey targets dgst AND is still live (its Expiry is in the future).
+// Entries whose timer has already fired but whose callback has not yet
+// returned are excluded — they are on the path to vacuum themselves and
+// must not be treated as a live reference, or the fast path turns into a
+// mutual-skip deadlock during a concurrent expiry burst.
+func (ttles *TTLExpirationScheduler) HasOtherReferencesToDigest(excludeKey string, dgst digest.Digest) bool {
+	now := time.Now()
+	ttles.Lock()
+	defer ttles.Unlock()
+
+	suffix := dgst.String()
+	for key, entry := range ttles.entries {
+		if key == excludeKey {
+			continue
+		}
+		if !entry.Expiry.After(now) {
+			continue
+		}
+		// Canonical reference.String() is "<name>@<digest>"; split on the
+		// last '@' because repository names may contain ':' but not '@'.
+		idx := strings.LastIndexByte(key, '@')
+		if idx < 0 {
+			continue
+		}
+		if key[idx+1:] == suffix {
+			return true
+		}
+	}
+	return false
+}
+
+// Start starts the scheduler
+func (ttles *TTLExpirationScheduler) Start() error {
+	ttles.Lock()
+
+	if err := ttles.readState(); err != nil {
+		ttles.Unlock()
 		return err
 	}
 
 	if !ttles.stopped {
+		ttles.Unlock()
 		return fmt.Errorf("scheduler already started")
 	}
 
 	dcontext.GetLogger(ttles.ctx).Infof("Starting cached object TTL expiration scheduler...")
 	ttles.stopped = false
 
-	// Start timer for each deserialized entry
+	// Start timer for each deserialized entry before releasing the lock so
+	// that any expiry that fires concurrently with reconcile cannot race
+	// against an unarmed entry.
 	for _, entry := range ttles.entries {
 		entry.timer = ttles.startTimer(entry, time.Until(entry.Expiry))
+	}
+
+	reconciler := ttles.onReconcile
+	ttles.Unlock()
+
+	// Reconcile runs after the mutex is released so its I/O does not widen
+	// the critical section. It publishes via AddBlobIfAbsent /
+	// AddManifestIfAbsent, which take the lock per-entry.
+	if reconciler != nil {
+		if err := reconciler(ttles); err != nil {
+			dcontext.GetLogger(ttles.ctx).Warnf("scheduler bootstrap reconcile failed (continuing): %v", err)
+		}
 	}
 
 	// Start a ticker to periodically save the entries index
@@ -175,11 +304,12 @@ func (ttles *TTLExpirationScheduler) add(r reference.Reference, ttl time.Duratio
 
 func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.Duration) *time.Timer {
 	return time.AfterFunc(ttl, func() {
+		// Resolve the callback under the lock, then release it so the
+		// callback can perform I/O and call back into the scheduler
+		// (e.g. HasOtherReferencesToDigest) without deadlocking on the
+		// non-reentrant sync.Mutex.
 		ttles.Lock()
-		defer ttles.Unlock()
-
 		var f expiryFunc
-
 		switch entry.EntryType {
 		case entryTypeBlob:
 			f = ttles.onBlobExpire
@@ -190,6 +320,7 @@ func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.
 				return fmt.Errorf("scheduler entry type")
 			}
 		}
+		ttles.Unlock()
 
 		ref, err := reference.Parse(entry.Key)
 		if err == nil {
@@ -200,8 +331,15 @@ func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.
 			dcontext.GetLogger(ttles.ctx).Errorf("Error unpacking reference: %s", err)
 		}
 
-		delete(ttles.entries, entry.Key)
-		ttles.indexDirty = true
+		// Re-acquire to remove the entry, but only if the map still holds
+		// this exact entry pointer. A concurrent AddBlob may have replaced
+		// it with a fresh one (new timer) that must not be evicted.
+		ttles.Lock()
+		if cur, ok := ttles.entries[entry.Key]; ok && cur == entry {
+			delete(ttles.entries, entry.Key)
+			ttles.indexDirty = true
+		}
+		ttles.Unlock()
 	})
 }
 

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -331,8 +332,11 @@ func TestAddBlobIfAbsent(t *testing.T) {
 }
 
 func TestEvictionLock(t *testing.T) {
-	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 1))
-	other := digest.Digest("sha256:" + fmt.Sprintf("%064d", 2))
+	// Pick digests whose first encoded byte differs so they land in
+	// different stripes of the lock table.
+	d := digest.Digest("sha256:11" + fmt.Sprintf("%062d", 1))
+	sameStripe := digest.Digest("sha256:11" + fmt.Sprintf("%062d", 2))
+	otherStripe := digest.Digest("sha256:22" + fmt.Sprintf("%062d", 1))
 
 	s := New(dcontext.Background(), inmemory.New(), "/ttl-evictlock")
 
@@ -342,9 +346,15 @@ func TestEvictionLock(t *testing.T) {
 	if m1 != m2 {
 		t.Fatalf("EvictionLock for the same digest must return the same mutex: %p vs %p", m1, m2)
 	}
-	// Different digest → different mutex (so unrelated digests stay parallel).
-	if m1 == s.EvictionLock(other) {
-		t.Fatalf("EvictionLock must return distinct mutexes per digest")
+	// Digests in the same stripe share a mutex by design (collisions
+	// over-serialise but never break correctness).
+	if m1 != s.EvictionLock(sameStripe) {
+		t.Fatalf("digests hashing to the same stripe should share a mutex")
+	}
+	// Different stripe → different mutex (so unrelated digests stay
+	// parallel for the common case).
+	if m1 == s.EvictionLock(otherStripe) {
+		t.Fatalf("digests in different stripes must return distinct mutexes")
 	}
 	// And it actually locks.
 	m1.Lock()
@@ -363,42 +373,46 @@ func TestEvictionLock(t *testing.T) {
 	<-locked
 }
 
-func TestHasOtherReferencesToDigest_IgnoresAlreadyExpiredEntries(t *testing.T) {
+// TestClaimVacuumSerialisesConcurrentExpiries verifies the protocol
+// that protects the shared blob in a concurrent expiry burst: every
+// caller atomically drops its own entry and observes the remainder, so
+// exactly the last caller in the chain receives the green light to
+// vacuum. ClaimVacuum is the primitive that eliminates the
+// mutual-skip race that the older HasOtherReferencesToDigest-only path
+// required the on-disk walk to mop up.
+func TestClaimVacuumSerialisesConcurrentExpiries(t *testing.T) {
 	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 5))
-	live := canonicalRef(t, "repo-live@"+d.String())
-	stale := canonicalRef(t, "repo-stale@"+d.String())
+	refs := []reference.Canonical{
+		canonicalRef(t, "repo-a@"+d.String()),
+		canonicalRef(t, "repo-b@"+d.String()),
+		canonicalRef(t, "repo-c@"+d.String()),
+	}
 
-	s := New(dcontext.Background(), inmemory.New(), "/ttl-expired")
+	s := New(dcontext.Background(), inmemory.New(), "/ttl-claim")
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
 	defer s.Stop()
-
-	// A live entry counts.
-	if err := s.AddBlob(live, time.Hour); err != nil {
-		t.Fatal(err)
-	}
-	if !s.HasOtherReferencesToDigest("never", d) {
-		t.Fatal("live entry should count as a reference")
+	for _, r := range refs {
+		if err := s.AddBlob(r, time.Hour); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// Add a stale entry through the public API (gets a real timer that
-	// Stop can clean up) and then back-date its Expiry directly. This
-	// mirrors the in-flight expiry state during a concurrent burst.
-	if err := s.AddBlob(stale, time.Hour); err != nil {
-		t.Fatal(err)
+	if got := s.ClaimVacuum(refs[0].String(), d); got {
+		t.Fatal("first claim must observe siblings; got vacuum=true")
 	}
-	s.Lock()
-	s.entries[stale.String()].Expiry = time.Now().Add(-time.Second)
-	s.Unlock()
+	if got := s.ClaimVacuum(refs[1].String(), d); got {
+		t.Fatal("second claim must observe the remaining sibling; got vacuum=true")
+	}
+	if got := s.ClaimVacuum(refs[2].String(), d); !got {
+		t.Fatal("last claim must observe an empty map and proceed to vacuum")
+	}
 
-	if !s.HasOtherReferencesToDigest("never", d) {
-		t.Fatal("the live entry must still be counted even with a stale one alongside")
-	}
-	// Excluding the live entry, only the stale one remains — it must
-	// NOT be reported as a surviving reference.
-	if s.HasOtherReferencesToDigest(live.String(), d) {
-		t.Fatal("a stale (expired) entry must not count as a surviving reference")
+	// Idempotency: a repeat claim on an already-removed entry must not
+	// flap or panic, and must still report vacuum=true (no entries).
+	if got := s.ClaimVacuum(refs[2].String(), d); !got {
+		t.Fatal("repeat claim on a removed entry should still report vacuum=true")
 	}
 }
 
@@ -427,9 +441,9 @@ func TestStartReconcileRuns(t *testing.T) {
 	ref := canonicalRef(t, "discovered@"+d.String())
 
 	s := New(dcontext.Background(), inmemory.New(), "/ttl")
-	called := 0
+	var called atomic.Int32
 	s.OnReconcile(func(s *TTLExpirationScheduler) error {
-		called++
+		called.Add(1)
 		_, err := s.AddBlobIfAbsent(ref, time.Hour)
 		return err
 	})
@@ -439,9 +453,12 @@ func TestStartReconcileRuns(t *testing.T) {
 	}
 	defer s.Stop()
 
-	// Reconcile runs synchronously inside Start.
-	if called != 1 {
-		t.Fatalf("reconciler called %d times; want 1", called)
+	// Reconcile now runs in a background goroutine; poll Reconciled()
+	// instead of asserting synchronously.
+	waitForReconciled(t, s, 2*time.Second)
+
+	if got := called.Load(); got != 1 {
+		t.Fatalf("reconciler called %d times; want 1", got)
 	}
 
 	s.Lock()
@@ -450,6 +467,19 @@ func TestStartReconcileRuns(t *testing.T) {
 	if !present {
 		t.Fatalf("reconciler discovery was not committed to the entries map")
 	}
+}
+
+// waitForReconciled polls until s.Reconciled() is true or timeout elapses.
+func waitForReconciled(t *testing.T, s *TTLExpirationScheduler, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s.Reconciled() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("scheduler did not finish reconcile within %s", timeout)
 }
 
 func TestStartReconcileErrorIsNonFatal(t *testing.T) {

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -2,12 +2,14 @@ package scheduler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/distribution/distribution/v3/internal/dcontext"
 	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -231,5 +233,267 @@ func TestDoubleStart(t *testing.T) {
 	err = s.Start()
 	if err == nil {
 		t.Fatal("Scheduler started twice without error")
+	}
+}
+
+func canonicalRef(t *testing.T, s string) reference.Canonical {
+	t.Helper()
+	ref, err := reference.Parse(s)
+	if err != nil {
+		t.Fatalf("parse reference %q: %v", s, err)
+	}
+	c, ok := ref.(reference.Canonical)
+	if !ok {
+		t.Fatalf("reference %q is not canonical", s)
+	}
+	return c
+}
+
+func TestHasOtherReferencesToDigest(t *testing.T) {
+	d1 := digest.Digest("sha256:" + fmt.Sprintf("%064d", 1))
+	d2 := digest.Digest("sha256:" + fmt.Sprintf("%064d", 2))
+	refA := canonicalRef(t, "repo-a@"+d1.String())
+	refB := canonicalRef(t, "repo-b@"+d1.String())
+	refC := canonicalRef(t, "repo-c@"+d2.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	if got := s.HasOtherReferencesToDigest(refA.String(), d1); got {
+		t.Fatalf("empty scheduler must return false; got true")
+	}
+
+	if err := s.AddBlob(refA, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.HasOtherReferencesToDigest(refA.String(), d1); got {
+		t.Fatalf("only the excluded entry references d1; want false, got true")
+	}
+
+	if err := s.AddBlob(refB, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.HasOtherReferencesToDigest(refA.String(), d1); !got {
+		t.Fatalf("refB also references d1; want true, got false")
+	}
+
+	if got := s.HasOtherReferencesToDigest(refA.String(), d2); got {
+		t.Fatalf("d2 unknown; want false, got true")
+	}
+	if err := s.AddBlob(refC, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.HasOtherReferencesToDigest(refA.String(), d2); !got {
+		t.Fatalf("refC references d2; want true, got false")
+	}
+}
+
+func TestAddBlobIfAbsent(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 1))
+	ref := canonicalRef(t, "repo@"+d.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	added, err := s.AddBlobIfAbsent(ref, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !added {
+		t.Fatalf("first call should have added; got added=false")
+	}
+
+	s.Lock()
+	first := s.entries[ref.String()]
+	s.Unlock()
+
+	added, err = s.AddBlobIfAbsent(ref, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added {
+		t.Fatalf("second call must not have added; got added=true")
+	}
+
+	s.Lock()
+	second := s.entries[ref.String()]
+	s.Unlock()
+
+	if first != second {
+		t.Fatalf("AddBlobIfAbsent replaced an existing entry: %p -> %p", first, second)
+	}
+}
+
+func TestEvictionLock(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 1))
+	other := digest.Digest("sha256:" + fmt.Sprintf("%064d", 2))
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl-evictlock")
+
+	// Same digest → same mutex instance.
+	m1 := s.EvictionLock(d)
+	m2 := s.EvictionLock(d)
+	if m1 != m2 {
+		t.Fatalf("EvictionLock for the same digest must return the same mutex: %p vs %p", m1, m2)
+	}
+	// Different digest → different mutex (so unrelated digests stay parallel).
+	if m1 == s.EvictionLock(other) {
+		t.Fatalf("EvictionLock must return distinct mutexes per digest")
+	}
+	// And it actually locks.
+	m1.Lock()
+	locked := make(chan struct{})
+	go func() {
+		m1.Lock()
+		close(locked)
+		m1.Unlock()
+	}()
+	select {
+	case <-locked:
+		t.Fatal("second Lock on the same mutex must block")
+	case <-time.After(30 * time.Millisecond):
+	}
+	m1.Unlock()
+	<-locked
+}
+
+func TestHasOtherReferencesToDigest_IgnoresAlreadyExpiredEntries(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 5))
+	live := canonicalRef(t, "repo-live@"+d.String())
+	stale := canonicalRef(t, "repo-stale@"+d.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl-expired")
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// A live entry counts.
+	if err := s.AddBlob(live, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if !s.HasOtherReferencesToDigest("never", d) {
+		t.Fatal("live entry should count as a reference")
+	}
+
+	// Add a stale entry through the public API (gets a real timer that
+	// Stop can clean up) and then back-date its Expiry directly. This
+	// mirrors the in-flight expiry state during a concurrent burst.
+	if err := s.AddBlob(stale, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	s.Lock()
+	s.entries[stale.String()].Expiry = time.Now().Add(-time.Second)
+	s.Unlock()
+
+	if !s.HasOtherReferencesToDigest("never", d) {
+		t.Fatal("the live entry must still be counted even with a stale one alongside")
+	}
+	// Excluding the live entry, only the stale one remains — it must
+	// NOT be reported as a surviving reference.
+	if s.HasOtherReferencesToDigest(live.String(), d) {
+		t.Fatal("a stale (expired) entry must not count as a surviving reference")
+	}
+}
+
+func TestAddManifestIfAbsent(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 2))
+	ref := canonicalRef(t, "repo@"+d.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl-manifest")
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	added, err := s.AddManifestIfAbsent(ref, time.Hour)
+	if err != nil || !added {
+		t.Fatalf("first call: added=%v err=%v; want true,nil", added, err)
+	}
+	added, err = s.AddManifestIfAbsent(ref, time.Hour)
+	if err != nil || added {
+		t.Fatalf("second call: added=%v err=%v; want false,nil", added, err)
+	}
+}
+
+func TestStartReconcileRuns(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 7))
+	ref := canonicalRef(t, "discovered@"+d.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	called := 0
+	s.OnReconcile(func(s *TTLExpirationScheduler) error {
+		called++
+		_, err := s.AddBlobIfAbsent(ref, time.Hour)
+		return err
+	})
+
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// Reconcile runs synchronously inside Start.
+	if called != 1 {
+		t.Fatalf("reconciler called %d times; want 1", called)
+	}
+
+	s.Lock()
+	_, present := s.entries[ref.String()]
+	s.Unlock()
+	if !present {
+		t.Fatalf("reconciler discovery was not committed to the entries map")
+	}
+}
+
+func TestStartReconcileErrorIsNonFatal(t *testing.T) {
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	sentinel := errors.New("reconcile boom")
+	s.OnReconcile(func(*TTLExpirationScheduler) error {
+		return sentinel
+	})
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("scheduler must not fail Start on reconciler error: %v", err)
+	}
+	defer s.Stop()
+}
+
+// TestCallbackCanReenterScheduler asserts that the OnBlobExpire callback
+// can call HasOtherReferencesToDigest without deadlocking. Before the
+// startTimer lock-split fix this would hang.
+func TestCallbackCanReenterScheduler(t *testing.T) {
+	d := digest.Digest("sha256:" + fmt.Sprintf("%064d", 9))
+	ref := canonicalRef(t, "repo@"+d.String())
+
+	s := New(dcontext.Background(), inmemory.New(), "/ttl")
+	done := make(chan bool, 1)
+	s.OnBlobExpire(func(r reference.Reference) error {
+		c := r.(reference.Canonical)
+		done <- s.HasOtherReferencesToDigest(c.String(), c.Digest())
+		return nil
+	})
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	if err := s.AddBlob(ref, 10*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-done:
+		if got {
+			t.Fatalf("only one ref scheduled; want false, got true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("OnBlobExpire callback deadlocked")
 	}
 }

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -256,6 +256,28 @@ func pathFor(spec pathSpec) (string, error) {
 	}
 }
 
+// BlobLinkPath returns the storage path of the per-repository link
+// file for a blob: <root>/v2/repositories/<repo>/_layers/<algorithm>/<hex>/link.
+func BlobLinkPath(repo string, dgst digest.Digest) (string, error) {
+	return pathFor(layerLinkPathSpec{name: repo, digest: dgst})
+}
+
+// ManifestRevisionLinkPath returns the storage path of the per-repository
+// revision link file for a manifest:
+// <root>/v2/repositories/<repo>/_manifests/revisions/<algorithm>/<hex>/link.
+func ManifestRevisionLinkPath(repo string, dgst digest.Digest) (string, error) {
+	return pathFor(manifestRevisionLinkPathSpec{name: repo, revision: dgst})
+}
+
+// RepositoriesRootPath returns the storage path that contains all
+// repository subtrees: <root>/v2/repositories.
+func RepositoriesRootPath() string {
+	// Errors from pathFor for repositoriesRootPathSpec are not possible
+	// (no digest parsing), so the discard is safe.
+	p, _ := pathFor(repositoriesRootPathSpec{})
+	return p
+}
+
 // pathSpec is a type to mark structs as path specs. There is no
 // implementation because we'd like to keep the specs and the mappers
 // decoupled.

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -134,3 +134,49 @@ func TestDigestFromPath(t *testing.T) {
 		}
 	}
 }
+
+func TestExportedPathHelpers(t *testing.T) {
+	const repo = "foo/bar"
+	dgst := digest.Digest("sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+
+	got, err := BlobLinkPath(repo, dgst)
+	if err != nil {
+		t.Fatalf("BlobLinkPath: %v", err)
+	}
+	want, err := pathFor(layerLinkPathSpec{name: repo, digest: dgst})
+	if err != nil {
+		t.Fatalf("pathFor(layerLinkPathSpec): %v", err)
+	}
+	if got != want {
+		t.Errorf("BlobLinkPath = %q; want %q", got, want)
+	}
+
+	got, err = ManifestRevisionLinkPath(repo, dgst)
+	if err != nil {
+		t.Fatalf("ManifestRevisionLinkPath: %v", err)
+	}
+	want, err = pathFor(manifestRevisionLinkPathSpec{name: repo, revision: dgst})
+	if err != nil {
+		t.Fatalf("pathFor(manifestRevisionLinkPathSpec): %v", err)
+	}
+	if got != want {
+		t.Errorf("ManifestRevisionLinkPath = %q; want %q", got, want)
+	}
+
+	gotRoot := RepositoriesRootPath()
+	wantRoot, err := pathFor(repositoriesRootPathSpec{})
+	if err != nil {
+		t.Fatalf("pathFor(repositoriesRootPathSpec): %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Errorf("RepositoriesRootPath = %q; want %q", gotRoot, wantRoot)
+	}
+
+	// Invalid digest should surface as an error rather than a bogus path.
+	if _, err := BlobLinkPath(repo, digest.Digest("not-a-digest")); err == nil {
+		t.Error("BlobLinkPath: want error for invalid digest, got nil")
+	}
+	if _, err := ManifestRevisionLinkPath(repo, digest.Digest("not-a-digest")); err == nil {
+		t.Error("ManifestRevisionLinkPath: want error for invalid digest, got nil")
+	}
+}


### PR DESCRIPTION
Hi

This PR fixes a bug in the pull-through cache where shared blobs could be vacuumed while still referenced, causing pulls to return HTTP 200 with an empty body. Also fixes hot blobs expiring on first-pull TTL despite ongoing traffic.

**Root cause**

The pull-through cache scheduler is keyed by repo@digest, so a blob shared by N repositories had N independent timers. The first to fire called Vacuum.RemoveBlob on the underlying file regardless of the other surviving references; the remaining repos kept their per-repo descriptor cache valid and started returning HTTP 200 with a zero-byte body to every subsequent pull. Hot blobs also expired on their first-pull TTL because AddBlob was only called on cache miss, never on cache hit.

**What changed**

- OnBlobExpire now deletes the per-repository link first (clears the expiring repo's descriptor cache regardless of the outcome), then asks the scheduler whether any other live entry references the digest (fast path), then walks the storage tree with pruning over /_layers/<alg>/<hex>/ for any surviving on-disk link (slow path). The shared blob is vacuumed only when both checks come back empty. The full sequence runs under a per-digest scheduler.EvictionLock so that N concurrent expiries for the same digest serialise rather than racing each other into a leak. HasOtherReferencesToDigest ignores entries whose timer has already fired so the fast path is not misled by in-flight callbacks.

- proxyBlobStore.ServeBlob refreshes the scheduler entry through AddBlob on every cache hit, so frequently-pulled blobs no longer expire while traffic continues. Touch failures are logged but do not fail the response (the body has already been streamed to the client).

- On Start the scheduler runs a one-shot Reconciler hook that walks the repositories tree once and registers any orphan blob/manifest link not already present in scheduler-state.json. State written by earlier binaries that under-tracked links is now picked up rather than leaked.

**Notes**

- The startTimer lock is split: the user callback runs without the scheduler mutex held (the new ref-count check would otherwise deadlock on the non-reentrant sync.Mutex), and the entry is dropped only when the map still holds the same pointer (so a concurrent AddBlob cannot have its fresh entry evicted by the old timer).

- Three minimal additive exports in registry/storage (BlobLinkPath, ManifestRevisionLinkPath, RepositoriesRootPath) keep all path construction inside the storage package; nothing in proxy hardcodes storage layout strings.

- scheduler-state.json keeps the existing repo@digest keys, no new fields, no version bump - patched and unpatched binaries can read each other's state in both directions.

Fixes: distribution/distribution#2367, distribution/distribution#3247

<details>

<summary>Broken example</summary>

```shell
# grep 'Image\|TTL' /etc/containers/systemd/registry-dockerhub.container
Image=ghcr.io/distribution/distribution:3.1.1
Environment=REGISTRY_PROXY_TTL=5m

# systemctl stop registry-dockerhub; rm -rf /data/registry/dockerhub/*; systemctl start registry-dockerhub; sleep 3; docker system prune -af;
Total reclaimed space: 0B

# docker pull dockerhub.mirror.<redacted>/library/alpine:3.22;
3.22: Pulling from library/alpine
84f5eff04246: Pull complete
513a321f20b9: Download complete
c087f1df63f4: Download complete
Digest: sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
Status: Downloaded newer image for dockerhub.mirror.<redacted>/library/alpine:3.22
dockerhub.mirror.<redacted>/library/alpine:3.22

# jq 'keys[] | select(test("alpine@"))' /data/registry/dockerhub/scheduler-state.json;
"library/alpine@sha256:2039be0c5ec6ce8566809626a252c930216a92109c043f282504accb5ee3c0c6"
"library/alpine@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601"
"library/alpine@sha256:4f79b35a0947bbc2172d03fbeb9d0bc25831dbe5749210c6c9d7674bb86a4cad"
"library/alpine@sha256:513a321f20b9fead75695a39ff36922fd535d884b99f694d40aff1510f896bd6"
"library/alpine@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"
"library/alpine@sha256:9292219a28ffaeaa2dc461905c5c2d773bf49671f9c927c338c6f28ce08ac61b"
"library/alpine@sha256:c087f1df63f42800214f07850eb0b9469be3e9eef5533531559a01cd44110b1c"
"library/alpine@sha256:d3f4d4e2957919707fd3083f0e47b1dd89222070fc4c8a2429c4022d55120370"

# docker system prune -af;
Untagged: dockerhub.mirror.<redacted>/library/alpine:3.22
Deleted: sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
Total reclaimed space: 0B

# sleep 210; docker pull dockerhub.mirror.<redacted>/library/rust:alpine3.22
alpine3.22: Pulling from library/rust
abd89bdc4eb5: Pull complete
d12e6db68193: Pull complete
84f5eff04246: Pull complete
e4669461c36d: Download complete
b6eff066a880: Download complete
Digest: sha256:064dfc925d68d1a63f4fd2871bd7dc6e6ea56692989a487185855d62885d90aa
Status: Downloaded newer image for dockerhub.mirror.<redacted>/library/rust:alpine3.22
dockerhub.mirror.<redacted>/library/rust:alpine3.22

# jq 'keys[] | select(endswith("@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"))' /data/registry/dockerhub/scheduler-state.json
"library/alpine@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"
"library/rust@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"

# docker system prune -af; sleep 100;
Untagged: dockerhub.mirror.<redacted>/library/rust:alpine3.22
Deleted: sha256:064dfc925d68d1a63f4fd2871bd7dc6e6ea56692989a487185855d62885d90aa
Total reclaimed space: 0B

# jq 'keys[] | select(endswith("@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"))' /data/registry/dockerhub/scheduler-state.json
"library/rust@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"

# ls /data/registry/dockerhub/docker/registry/v2/blobs/sha256/84/84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e/data
ls: cannot access '/data/registry/dockerhub/docker/registry/v2/blobs/sha256/84/84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e/data': No such file or directory

# journalctl -u registry-dockerhub --since '2 min ago' | grep '84f5eff04246'
May 21 14:48:35 mirror1.<redacted> registry-dockerhub[549042]: time="2026-05-21T14:48:35.998238828Z" level=info msg="Deleting blob: /docker/registry/v2/blobs/sha256/84/84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e" environment=development go.version=go1.25.9 instance.id=019e4afd-c458-75fe-8794-4f7131f4f600 service=registry version=3.1.1

# docker pull dockerhub.mirror.<redacted>/library/rust:alpine3.22
alpine3.22: Pulling from library/rust
d12e6db68193: Downloading [>                                                  ]  1.049MB/65.08MB
84f5eff04246: Pulling fs layer
abd89bdc4eb5: Downloading [>                                                  ]  2.097MB/269.6MB
e4669461c36d: Download complete
b6eff066a880: Download complete
short read: expected 3808189 bytes but got 0: unexpected EOF
```

</details>

<details>

<summary>Fixed example</summary>

```shell
# jq '."insecure-registries"' /etc/docker/daemon.json
[
  "registry-dockerhub-fix-ttl.dns.podman:5000"
]

# grep 'Image\|TTL' /etc/containers/systemd/registry-dockerhub-fix-ttl.container
Image=<redacted>/testing/distribution:3.1.1-fix-ttl
Environment=REGISTRY_PROXY_TTL=5m

# systemctl stop registry-dockerhub-fix-ttl; rm -rf /data/registry/dockerhub_test_ttl/*; systemctl start registry-dockerhub-fix-ttl; sleep 3; docker system prune -af;
Total reclaimed space: 0B

# docker pull registry-dockerhub-fix-ttl.dns.podman:5000/library/alpine:3.22;
3.22: Pulling from library/alpine
84f5eff04246: Pull complete
513a321f20b9: Download complete
c087f1df63f4: Download complete
Digest: sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
Status: Downloaded newer image for registry-dockerhub-fix-ttl.dns.podman:5000/library/alpine:3.22
registry-dockerhub-fix-ttl.dns.podman:5000/library/alpine:3.22

# jq 'keys[] | select(test("alpine@"))' /data/registry/dockerhub_test_ttl/scheduler-state.json;
"library/alpine@sha256:2039be0c5ec6ce8566809626a252c930216a92109c043f282504accb5ee3c0c6"
"library/alpine@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601"
"library/alpine@sha256:4f79b35a0947bbc2172d03fbeb9d0bc25831dbe5749210c6c9d7674bb86a4cad"
"library/alpine@sha256:513a321f20b9fead75695a39ff36922fd535d884b99f694d40aff1510f896bd6"
"library/alpine@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"
"library/alpine@sha256:9292219a28ffaeaa2dc461905c5c2d773bf49671f9c927c338c6f28ce08ac61b"
"library/alpine@sha256:c087f1df63f42800214f07850eb0b9469be3e9eef5533531559a01cd44110b1c"
"library/alpine@sha256:d3f4d4e2957919707fd3083f0e47b1dd89222070fc4c8a2429c4022d55120370"

# docker system prune -af;
Untagged: registry-dockerhub-fix-ttl.dns.podman:5000/library/alpine:3.22
Deleted: sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
Total reclaimed space: 0B

# sleep 210; docker pull registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
alpine3.22: Pulling from library/rust
b6eff066a880: Download complete
e4669461c36d: Download complete
84f5eff04246: Pull complete
d12e6db68193: Pull complete
abd89bdc4eb5: Pull complete
Digest: sha256:064dfc925d68d1a63f4fd2871bd7dc6e6ea56692989a487185855d62885d90aa
Status: Downloaded newer image for registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22

# jq 'keys[] | select(endswith("@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"))' /data/registry/dockerhub_test_ttl/scheduler-state.json
"library/alpine@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"
"library/rust@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"

# docker system prune -af; sleep 100;
Untagged: registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
Deleted: sha256:064dfc925d68d1a63f4fd2871bd7dc6e6ea56692989a487185855d62885d90aa
Total reclaimed space: 0B

# jq 'keys[] | select(endswith("@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"))' /data/registry/dockerhub_test_ttl/scheduler-state.json
"library/rust@sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e"

# ls /data/registry/dockerhub_test_ttl/docker/registry/v2/blobs/sha256/84/84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e/data
/data/registry/dockerhub_test_ttl/docker/registry/v2/blobs/sha256/84/84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e/data

# journalctl -u registry-dockerhub-fix-ttl --since '2 min ago' | grep '84f5eff04246'
May 21 15:02:47 mirror1.<redacted> registry-dockerhub-fix-ttl[567465]: time="2026-05-21T15:02:47.95625634Z" level=info msg="skipping blob vacuum for sha256:84f5eff04246b56d48d1ed6cbd82d6bc7e53f7e790db6a467f92571c69f3289e: another scheduled entry still references the digest" environment=development go.version=go1.26.3 instance.id=019e4b09-66b8-734c-9634-b786dddf2446 service=registry version=v3.1.1+unknown


# docker pull registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
alpine3.22: Pulling from library/rust
abd89bdc4eb5: Pull complete
84f5eff04246: Pull complete
d12e6db68193: Pull complete
e4669461c36d: Download complete
b6eff066a880: Download complete
Digest: sha256:064dfc925d68d1a63f4fd2871bd7dc6e6ea56692989a487185855d62885d90aa
Status: Downloaded newer image for registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
registry-dockerhub-fix-ttl.dns.podman:5000/library/rust:alpine3.22
```

</details>
