### PR TITLE
fix(storage): preserve media type when caching blob descriptors

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -879,6 +879,65 @@ func TestBlobDeleteDisabled(t *testing.T) {
 	checkResponse(t, "status of disabled delete", resp, http.StatusMethodNotAllowed)
 }
 
+func TestBlobAPIManifestDigestContentTypeFromCache(t *testing.T) {
+	config := configuration.Configuration{
+		Storage: configuration.Storage{
+			"inmemory": configuration.Parameters{},
+			"cache": configuration.Parameters{
+				"blobdescriptor": "inmemory",
+			},
+			"maintenance": configuration.Parameters{"uploadpurging": map[any]any{
+				"enabled": false,
+			}},
+		},
+		Catalog: configuration.Catalog{
+			MaxEntries: 5,
+		},
+		Tags: configuration.Tags{
+			MaxTags: 1000,
+		},
+	}
+	config.HTTP.Headers = headerConfig
+
+	env := newTestEnvWithConfig(t, &config)
+	defer env.Shutdown()
+
+	imageName, err := reference.WithName("foo/bar")
+	if err != nil {
+		t.Fatalf("unable to parse reference: %v", err)
+	}
+	manifestDigest := createRepository(env, t, imageName.Name(), "latest")
+
+	ref, err := reference.WithDigest(imageName, manifestDigest)
+	if err != nil {
+		t.Fatalf("unable to build digest reference: %v", err)
+	}
+	blobURL, err := env.builder.BuildBlobURL(ref)
+	if err != nil {
+		t.Fatalf("unexpected error building blob URL: %v", err)
+	}
+
+	for _, method := range []string{http.MethodHead, http.MethodGet} {
+		t.Run(method, func(t *testing.T) {
+			req, err := http.NewRequest(method, blobURL, nil)
+			if err != nil {
+				t.Fatalf("unexpected error building request: %v", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unexpected error requesting manifest as blob: %v", err)
+			}
+			defer resp.Body.Close()
+
+			checkResponse(t, "requesting manifest digest through blob API", resp, http.StatusOK)
+			if got := resp.Header.Get("Content-Type"); got != schema2.MediaTypeManifest {
+				t.Fatalf("Content-Type = %q, want %q", got, schema2.MediaTypeManifest)
+			}
+		})
+	}
+}
+
 func testBlobAPI(t *testing.T, env *testEnv, args blobArgs) *testEnv {
 	// TODO(stevvooe): This test code is complete junk but it should cover the
 	// complete flow. This must be broken down and checked against the

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -91,13 +91,15 @@ func (lbs *linkedBlobStore) Put(ctx context.Context, mediaType string, p []byte)
 		return v1.Descriptor{}, err
 	}
 
+	// Preserve the repository-local media type. The central blob store
+	// deliberately returns application/octet-stream.
+	if mediaType != "" {
+		desc.MediaType = mediaType
+	}
+
 	if err := lbs.blobAccessController.SetDescriptor(ctx, dgst, desc); err != nil {
 		return v1.Descriptor{}, err
 	}
-
-	// TODO(stevvooe): Write out mediatype if incoming differs from what is
-	// returned by Put above. Note that we should allow updates for a given
-	// repository.
 
 	return desc, lbs.linkBlob(ctx, desc)
 }

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -820,9 +820,27 @@ func TestManifestStorageCache(t *testing.T) {
 		t.Fatalf("unexpected error putting manifest: %v", err)
 	}
 
-	_, err = repositoryScopedCacheProvider.Stat(ctx, manifestDigest)
+	manifestMediaType, _, err := sm.Payload()
 	if err != nil {
-		t.Errorf("Manifest should be cached")
+		t.Fatalf("unexpected error getting manifest payload: %v", err)
+	}
+
+	// Regression coverage for #4812: cached manifest descriptors can later be
+	// consumed through Blobs().Stat for /blobs/<manifest-digest>.
+	cachedDesc, err := repositoryScopedCacheProvider.Stat(ctx, manifestDigest)
+	if err != nil {
+		t.Fatalf("manifest should be cached: %v", err)
+	}
+	if cachedDesc.MediaType != manifestMediaType {
+		t.Fatalf("cached manifest media type = %q, want %q", cachedDesc.MediaType, manifestMediaType)
+	}
+
+	blobDesc, err := blobStore.Stat(ctx, manifestDigest)
+	if err != nil {
+		t.Fatalf("unexpected error statting cached manifest as blob: %v", err)
+	}
+	if blobDesc.MediaType != manifestMediaType {
+		t.Fatalf("cached blob media type = %q, want %q", blobDesc.MediaType, manifestMediaType)
 	}
 
 	exists, err := ms.Exists(ctx, manifestDigest)


### PR DESCRIPTION
`linkedBlobStore.Put` was caching descriptors using the `application/octet-stream` placeholder returned by the central blob store instead of the repository-local media type the caller supplied. After #4595 wired the manifest service through the same repository-scoped descriptor cache, this caused `GET`/`HEAD` `/v2/<name>/blobs/<manifest-digest>` to serve manifest content with `Content-Type: application/octet-stream`, breaking clients such as containerd that fetch manifests by digest via the blobs API and pollute their local image cache with the wrong media type.

Set `desc.MediaType` from the incoming media type before caching the descriptor so subsequent `Stat` calls (including those served by the blob endpoint) return the correct repository-local `Content-Type`.

Adds regression coverage at both the storage layer (manifest cache and blob statter agree on the cached media type) and the HTTP handler layer (`HEAD`/`GET` `/blobs/<manifest-digest>` returns `200` with the manifest media type).

Fixes #4812