### PR TITLE
fix(tracing): respect OTEL_TRACES_EXPORTER

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	go.opentelemetry.io/contrib/exporters/autoexport v0.67.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
 	go.opentelemetry.io/otel v1.43.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.52.0
@@ -107,6 +106,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.64.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.18.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.42.0 // indirect
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -7,7 +7,6 @@ import (
 	"github.com/distribution/distribution/v3/version"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -50,12 +49,7 @@ func InitOpenTelemetry(ctx context.Context) error {
 		logger: dcontext.GetLogger(ctx),
 	}
 
-	loggerExp, err := stdouttrace.New(stdouttrace.WithWriter(lw))
-	if err != nil {
-		return err
-	}
-
-	compositeExp := newCompositeExporter(autoExp, loggerExp)
+	compositeExp := newCompositeExporter(autoExp)
 
 	sp := sdktrace.NewBatchSpanProcessor(compositeExp)
 	provider := sdktrace.NewTracerProvider(

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -1,0 +1,44 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/distribution/distribution/v3/internal/dcontext"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestInitOpenTelemetryNoneDoesNotLogSpans(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	var output bytes.Buffer
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(&output)
+	ctx := dcontext.WithLogger(context.Background(), logrus.NewEntry(logger))
+
+	previousProvider := otel.GetTracerProvider()
+
+	if err := InitOpenTelemetry(ctx); err != nil {
+		t.Fatal(err)
+	}
+	provider := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previousProvider)
+	})
+
+	_, span := otel.Tracer("test").Start(ctx, "disabled-exporter-span")
+	span.End()
+	if err := provider.ForceFlush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(output.String(), "disabled-exporter-span") {
+		t.Fatalf("span was logged with OTEL_TRACES_EXPORTER=none: %s", output.String())
+	}
+}


### PR DESCRIPTION
## What changed

- Remove the unconditional logger-backed stdout trace exporter.
- Keep only the exporter selected by OpenTelemetry environment configuration.
- Add a regression test for `OTEL_TRACES_EXPORTER=none`.

## Why

The logging exporter was always added alongside the configured exporter, so spans were written to the registry debug log even when tracing was explicitly disabled.

Fixes #4909

## Validation

- `go test ./tracing -run ^TestInitOpenTelemetryNoneDoesNotLogSpans$ -count=1`
- Linux Go 1.25.9 `make test-coverage`
- Linux Go 1.25.9 `make binaries` and API docs diff
- `make test-s3-storage`
- `make test-azure-storage`
- `COMMIT_RANGE=HEAD^..HEAD make validate`