### PR TITLE
build: remove duplicate ldflags in go build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ version/version.go:
 
 bin/%: cmd/% FORCE ## build individual binary
 	@echo "$(WHALE) $@${BINARY_SUFFIX}"
-	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS}  ./$<
+	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS}  ./$<
 
 binaries: $(BINARIES) ## build binaries
 	@echo "$(WHALE) $@"
 
 build: ## build go packages
 	@echo "$(WHALE) $@"
-	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS} $(PACKAGES)
+	@go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} ${GO_TAGS} $(PACKAGES)
 
 image: ## build docker image IMAGE_NAME=<name>
 	docker buildx bake --set "*.tags=${IMAGE_NAME}" image-local


### PR DESCRIPTION
## Summary

This removes the duplicated --ldflags from the build and binaries targets.

The Makefile already defines `GO_LDFLAGS` with the version metadata.
However, the go build commands passed another `--ldflags` after `GO_LDFLAGS`.

 According to the Go command documentation:

> If a package matches patterns given in multiple flags, the latest match on the command line wins.

https://pkg.go.dev/cmd/go

As a result, the later `--ldflags` took precedence and the version metadata from `GO_LDFLAGS` was not applied.

## Verification

```console
$ make binaries VERSION=bar
+ bin/registry
+ bin/digest
+ bin/registry-api-descriptor-template
+ binaries
$ ./bin/registry --version
./bin/registry github.com/distribution/distribution/v3 v3.1.1+unknown
$ ./bin/digest --version
./bin/digest github.com/distribution/distribution/v3 v3.1.1+unknown
$ git diff
diff --git a/Makefile b/Makefile
index 9bf6e85c..d44d0b49 100644
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ version/version.go:

 bin/%: cmd/% FORCE ## build individual binary
        @echo "$(WHALE) $@${BINARY_SUFFIX}"
-       @go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS}  ./$<
+       @go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS}  ./$<

 binaries: $(BINARIES) ## build binaries
        @echo "$(WHALE) $@"

 build: ## build go packages
        @echo "$(WHALE) $@"
-       @go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} --ldflags '-extldflags "-Wl,-z,now" -s' ${GO_TAGS} $(PACKAGES)
+       @go build -buildmode=pie ${GO_GCFLAGS} ${GO_BUILD_FLAGS} ${GO_LDFLAGS} ${GO_TAGS} $(PACKAGES)

 image: ## build docker image IMAGE_NAME=<name>
        docker buildx bake --set "*.tags=${IMAGE_NAME}" image-local
$ make clean
+ clean
$ make binaries VERSION=bar
+ bin/registry
+ bin/digest
+ bin/registry-api-descriptor-template
+ binaries
$ ./bin/registry --version
./bin/registry github.com/distribution/distribution/v3 bar
$ ./bin/digest --version
./bin/digest github.com/distribution/distribution/v3 bar

```


