### PR TITLE
fix(s3): bound pooled part buffer growth to chunk size

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -542,7 +542,10 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		StorageClass:                params.StorageClass,
 		ObjectACL:                   params.ObjectACL,
 		pool: &sync.Pool{
-			New: func() any { return &bytes.Buffer{} },
+			// Sized to ChunkSize plus one Write's worth of overflow: an empty
+			// buffer would grow geometrically while filling and settle at ~2x
+			// ChunkSize, doubling per-upload memory under concurrent pushes.
+			New: func() any { return bytes.NewBuffer(make([]byte, 0, params.ChunkSize+64*1024)) },
 		},
 	}
 


### PR DESCRIPTION
Caps each in-flight S3 upload's part buffer at `chunksize`. Today the buffer settles at about 2x `chunksize`, so per-upload memory under concurrent pushes is double what the configuration suggests.

## Problem

Each upload holds a pooled `bytes.Buffer` that fills to `chunksize` before a part is flushed. Pooled buffers start empty, and `bytes.Buffer` grows geometrically while filling, ending near 2x `chunksize`. A single `Write` larger than the remaining space grows it further.

With 32 concurrent 100 MiB uploads at the default 10 MiB `chunksize`, the driver peaks at 740 MiB of heap, almost all of it in `bytes.growSlice` called from `(*writer).Write`.

## Change

The writer now grows the buffer itself. The first allocation matches the first write, later growth is 8x, and capacity is capped at `chunksize`. `Write` splits input at chunk boundaries and flushes as soon as the buffer is full. The buffer therefore:

- never exceeds `chunksize`, whatever the caller's write size
- does not reserve a full chunk for small uploads
- avoids size arithmetic that could overflow on 32-bit, where `chunksize` can be `math.MaxInt32`

S3 still receives `chunksize` parts plus a smaller final part.

## Results

| | Peak heap |
|---|---|
| main | 740 MiB |
| this PR | 371 MiB |

Measured with the driver against an in-process fake S3 that checks every byte of every part against the expected pattern. No corrupt parts. Harness: https://gist.github.com/Vad1mo/59e1e5d1e084e89ecc1835e1fdd31a49

Implementation by @milosgajdos (Vad1mo/distribution#1).

## Related

- #4066 added the buffer pool
- #1533 reported memory scaling with `chunksize`
- #4920 adds an optional `spooldir` that moves part data to disk
