### PR TITLE
verify fetched manifest matches requested digest

### DIFF
--- a/internal/client/repository.go
+++ b/internal/client/repository.go
@@ -514,6 +514,7 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		err         error
 		contentDgst *digest.Digest
 		mediaTypes  []string
+		byDigest    bool
 	)
 
 	for _, option := range options {
@@ -542,6 +543,7 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		if err != nil {
 			return nil, err
 		}
+		byDigest = true
 	}
 
 	if len(mediaTypes) == 0 {
@@ -588,6 +590,20 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+	if byDigest {
+		// When the manifest is requested by digest, the response body is
+		// content-addressed: confirm it actually hashes to the digest we
+		// asked for before handing it back. Otherwise a tampered or
+		// misbehaving registry could return arbitrary content under a
+		// trusted digest.
+		verifier := dgst.Verifier()
+		if _, err := verifier.Write(body); err != nil {
+			return nil, err
+		}
+		if !verifier.Verified() {
+			return nil, fmt.Errorf("manifest digest mismatch: requested %s but content does not match", dgst)
+		}
 	}
 	m, _, err := distribution.UnmarshalManifest(mt, body)
 	if err != nil {

--- a/internal/client/repository_test.go
+++ b/internal/client/repository_test.go
@@ -1139,6 +1139,39 @@ func TestOCIManifestFetch(t *testing.T) {
 	}
 }
 
+func TestManifestFetchByDigestMismatch(t *testing.T) {
+	ctx := dcontext.Background()
+	repo, _ := reference.WithName("test.example.com/repo")
+	_, realDgst, pl := newRandomOCIManifest(t, 6)
+
+	// A valid-format digest that does not match the manifest content.
+	wrongDgst := digest.FromBytes([]byte("not the manifest content"))
+	if wrongDgst == realDgst {
+		t.Fatal("digests unexpectedly equal")
+	}
+
+	var m testutil.RequestResponseMap
+	// The registry answers a by-digest request for wrongDgst with content
+	// whose actual digest is realDgst.
+	addTestManifest(repo, wrongDgst.String(), v1.MediaTypeImageManifest, pl, &m)
+
+	e, c := testServer(m)
+	defer c()
+
+	r, err := NewRepository(repo, e, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ms.Get(ctx, wrongDgst); err == nil {
+		t.Fatal("expected Get to reject content that does not match the requested digest")
+	}
+}
+
 func TestManifestFetchWithEtag(t *testing.T) {
 	repo, _ := reference.WithName("test.example.com/repo/by/tag")
 	_, d1, p1 := newRandomOCIManifest(t, 6)


### PR DESCRIPTION
`(*manifests).Get` reads the response body and unmarshals it without checking that it hashes to the digest that was requested. On a fetch by digest (the path the pull-through cache proxy takes against its upstream), an upstream that returns content not matching the requested digest is accepted, so the caller is handed content under a digest it never produced.

The fix runs the body through the requested digest's `Verifier` and rejects a mismatch before unmarshalling, only when the request was made by digest (a tag fetch has no digest to compare against, so it is left alone). The check sits in the client because that is where the content-addressed response is first read; consumers such as the proxy serve it straight on before any storage-layer rehash would catch the mismatch.

Repro: have a registry answer `GET /v2/<repo>/manifests/<digestA>` with a body whose real digest is `digestB`.
Expected: `Get` returns an error.
Actual (before): `Get` returns the manifest with no error.
