### PR TITLE
fix(s3): omit StartAfter in Walk when no hint is given

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1120,10 +1120,16 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, from, sta
 	}
 
 	listObjectsInput := &s3.ListObjectsV2Input{
-		Bucket:     aws.String(d.Bucket),
-		Prefix:     aws.String(d.s3Path(path)),
-		MaxKeys:    aws.Int64(listMax),
-		StartAfter: aws.String(d.s3Path(startAfter)),
+		Bucket:  aws.String(d.Bucket),
+		Prefix:  aws.String(d.s3Path(path)),
+		MaxKeys: aws.Int64(listMax),
+	}
+
+	// An empty startAfter resolves to the bare rootDirectory, a lexical ancestor
+	// of every key under the prefix. AWS ignores it, but some S3 gateways (e.g.
+	// SeaweedFS) return an empty listing, breaking Walk. Only set it when given.
+	if startAfter != "" {
+		listObjectsInput.StartAfter = aws.String(d.s3Path(startAfter))
 	}
 
 	ctx, done := dcontext.WithTrace(parentCtx)


### PR DESCRIPTION
`doWalk` sets `StartAfter` to `d.s3Path(startAfter)` on the first `ListObjectsV2` of every walk. The repository-enumeration callers (`GetNextRepository`, `GetNextRepositories`) walk without a start-after hint, so `startAfter` is empty — and when `rootdirectory` is configured, `d.s3Path("")` returns the bare root directory (e.g. `zot`) rather than an empty string. The driver then sends that as `StartAfter`.

The root directory is a lexical ancestor of every key under the walk prefix. AWS S3 tolerates this: `StartAfter` is exclusive and every real key sorts after it, so nothing is dropped. Stricter S3-compatible gateways do not — SeaweedFS returns an empty listing when `StartAfter` names an ancestor prefix instead of a real key. On those backends the walk enumerates nothing, which silently breaks every `Walk`-based operation: garbage collection, `/v2/_catalog`, and metadata reconstruction all report zero repositories even though the data is present and served correctly. (`List()` is unaffected because it never sets `StartAfter`.)

The change sets `StartAfter` only when the caller supplied a non-empty hint. Behavior on AWS is unchanged — it was already ignoring the ancestor marker — and the walk now works on stricter gateways.

Fixes #4932.

### Testing

The existing `s3-aws` unit tests pass. `TestWalk` covers this path but is integration-only and needs a live backend. I verified the change against a SeaweedFS-backed bucket: before, `Walk` returned no repositories and GC and the catalog were empty; after, enumeration works and both populate. Happy to add a regression test if you can point me at the preferred way to cover it without a live backend — the constructed `ListObjectsV2Input` isn't observable from a unit test as the code stands.
