### PR TITLE
fold CR/LF in mailer subject to avoid SMTP header injection

### DIFF
--- a/registry/handlers/mail.go
+++ b/registry/handlers/mail.go
@@ -20,11 +20,6 @@ func (mail *mailer) sendMail(subject, message string) error {
 		return errors.New("invalid Mail Address")
 	}
 	host := addr[0]
-	msg := []byte("To:" + strings.Join(mail.To, ";") +
-		"\r\nFrom: " + mail.From +
-		"\r\nSubject: " + subject +
-		"\r\nContent-Type: text/plain\r\n\r\n" +
-		message)
 	auth := smtp.PlainAuth(
 		"",
 		mail.Username,
@@ -36,10 +31,23 @@ func (mail *mailer) sendMail(subject, message string) error {
 		auth,
 		mail.From,
 		mail.To,
-		msg,
+		mail.buildMessage(subject, message),
 	)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+// buildMessage assembles the mail. subject is placed in the header block, so a
+// CR or LF in it is folded to a space to keep it on a single line and stop a
+// newline from injecting extra SMTP headers. subject is built from the log
+// entry message and is not guaranteed to be header-safe.
+func (mail *mailer) buildMessage(subject, message string) []byte {
+	subject = strings.NewReplacer("\r", " ", "\n", " ").Replace(subject)
+	return []byte("To:" + strings.Join(mail.To, ";") +
+		"\r\nFrom: " + mail.From +
+		"\r\nSubject: " + subject +
+		"\r\nContent-Type: text/plain\r\n\r\n" +
+		message)
 }

--- a/registry/handlers/mail_test.go
+++ b/registry/handlers/mail_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMailerBuildMessageFoldsSubject(t *testing.T) {
+	m := &mailer{
+		From: "registry@example.test",
+		To:   []string{"ops@example.test"},
+	}
+
+	msg := string(m.buildMessage("alert\r\nBcc: attacker@evil.test", "the body"))
+
+	headers, body, ok := strings.Cut(msg, "\r\n\r\n")
+	if !ok {
+		t.Fatalf("message has no header/body separator: %q", msg)
+	}
+	for _, line := range strings.Split(headers, "\r\n") {
+		if strings.HasPrefix(line, "Bcc:") {
+			t.Fatalf("newline in subject injected a header line:\n%s", headers)
+		}
+	}
+	if !strings.Contains(headers, "Subject: alert  Bcc: attacker@evil.test") {
+		t.Errorf("subject was not folded to a single line:\n%s", headers)
+	}
+	if body != "the body" {
+		t.Errorf("unexpected body: %q", body)
+	}
+}


### PR DESCRIPTION
1. `mailer.sendMail` puts `subject` straight into the SMTP header block, and the `mail` log hook sets that subject to `[level] host: entry.Message`.
2. so a `CR`/`LF` in a logged message ends the `Subject` line early and injects its own headers (`Bcc`, etc.) into the alert mail.

`repro`: subject `"alert\r\nBcc: attacker@evil.test"`
`expected`: the injected text stays on the `Subject` line
`actual`: a separate `Bcc: attacker@evil.test` header line appears before the body

folded `CR`/`LF` in the subject to a space, since the subject is log-derived and not guaranteed header-safe. test in `mail_test.go`.
