### PR TITLE
feat(registry/storage/driver/s3-aws): add spooldir to buffer upload parts on disk

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -27,6 +27,7 @@ Amazon S3 or S3 compatible services for object storage.
 | `skipverify`  | no  | Skips TLS verification when the value is set to `true`. The default is `false`. |
 | `v4auth`  | no | Indicates whether the registry uses Version 4 of AWS's authentication. The default is `true`. |
 | `chunksize`  | no | The S3 API requires multipart upload chunks to be at least 5MB. This value should be a number that is larger than 5 * 1024 * 1024.|
+| `spooldir`  | no | A local directory to spool pending multipart upload data to instead of buffering it in memory. When unset (the default), each in-flight blob upload buffers up to `chunksize` bytes in memory. |
 | `multipartcopychunksize` | no | Default chunk size for all but the last S3 Multipart Upload part when copying stored objects. |
 | `multipartcopymaxconcurrency` | no | Max number of concurrent S3 Multipart Upload operations when copying stored objects. |
 | `multipartcopythresholdsize` | no | Default object size above which S3 Multipart Upload will be used when copying stored objects. |
@@ -64,6 +65,8 @@ Amazon S3 or S3 compatible services for object storage.
 `v4auth`: (optional) Whether you would like to use aws signature version 4 with your requests. This defaults to `false` if not specified. The `eu-central-1` region does not work with version 2 signatures, so the driver errors out if initialized with this region and v4auth set to `false`.
 
 `chunksize`: (optional) The default part size for multipart uploads (performed by WriteStream) to S3. The default is 10 MB. Keep in mind that the minimum part size for S3 is 5MB. Depending on the speed of your connection to S3, a larger chunk size may result in better performance; faster connections benefit from larger chunk sizes.
+
+`spooldir`: (optional) A local directory used to spool pending multipart upload data to disk instead of holding it in memory. When unset, every in-flight blob upload buffers up to `chunksize` bytes in memory, so registry memory usage grows with the number of concurrent pushes; with `spooldir` set, that data is written to a temporary file per upload and streamed to S3 from disk. The directory must be writable by the registry process and have enough space for `chunksize` bytes per concurrent upload (a tmpfs or Kubernetes `emptyDir` works well).
 
 `multipartcopychunksize`: (optional) The default chunk size for all but the last Upload Part in the S3 Multipart Upload operation when copying stored objects. Default value is set to `32 MB`.
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -119,6 +120,7 @@ type DriverParameters struct {
 	UseFIPSEndpoint             bool
 	LogLevel                    aws.LogLevelType
 	RedirectEndpoint            string
+	SpoolDir                    string
 }
 
 func init() {
@@ -168,6 +170,7 @@ type driver struct {
 	StorageClass                string
 	ObjectACL                   string
 	RedirectEndpoint            *url.URL
+	SpoolDir                    string
 	pool                        *sync.Pool
 }
 
@@ -343,6 +346,11 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		redirectEndpoint = ""
 	}
 
+	spoolDir := parameters["spooldir"]
+	if spoolDir == nil {
+		spoolDir = ""
+	}
+
 	params := DriverParameters{
 		AccessKey:                   fmt.Sprint(accessKey),
 		SecretKey:                   fmt.Sprint(secretKey),
@@ -369,6 +377,7 @@ func FromParameters(ctx context.Context, parameters map[string]any) (*Driver, er
 		UseFIPSEndpoint:             useFIPSEndpointBool,
 		LogLevel:                    getS3LogLevelFromParam(parameters["loglevel"]),
 		RedirectEndpoint:            fmt.Sprint(redirectEndpoint),
+		SpoolDir:                    fmt.Sprint(spoolDir),
 	}
 
 	return New(ctx, params)
@@ -541,6 +550,7 @@ func New(ctx context.Context, params DriverParameters) (*Driver, error) {
 		RootDirectory:               params.RootDirectory,
 		StorageClass:                params.StorageClass,
 		ObjectACL:                   params.ObjectACL,
+		SpoolDir:                    params.SpoolDir,
 		pool: &sync.Pool{
 			New: func() any { return &bytes.Buffer{} },
 		},
@@ -648,7 +658,7 @@ func (d *driver) Writer(ctx context.Context, path string, appendMode bool) (stor
 		if err != nil {
 			return nil, err
 		}
-		return d.newWriter(ctx, key, *resp.UploadId, nil), nil
+		return d.newWriter(ctx, key, *resp.UploadId, nil)
 	}
 
 	listMultipartUploadsInput := &s3.ListMultipartUploadsInput{
@@ -683,7 +693,7 @@ func (d *driver) Writer(ctx context.Context, path string, appendMode bool) (stor
 				if err != nil {
 					return nil, err
 				}
-				return d.newWriter(ctx, key, *resp.UploadId, nil), nil
+				return d.newWriter(ctx, key, *resp.UploadId, nil)
 			}
 			return nil, storagedriver.Error{
 				DriverName: driverName,
@@ -718,7 +728,7 @@ func (d *driver) Writer(ctx context.Context, path string, appendMode bool) (stor
 				}
 				allParts = append(allParts, partsList.Parts...)
 			}
-			return d.newWriter(ctx, key, *multi.UploadId, allParts), nil
+			return d.newWriter(ctx, key, *multi.UploadId, allParts)
 		}
 
 		// resp.NextUploadIdMarker must have at least one element or we would have returned not found
@@ -1327,22 +1337,39 @@ type writer struct {
 	closed    bool
 	committed bool
 	cancelled bool
+
+	// spool replaces buf when the spooldir parameter is set, keeping
+	// per-upload memory independent of ChunkSize.
+	spool    *os.File
+	spoolLen int64
 }
 
-func (d *driver) newWriter(ctx context.Context, key, uploadID string, parts []*s3.Part) storagedriver.FileWriter {
+func (d *driver) newWriter(ctx context.Context, key, uploadID string, parts []*s3.Part) (storagedriver.FileWriter, error) {
 	var size int64
 	for _, part := range parts {
 		size += *part.Size
 	}
-	return &writer{
+	w := &writer{
 		ctx:      ctx,
 		driver:   d,
 		key:      key,
 		uploadID: uploadID,
 		parts:    parts,
 		size:     size,
-		buf:      d.pool.Get().(*bytes.Buffer),
 	}
+	if d.SpoolDir != "" {
+		f, err := os.CreateTemp(d.SpoolDir, "s3-upload-*")
+		if err != nil {
+			return nil, fmt.Errorf("creating upload spool file: %w", err)
+		}
+		w.spool = f
+		// spool mode rarely touches buf (small-object rewrite path only), so
+		// don't claim a pooled buffer it won't use
+		w.buf = &bytes.Buffer{}
+	} else {
+		w.buf = d.pool.Get().(*bytes.Buffer)
+	}
+	return w, nil
 }
 
 type completedParts []*s3.CompletedPart
@@ -1418,6 +1445,14 @@ func (w *writer) Write(p []byte) (int, error) {
 			if _, err := io.Copy(w.buf, resp.Body); err != nil {
 				return 0, err
 			}
+			if w.spool != nil {
+				// keep all pending data in one place: move it to the spool file
+				if _, err := w.spool.WriteAt(w.buf.Bytes(), 0); err != nil {
+					return 0, err
+				}
+				w.spoolLen = int64(w.buf.Len())
+				w.buf.Reset()
+			}
 		} else {
 			// Otherwise we can use the old file as the new first part
 			copyPartResp, err := w.driver.S3.UploadPartCopyWithContext(w.ctx, &s3.UploadPartCopyInput{
@@ -1436,6 +1471,20 @@ func (w *writer) Write(p []byte) (int, error) {
 				Size:       aws.Int64(w.size),
 			}}
 		}
+	}
+
+	if w.spool != nil {
+		n, err := w.spool.WriteAt(p, w.spoolLen)
+		if err != nil {
+			return n, err
+		}
+		w.spoolLen += int64(n)
+		for w.spoolLen >= int64(w.driver.ChunkSize) {
+			if err := w.flush(); err != nil {
+				return 0, fmt.Errorf("flush: %w", err)
+			}
+		}
+		return n, nil
 	}
 
 	n, _ := w.buf.Write(p)
@@ -1470,10 +1519,22 @@ func (w *writer) reset() {
 	w.buf.Reset()
 	w.parts = nil
 	w.size = 0
+	if w.spool != nil {
+		_ = w.spool.Truncate(0)
+		w.spoolLen = 0
+	}
 }
 
-// releaseBuffer resets the buffer and returns it to the pool.
+// releaseBuffer resets the buffer and returns it to the pool, or removes the
+// spool file when spooling is enabled.
 func (w *writer) releaseBuffer() {
+	if w.spool != nil {
+		name := w.spool.Name()
+		_ = w.spool.Close()
+		_ = os.Remove(name)
+		w.spool = nil
+		return // buf was never taken from the pool in spool mode
+	}
 	w.buf.Reset()
 	w.driver.pool.Put(w.buf)
 }
@@ -1565,6 +1626,10 @@ func (w *writer) Commit(ctx context.Context) error {
 // called by [writer.Write] if the buffer is full, and always by [writer.Close]
 // and [writer.Commit].
 func (w *writer) flush() error {
+	if w.spool != nil {
+		return w.flushSpool()
+	}
+
 	if w.buf.Len() == 0 {
 		return nil
 	}
@@ -1592,6 +1657,65 @@ func (w *writer) flush() error {
 	})
 
 	w.size += int64(partSize)
+
+	return nil
+}
+
+// flushSpool uploads up to [w.driver.ChunkSize] bytes from the head of the
+// spool file as one part, then slides the tail to the front. The SDK reads
+// the part from disk twice (sigv4 payload hash, then send); that is the
+// deliberate disk-reads-for-heap trade-off of spool mode.
+func (w *writer) flushSpool() error {
+	if w.spoolLen == 0 {
+		return nil
+	}
+
+	partLen := min(w.spoolLen, int64(w.driver.ChunkSize))
+	r := io.NewSectionReader(w.spool, 0, partLen)
+	partNumber := aws.Int64(int64(len(w.parts)) + 1)
+
+	resp, err := w.driver.S3.UploadPartWithContext(w.ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(w.driver.Bucket),
+		Key:        aws.String(w.key),
+		PartNumber: partNumber,
+		UploadId:   aws.String(w.uploadID),
+		Body:       r,
+	})
+	if err != nil {
+		return fmt.Errorf("upload part: %w", err)
+	}
+
+	w.parts = append(w.parts, &s3.Part{
+		ETag:       resp.ETag,
+		PartNumber: partNumber,
+		Size:       aws.Int64(partLen),
+	})
+	w.size += partLen
+
+	tail := w.spoolLen - partLen
+	if tail > 0 {
+		buf := make([]byte, 256*1024)
+		var off int64
+		for off < tail {
+			n, rerr := w.spool.ReadAt(buf[:min(int64(len(buf)), tail-off)], partLen+off)
+			if n > 0 {
+				if _, werr := w.spool.WriteAt(buf[:n], off); werr != nil {
+					return werr
+				}
+				off += int64(n)
+			}
+			if rerr != nil {
+				if rerr == io.EOF && off == tail {
+					break
+				}
+				return rerr
+			}
+		}
+	}
+	if err := w.spool.Truncate(tail); err != nil {
+		return err
+	}
+	w.spoolLen = tail
 
 	return nil
 }


### PR DESCRIPTION
Adds an optional `spooldir` parameter to the S3 driver. When set, each in-flight upload keeps its pending part on disk instead of in memory, so registry memory no longer grows with the number of concurrent pushes.

## Problem

The driver holds one pending part per in-flight blob upload in memory until it reaches `chunksize` and is sent with `UploadPart`. Memory therefore grows linearly with concurrent pushes, and under push load this OOM-kills registries. The only existing control is lowering `chunksize`, which trades memory for more API calls. #3873 notes that raising `chunksize` as an R2 workaround only moves the problem into memory.

#4919 caps the in-memory buffer at 1x `chunksize` instead of about 2x. This PR removes it from memory entirely for operators who opt in.

## Change

With `spooldir` set, the writer creates one temporary file per upload in that directory and appends incoming data to it. When the file holds a full chunk, the driver uploads that chunk from disk through an `io.SectionReader`. The reader is seekable, so SDK request signing and retries work unchanged. Bytes past the chunk boundary move to the front of the file for the next part. The file is removed when the writer closes, and cancelled uploads also close the writer.

With `spooldir` unset, the driver behaves exactly as before.

## Results

32 concurrent 100 MiB uploads, default 10 MiB `chunksize`:

| | Peak heap |
|---|---|
| `spooldir` unset | 754 MiB |
| `spooldir` set | 16 MiB |

Measured with the driver against an in-process fake S3 that checks every byte of every part, including non-aligned final parts. No corrupt parts, no spool files left afterwards, similar wall time. Harness: https://gist.github.com/Vad1mo/59e1e5d1e084e89ecc1835e1fdd31a49

## Operational notes

- The directory needs about `chunksize` of free space per concurrent upload. A tmpfs or Kubernetes `emptyDir` works.
- Each part is read from disk twice: once for the SigV4 payload hash and once to send it.
- Spool files from a crashed process are not cleaned up at startup.

## Related

- #1533 reported memory scaling with `chunksize`
- #4066 pooled the buffers but kept one per upload
- #2352 streamed uploads through a separate driver and was rejected for that reason; this PR adds an option to the existing driver
- #4919 bounds the in-memory buffer
