### PR TITLE
docs: fix CloudFront Origin Path guidance for S3 driver

### DIFF
--- a/docs/content/storage-drivers/s3.md
+++ b/docs/content/storage-drivers/s3.md
@@ -146,9 +146,11 @@ Defaults can be kept in most areas except:
 
 ### Origin:
 
-  - The CloudFront distribution must be created such that the `Origin Path` is set
-    to the directory level of the root "docker" key in S3. If your registry exists
-    on the root of the bucket, this path should be left blank.
+  - Leave the CloudFront `Origin Path` empty. The registry generates fully
+    qualified redirect URLs for clients that already include any storage
+    `rootdirectory` prefix. Setting `Origin Path` to a non-empty value (for
+    example to match `rootdirectory` or a top-level `docker/` key in the bucket)
+    double-prefixes object keys and causes pull failures.
 
   - For private S3 buckets, you must set `Restrict Bucket Access` to `Yes`. See
     the [CloudFront documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html).


### PR DESCRIPTION
## Summary

The CloudFront middleware docs told operators to set Origin Path to the registry's root directory (or the `docker` key). That is incorrect: the registry already emits fully qualified redirect URLs that include any `rootdirectory` prefix, so a non-empty Origin Path double-prefixes keys and breaks pulls.

## Changes

- Document that CloudFront `Origin Path` must be left empty.
- Explain why (qualified redirects include `rootdirectory`).

Fixes #1509