### PR TITLE
fix(tags): return empty array after final pagination marker

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -547,6 +547,12 @@ func TestTagsAPI(t *testing.T) {
 			}},
 		},
 		{
+			name:               "page after last tag",
+			queryParams:        url.Values{"last": []string{"sb71y"}, "n": []string{"1"}},
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       tagsAPIResponse{Name: imageName.Name(), Tags: []string{}},
+		},
+		{
 			name:               "page size bigger than full list",
 			queryParams:        url.Values{"n": []string{"100"}},
 			expectedStatusCode: http.StatusOK,
@@ -601,7 +607,7 @@ func TestTagsAPI(t *testing.T) {
 					t.Fatalf("unexpected error decoding response body: %v", err)
 				}
 				if !reflect.DeepEqual(body, test.expectedBody) {
-					t.Fatalf("expected response body to be:\n%+v\ngot:\n%+v", test.expectedBody, body)
+					t.Fatalf("expected response body to be:\n%#v\ngot:\n%#v", test.expectedBody, body)
 				}
 			}
 

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -79,7 +79,9 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 			// err is either io.EOF
 			moreEntries = false
 		}
-		filled = returnedTags
+		if returnedTags != nil {
+			filled = returnedTags
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
When requesting a tags page after the final tag, distribution returns `null` instead of an empty JSON array.

For example, with `<last-tag>` set to the repository’s lexicographically final tag:

```bash
curl -sS 'http://localhost:5000/v2/library/registry/tags/list?n=1&last=<last-tag>'
```

Before:

```json
{"name":"library/registry","tags":null}
```

Expected, consistent with Docker Hub:

```json
{"name":"library/registry","tags":[]}
```

It would appear that this regression was introduced in the [`b1ae1b2`](https://github.com/distribution/distribution/commit/b1ae1b211ec42c7242b896383b3afd98a326b7fe) where the refactored handler initializes an empty slice, but replaces it with the nil slice returned alongside `io.EOF` when pagination reaches the end. The nil slice then gets serialized to `null` instead of an empty JSON array.

I encountered this issue while working with a Rust library where the deserialization is more sensitive.