### PR TITLE
client: don't mask specific blob upload errors behind ErrBlobUploadUnknown

### DIFF
--- a/internal/client/blob_writer.go
+++ b/internal/client/blob_writer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -32,6 +33,18 @@ func (hbu *httpBlobUpload) Reader() (io.ReadCloser, error) {
 
 func (hbu *httpBlobUpload) handleErrorResponse(resp *http.Response) error {
 	if resp.StatusCode == http.StatusNotFound {
+		err := HandleHTTPResponseError(resp)
+		// BLOB_UPLOAD_UNKNOWN, along with other blob upload error codes such
+		// as BLOB_UPLOAD_INVALID, are all reported over HTTP 404. Only
+		// collapse to the generic sentinel when the registry didn't tell us
+		// anything more specific, so we don't hide the real error message.
+		if errs, ok := err.(errcode.Errors); ok {
+			for _, e := range errs {
+				if ec, ok := e.(errcode.ErrorCoder); ok && ec.ErrorCode() != errcode.ErrorCodeBlobUploadUnknown {
+					return err
+				}
+			}
+		}
 		return distribution.ErrBlobUploadUnknown
 	}
 	return HandleHTTPResponseError(resp)

--- a/internal/client/blob_writer_test.go
+++ b/internal/client/blob_writer_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/distribution/distribution/v3"
@@ -498,5 +500,65 @@ func TestUploadWrite(t *testing.T) {
 		t.Fatalf("Wrong error type %T: %s", err, err)
 	} else if expected := "500 " + http.StatusText(http.StatusInternalServerError); uploadErr.Status != expected {
 		t.Fatalf("Unexpected response status: %s, expected %s", uploadErr.Status, expected)
+	}
+}
+
+// TestUploadHandleErrorResponseNotFound covers
+// https://github.com/distribution/distribution/issues/2512: a 404 response
+// can mean the upload session is gone (BLOB_UPLOAD_UNKNOWN), but it can also
+// carry a more specific error such as BLOB_UPLOAD_INVALID. Only the former
+// should collapse to the generic distribution.ErrBlobUploadUnknown sentinel;
+// the latter must be passed through so the registry's actual error message
+// reaches the caller.
+func TestUploadHandleErrorResponseNotFound(t *testing.T) {
+	hbu := &httpBlobUpload{}
+
+	newResponse := func(body string) *http.Response {
+		header := http.Header{}
+		if body != "" {
+			header.Set("Content-Type", "application/json")
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
+
+	// No body at all: fall back to the generic sentinel.
+	if err := hbu.handleErrorResponse(newResponse("")); err != distribution.ErrBlobUploadUnknown {
+		t.Fatalf("expected ErrBlobUploadUnknown, got %v", err)
+	}
+
+	// Explicit BLOB_UPLOAD_UNKNOWN: still the generic sentinel.
+	err := hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_UNKNOWN","message":"blob upload unknown to registry"}]}`))
+	if err != distribution.ErrBlobUploadUnknown {
+		t.Fatalf("expected ErrBlobUploadUnknown, got %v", err)
+	}
+
+	// BLOB_UPLOAD_INVALID must not be masked by the generic sentinel.
+	err = hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid","detail":"digest mismatch"}]}`))
+	errs, ok := err.(errcode.Errors)
+	if !ok || len(errs) != 1 {
+		t.Fatalf("expected errcode.Errors with one entry, got %T: %v", err, err)
+	}
+	e, ok := errs[0].(errcode.Error)
+	if !ok || e.Code != errcode.ErrorCodeBlobUploadInvalid {
+		t.Fatalf("expected BLOB_UPLOAD_INVALID error, got %#v", errs[0])
+	}
+	if expected := "blob upload invalid"; e.Message != expected {
+		t.Fatalf("unexpected error message: %q, expected %q", e.Message, expected)
+	}
+
+	// BLOB_UPLOAD_INVALID with no detail and the default message unmarshals
+	// to a bare errcode.ErrorCode rather than errcode.Error (see
+	// errcode.Errors.UnmarshalJSON), so it must be recognized too.
+	err = hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}`))
+	errs, ok = err.(errcode.Errors)
+	if !ok || len(errs) != 1 {
+		t.Fatalf("expected errcode.Errors with one entry, got %T: %v", err, err)
+	}
+	if ec, ok := errs[0].(errcode.ErrorCode); !ok || ec != errcode.ErrorCodeBlobUploadInvalid {
+		t.Fatalf("expected BLOB_UPLOAD_INVALID error code, got %#v", errs[0])
 	}
 }

--- a/internal/client/blob_writer_test.go
+++ b/internal/client/blob_writer_test.go
@@ -526,18 +526,25 @@ func TestUploadHandleErrorResponseNotFound(t *testing.T) {
 	}
 
 	// No body at all: fall back to the generic sentinel.
-	if err := hbu.handleErrorResponse(newResponse("")); err != distribution.ErrBlobUploadUnknown {
+	resp := newResponse("")
+	err := hbu.handleErrorResponse(resp)
+	resp.Body.Close()
+	if err != distribution.ErrBlobUploadUnknown {
 		t.Fatalf("expected ErrBlobUploadUnknown, got %v", err)
 	}
 
 	// Explicit BLOB_UPLOAD_UNKNOWN: still the generic sentinel.
-	err := hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_UNKNOWN","message":"blob upload unknown to registry"}]}`))
+	resp = newResponse(`{"errors":[{"code":"BLOB_UPLOAD_UNKNOWN","message":"blob upload unknown to registry"}]}`)
+	err = hbu.handleErrorResponse(resp)
+	resp.Body.Close()
 	if err != distribution.ErrBlobUploadUnknown {
 		t.Fatalf("expected ErrBlobUploadUnknown, got %v", err)
 	}
 
 	// BLOB_UPLOAD_INVALID must not be masked by the generic sentinel.
-	err = hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid","detail":"digest mismatch"}]}`))
+	resp = newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid","detail":"digest mismatch"}]}`)
+	err = hbu.handleErrorResponse(resp)
+	resp.Body.Close()
 	errs, ok := err.(errcode.Errors)
 	if !ok || len(errs) != 1 {
 		t.Fatalf("expected errcode.Errors with one entry, got %T: %v", err, err)
@@ -553,7 +560,9 @@ func TestUploadHandleErrorResponseNotFound(t *testing.T) {
 	// BLOB_UPLOAD_INVALID with no detail and the default message unmarshals
 	// to a bare errcode.ErrorCode rather than errcode.Error (see
 	// errcode.Errors.UnmarshalJSON), so it must be recognized too.
-	err = hbu.handleErrorResponse(newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}`))
+	resp = newResponse(`{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}`)
+	err = hbu.handleErrorResponse(resp)
+	resp.Body.Close()
 	errs, ok = err.(errcode.Errors)
 	if !ok || len(errs) != 1 {
 		t.Fatalf("expected errcode.Errors with one entry, got %T: %v", err, err)


### PR DESCRIPTION
Motivation:

The registry API registers both BLOB_UPLOAD_UNKNOWN and
BLOB_UPLOAD_INVALID with HTTP 404 (registry/api/errcode/register.go),
so a 404 from the server can mean two different things. In
internal/client/blob_writer.go, httpBlobUpload.handleErrorResponse
treated every 404 the same way: it discarded whatever error body the
server sent and always returned the generic sentinel
distribution.ErrBlobUploadUnknown. This meant a specific
BLOB_UPLOAD_INVALID error (e.g. describing a digest mismatch) was
silently replaced with the generic message, which complicates
debugging blob push failures for anything using this client library.

This is the internal/client analogue of #2512, filed against the old
registry/client package in docker/distribution. That package no
longer exists in this repo (it lives on as internal/client), but the
same discard-on-404 behavior was carried forward, so the underlying
problem still applies here today.

Note on scope: internal/client's blob-upload write path (Write/
ReadFrom/Commit) is currently only exercised by this package's own
tests - the in-repo caller of this client (registry/proxy) only uses
it for read/pull operations, not blob uploads. So this change doesn't
alter any currently-reachable user-visible behavior in this repo; it
fixes the client library itself for any future or external caller
that pushes blobs through it.

Approach:

Change handleErrorResponse to parse the 404 response body first (via
the existing HandleHTTPResponseError/errcode machinery) and only
collapse to the generic ErrBlobUploadUnknown sentinel when the
registry actually reported BLOB_UPLOAD_UNKNOWN, or when the body
doesn't carry a recognizable errcode.Errors payload at all (preserving
prior behavior for bodyless/legacy 404s). Any other error code
(e.g. BLOB_UPLOAD_INVALID) is now returned as-is so callers see the
registry's real error and message.

The parsed error can appear either as a full errcode.Error or, when it
has no Detail and its Message matches the code's default message, as a
bare errcode.ErrorCode (see errcode.Errors.UnmarshalJSON) - the code
checks both by asserting on the shared errcode.ErrorCoder interface.

Validation:

    go build ./...
    go test ./internal/client/...

Both pass, including a new test, TestUploadHandleErrorResponseNotFound,
covering: a bodyless 404 (sentinel), an explicit BLOB_UPLOAD_UNKNOWN
body (sentinel), and BLOB_UPLOAD_INVALID bodies in both its
detailed-Error and bare-ErrorCode shapes (both now passed through
instead of being masked).

Fixes #2512

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>