### PR TITLE
handlers: do not append an error envelope to a response already streaming

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -721,7 +721,17 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 			// own errors if they need different behavior (such as range errors
 			// for layer upload).
 			if context.Errors.Len() > 0 {
-				_ = errcode.ServeJSON(w, context.Errors)
+				if responseStarted(context) {
+					// The handler already began streaming the response body,
+					// which happens when a read fails part way through, so the
+					// error envelope cannot be delivered: net/http discards the
+					// second WriteHeader and the JSON would be appended to the
+					// partial payload the client is still reading. Record the
+					// error instead of corrupting the response.
+					dcontext.GetLogger(context).Errorf("error after response body started, not serving error envelope: %v", context.Errors)
+				} else {
+					_ = errcode.ServeJSON(w, context.Errors)
+				}
 				app.logError(context, context.Errors)
 			} else if status, ok := context.Value("http.response.status").(int); ok && status >= 200 && status <= 399 {
 				dcontext.GetResponseLogger(context).Infof("response completed")
@@ -791,6 +801,15 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 
 		dispatch(context, r).ServeHTTP(w, r)
 	})
+}
+
+// responseStarted reports whether any response body bytes have already been
+// written for this request. Header-only writes do not count: a handler that
+// sets its own status but no body can still have an error envelope appended,
+// which is the existing behaviour for layer upload range errors.
+func responseStarted(ctx context.Context) bool {
+	written, ok := ctx.Value("http.response.written").(int64)
+	return ok && written > 0
 }
 
 type errCodeKey struct{}

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -273,5 +274,88 @@ func TestAppendAccessRecords(t *testing.T) {
 	expectedResult = []auth.Access{expectedDeleteRecord}
 	if ok := reflect.DeepEqual(result, expectedResult); !ok {
 		t.Fatal("Actual access record differs from expected")
+	}
+}
+
+// TestDispatcherErrorEnvelopeAfterResponseStarted ensures that the automated
+// error response handling does not append an error envelope to a response body
+// that a handler already started writing, and that it still serves the
+// envelope when nothing has been written yet.
+func TestDispatcherErrorEnvelopeAfterResponseStarted(t *testing.T) {
+	for _, testcase := range []struct {
+		name         string
+		partialWrite string
+		expectedBody string
+		expectedCode int
+	}{
+		{
+			name:         "response already started",
+			partialWrite: "partial blob",
+			expectedBody: "partial blob",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "nothing written yet",
+			expectedCode: http.StatusInternalServerError,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			driver := inmemory.New()
+			ctx := dcontext.Background()
+			registry, err := storage.NewRegistry(ctx, driver, storage.BlobDescriptorCacheProvider(memorycache.NewInMemoryBlobDescriptorCacheProvider(0)), storage.EnableDelete, storage.EnableRedirect)
+			if err != nil {
+				t.Fatalf("error creating registry: %v", err)
+			}
+			app := &App{
+				Config:   &configuration.Configuration{},
+				Context:  ctx,
+				router:   v2.RouterWithPrefix(""),
+				driver:   driver,
+				registry: registry,
+			}
+
+			app.register(v2.RouteNameTags, func(ctx *Context, r *http.Request) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if testcase.partialWrite != "" {
+						if _, err := w.Write([]byte(testcase.partialWrite)); err != nil {
+							t.Fatalf("error writing partial response: %v", err)
+						}
+					}
+					ctx.Errors = append(ctx.Errors, errcode.ErrorCodeUnknown.WithDetail("upstream read failed"))
+				})
+			})
+
+			server := httptest.NewServer(app)
+			defer server.Close()
+
+			resp, err := http.Get(server.URL + "/v2/foo/bar/tags/list")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("error reading body: %v", err)
+			}
+			if resp.StatusCode != testcase.expectedCode {
+				t.Fatalf("unexpected status code: %v != %v (body %q)", resp.StatusCode, testcase.expectedCode, string(body))
+			}
+
+			if testcase.expectedBody != "" {
+				if string(body) != testcase.expectedBody {
+					t.Fatalf("error envelope leaked into a started response: %q != %q", string(body), testcase.expectedBody)
+				}
+				return
+			}
+
+			var errs errcode.Errors
+			if err := json.Unmarshal(body, &errs); err != nil {
+				t.Fatalf("error unmarshaling error envelope %q: %v", string(body), err)
+			}
+			if len(errs) != 1 {
+				t.Fatalf("unexpected number of errors: %d != 1", len(errs))
+			}
+		})
 	}
 }


### PR DESCRIPTION

Fixes #4937

### Problem

When a handler fails part way through writing the response body, the dispatcher still calls `errcode.ServeJSON` in its deferred error handling (`registry/handlers/app.go`). The status line and headers are already sent, so `net/http` discards the second `WriteHeader` and logs `http: superfluous response.WriteHeader call`, but the JSON is still encoded onto the connection. The client ends up with a truncated payload plus an error object appended to it, under the original status and a `Content-Length` that is never reached.

It also makes the request log inaccurate. `errcode.ServeJSON` sets `Content-Type: application/json` and calls `WriteHeader(500)`, and while `net/http` ignores both, `instrumentedResponseWriter` records them, so `GetResponseLogger` reports `http.response.status=500 http.response.contenttype=application/json` for a response the client received as `200 application/octet-stream`.

This shows up in proxy (pull-through cache) mode when an upstream read fails mid-layer. On one deployment over a week, 67 requests had written more than 100 KB of layer data before the envelope went out, the largest 71 MB.

### Fix

Skip the envelope once body bytes have been written, and log the errors instead. `written > 0` comes from `http.response.written`, which `instrumentedResponseWriter` already exposes via `Context.Value`, so no new plumbing is needed.

Header-only writes are deliberately unaffected: a handler that sets its own status but writes no body can still have an envelope appended, which is the existing behaviour that layer upload range errors depend on.

This does not change which requests succeed or fail. A response that reached this path was already truncated. It stops the registry writing JSON onto the tail of that truncated body, and it keeps the logged status and content type describing what was actually sent.

### Diff

```diff
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -720,7 +720,17 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 			// own errors if they need different behavior (such as range errors
 			// for layer upload).
 			if context.Errors.Len() > 0 {
-				_ = errcode.ServeJSON(w, context.Errors)
+				if responseStarted(context) {
+					// The handler already began streaming the response body,
+					// which happens when a read fails part way through, so the
+					// error envelope cannot be delivered: net/http discards the
+					// second WriteHeader and the JSON would be appended to the
+					// partial payload the client is still reading. Record the
+					// error instead of corrupting the response.
+					dcontext.GetLogger(context).Errorf("error after response body started, not serving error envelope: %v", context.Errors)
+				} else {
+					_ = errcode.ServeJSON(w, context.Errors)
+				}
 				app.logError(context, context.Errors)
 			} else if status, ok := context.Value("http.response.status").(int); ok && status >= 200 && status <= 399 {
 				dcontext.GetResponseLogger(context).Infof("response completed")
@@ -793,6 +803,15 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 	})
 }

+// responseStarted reports whether any response body bytes have already been
+// written for this request. Header-only writes do not count: a handler that
+// sets its own status but no body can still have an error envelope appended,
+// which is the existing behaviour for layer upload range errors.
+func responseStarted(ctx context.Context) bool {
+	written, ok := ctx.Value("http.response.written").(int64)
+	return ok && written > 0
+}
+
 type errCodeKey struct{}
```

### Tests

`TestDispatcherErrorEnvelopeAfterResponseStarted` in `registry/handlers/app_test.go` covers both branches: a handler that writes partial content keeps its body and status, and a handler that writes nothing still gets the envelope. It reuses the existing `inmemory` driver plus `memorycache` scaffolding already used by `TestAppDispatcher`, and adds `io` to the test imports.

### Notes for reviewers

- Reading `http.response.written` through `Context.Value` keeps the change to one file and matches how the surrounding code reads `http.response.status`. Happy to switch to asserting on the `ResponseWriter` if you would rather not depend on the context key here.
- This is a client-visible behaviour change in the failure path, so it may warrant a release note.

### Verifying the test catches it

With only the test applied and `app.go` left as-is on `main`:

```
--- FAIL: TestDispatcherErrorEnvelopeAfterResponseStarted/response_already_started
    app_test.go:347: error envelope leaked into a started response:
      "partial blob{\"errors\":[{\"code\":\"UNKNOWN\",\"message\":\"unknown error\",\"detail\":\"upstream read failed\"}]}\n"
      != "partial blob"
```

With the fix, both subtests pass and the full `./registry/handlers/` package is green.
