### PR TITLE
registry/storage: avoid duplicate SHA-256 in canonical full-fallback validation

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -244,9 +244,6 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc v1.Descriptor) (v1.
 		// paths. We may be able to make the size-based check a stronger
 		// guarantee, so this may be defensive.
 		if !verified {
-			digester := digest.Canonical.Digester()
-			verifier := desc.Digest.Verifier()
-
 			// Read the file from the backend driver and validate it.
 			fr, err := newFileReader(ctx, bw.driver, bw.path, desc.Size)
 			if err != nil {
@@ -254,14 +251,26 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc v1.Descriptor) (v1.
 			}
 			defer fr.Close()
 
-			tr := io.TeeReader(fr, digester.Hash())
+			if desc.Digest.Algorithm() == digest.Canonical {
+				digester := digest.Canonical.Digester()
+				if _, err := io.Copy(digester.Hash(), fr); err != nil {
+					return v1.Descriptor{}, err
+				}
 
-			if _, err := io.Copy(verifier, tr); err != nil {
-				return v1.Descriptor{}, err
+				canonical = digester.Digest()
+				verified = desc.Digest == canonical
+			} else {
+				digester := digest.Canonical.Digester()
+				verifier := desc.Digest.Verifier()
+				tr := io.TeeReader(fr, digester.Hash())
+
+				if _, err := io.Copy(verifier, tr); err != nil {
+					return v1.Descriptor{}, err
+				}
+
+				canonical = digester.Digest()
+				verified = verifier.Verified()
 			}
-
-			canonical = digester.Digest()
-			verified = verifier.Verified()
 		}
 	}
 


### PR DESCRIPTION
## Summary

Avoid a redundant canonical SHA-256 pass when blob validation reaches canonical full-hash fallback. The fallback now re-derives the canonical digest from the bytes freshly read from storage and compares it with the requested canonical descriptor. The tested SHA-512/noncanonical fallback scenarios retain their existing verification behavior.

## Performance

For the primary 128 MiB in-memory canonical SHA-256 full-fallback validation benchmark, median time improved from 778,789,861.5 ns/op to 416,956,704 ns/op (46.46% lower; p=0.0000108).

Additional `Commit` full-fallback measurements observed the following medians:

- 8 MiB: 51,843,064 to 29,074,548 ns/op (43.92% lower; p=0.0000108)
- 64 MiB: 389,925,988.5 to 213,444,111 ns/op (45.26% lower; p=0.0000108)
- 256 MiB: 1,575,609,110 to 841,048,106 ns/op (46.62% lower; p=0.0000108)

The SHA-512 fallback measurement was 659,583,574 to 665,301,413.5 ns/op (+0.87%; p=0.247), and resumed SHA-512 was 667,379,567 to 660,202,668 ns/op (-1.08%; p=0.123). Neither difference was statistically significant.

## Validation

Focused fallback and resumed-digest tests, `go vet` for `registry/storage`, upstream lint, vendor validation, and the binaries/API-document validation passed.

## Scope

This change is limited to the full-hash fallback validation branch. The common size-based fast-path branch is not modified and was not benchmarked. The primary performance claim is limited to canonical SHA-256 full-fallback validation.

Full measured evidence: https://app.perfloop.ai/t/oss/case_6nr6g3vmet