### PR TITLE
fix(s3): omit StartAfter in Walk when no hint is given

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1120,10 +1120,16 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, from, sta
 	}
 
 	listObjectsInput := &s3.ListObjectsV2Input{
-		Bucket:     aws.String(d.Bucket),
-		Prefix:     aws.String(d.s3Path(path)),
-		MaxKeys:    aws.Int64(listMax),
-		StartAfter: aws.String(d.s3Path(startAfter)),
+		Bucket:  aws.String(d.Bucket),
+		Prefix:  aws.String(d.s3Path(path)),
+		MaxKeys: aws.Int64(listMax),
+	}
+
+	// An empty startAfter resolves to the bare rootDirectory, a lexical ancestor
+	// of every key under the prefix. AWS ignores it, but some S3 gateways (e.g.
+	// SeaweedFS) return an empty listing, breaking Walk. Only set it when given.
+	if startAfter != "" {
+		listObjectsInput.StartAfter = aws.String(d.s3Path(startAfter))
 	}
 
 	ctx, done := dcontext.WithTrace(parentCtx)


### PR DESCRIPTION
`doWalk` always passes `StartAfter: d.s3Path(startAfter)`. When `Walk` is called without a hint (repository enumeration), `startAfter` is empty and `d.s3Path("")` resolves to the bare root directory — a lexical ancestor of every key under the prefix.

AWS S3 ignores that marker and still returns the keys; stricter gateways like SeaweedFS return an empty listing, so `Walk` finds no repositories and garbage collection and `/v2/_catalog` silently see an empty store.

Set `StartAfter` only when a non-empty hint is given. No change on AWS; fixes enumeration on strict gateways.

Fixes #4934.
