### PR TITLE
wire validateManifestList into manifest list unmarshal

### DIFF
--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -36,6 +36,10 @@ func init() {
 }
 
 func unmarshalManifestList(b []byte) (distribution.Manifest, v1.Descriptor, error) {
+	if err := validateManifestList(b); err != nil {
+		return nil, v1.Descriptor{}, err
+	}
+
 	m := &DeserializedManifestList{}
 	if err := m.UnmarshalJSON(b); err != nil {
 		return nil, v1.Descriptor{}, err

--- a/manifest/manifestlist/manifestlist_test.go
+++ b/manifest/manifestlist/manifestlist_test.go
@@ -204,3 +204,20 @@ func TestValidateManifestList(t *testing.T) {
 		}
 	})
 }
+
+func TestUnmarshalManifestListRejectsManifest(t *testing.T) {
+	// A document carrying the manifest-list media type but also image-manifest
+	// fields (config/layers) is ambiguous and must be rejected by the
+	// registered unmarshal path, not just by validateManifestList in isolation.
+	b := []byte(`{
+		"schemaVersion": 2,
+		"mediaType": "` + MediaTypeManifestList + `",
+		"config": {"size": 1},
+		"layers": [{"size": 2}],
+		"manifests": [{"size": 3}]
+	}`)
+
+	if _, _, err := distribution.UnmarshalManifest(MediaTypeManifestList, b); err == nil {
+		t.Fatal("ambiguous manifest/list document should not unmarshal as a manifest list")
+	}
+}


### PR DESCRIPTION
`Repro:` decode a payload with `Content-Type: application/vnd.docker.distribution.manifest.list.v2+json` whose JSON also carries `config` and `layers` alongside `manifests`. `distribution.UnmarshalManifest` accepts it as a manifest list.

`Cause:` `unmarshalManifestList` never calls `validateManifestList`, so a document that is simultaneously an image manifest and a list parses as a list. The OCI sibling `unmarshalImageIndex` already calls `validateIndex` to reject the ambiguous shape; the docker list path was the only one missing the guard, and `validateManifestList` was sitting unused despite having its own unit test.

`Fix:` call `validateManifestList(b)` at the top of `unmarshalManifestList`, matching the OCI index path. Regression test drives the registered `distribution.UnmarshalManifest` path so the guard stays wired.
