### PR TITLE
docs(health): fix broken code examples in package documentation

### DIFF
--- a/health/doc.go
+++ b/health/doc.go
@@ -81,8 +81,8 @@
 // endpoint always return an error:
 //
 //	health.RegisterFunc("my_check", func() error {
-//	 return Errors.new("This is an error!")
-//	}))
+//	 return errors.New("This is an error!")
+//	})
 //
 // # Examples
 //
@@ -95,7 +95,7 @@
 //	updater = health.NewStatusUpdater()
 //	 health.RegisterFunc("database_check", func() error {
 //	  return updater.Check()
-//	}))
+//	})
 //
 //	conn, err := Connect(...) // database call here
 //	if err != nil {
@@ -105,7 +105,7 @@
 // You can also use the predefined Checkers that come included with the health
 // package. First, import the checks:
 //
-//	import "github.com/distribution/distribution/v3/health/checks
+//	import "github.com/distribution/distribution/v3/health/checks"
 //
 // After that you can make use of any of the provided checks. An example of
 // using a `FileChecker` to take the application out of rotation if a certain


### PR DESCRIPTION
The `health` package godoc had three busted code examples that would fail to compile if anyone copy-pasted them:

- `Errors.new(...)` - no such thing in Go. Should be `errors.New(...)` (lowercase `e`)
- `}))` appears twice - extra closing paren makes both `RegisterFunc` examples syntactically invalid
- `import "github.com/.../health/checks` - missing the closing `"`

These are easy to hit: just follow the package docs and try to build. The first one gives you `undefined: Errors`, the import typo gives an `unexpected newline` syntax error.

**Reproduce:**
Copy the snippet from line ~83 of `health/doc.go` into any Go file and run `go build` - it blows up immediately.

**Fix:** three-line patch, no logic changed, tests still pass.