### PR TITLE
Fix 500s from malformed manifest digests and out-of-order final chunk PUTs

### DIFF
--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -191,6 +191,30 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 	}
 	defer buh.Upload.Close()
 
+	cr := r.Header.Get("Content-Range")
+	cl := r.Header.Get("Content-Length")
+	if cr != "" && cl != "" {
+		start, end, err := parseContentRange(cr)
+		if err != nil {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
+			return
+		}
+		if start > end || start != buh.Upload.Size() {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeRangeInvalid)
+			return
+		}
+
+		clInt, err := strconv.ParseInt(cl, 10, 64)
+		if err != nil {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
+			return
+		}
+		if clInt != (end-start)+1 {
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeSizeInvalid)
+			return
+		}
+	}
+
 	dgstStr := r.FormValue("digest") // TODO(stevvooe): Support multiple digest parameters!
 
 	if dgstStr == "" {

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -51,6 +51,11 @@ func manifestDispatcher(ctx *Context, r *http.Request) http.Handler {
 	ref := getReference(ctx)
 	dgst, err := digest.Parse(ref)
 	if err != nil {
+		if strings.ContainsRune(ref, ':') {
+			// Looks like a digest but failed to parse; reject rather than treating the malformed digest as a tag name.
+			ctx.Errors = append(ctx.Errors, errcode.ErrorCodeDigestInvalid.WithDetail(err))
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		}
 		// We just have a tag
 		manifestHandler.Tag = ref
 	} else {


### PR DESCRIPTION
`registry/handlers/blobupload.go`: `PutBlobUploadComplete` never validated `Content-Range` contiguity on the final chunked-upload PUT, so an out-of-order last chunk fell through to digest validation and returned 400 instead of the spec-mandated 416.  d7a2b14489cacf30b996700a7e0c8f555f0804e0 ("add content range handling in patch blob") added this contiguity check to `PatchBlobData` but never extended it to the PUT completion path, so this reuses the same check there.

`registry/handlers/manifests.go`: `manifestDispatcher` silently treated any reference containing `:` that failed `digest.Parse` as a tag name, so a malformed digest reference (such as `sha256:baddigeststring`) reached the tag-based storage path and produced a 500 from an invalid filesystem path instead of a clean 400.  Reject it as `ErrorCodeDigestInvalid` before the tag fallback instead.

Verified against the OCI distribution-spec conformance suite -- the three previously-failing tests (chunked out-of-order + put chunk, invalid-digest-format manifest-put, invalid-digest-format manifest-get) now pass; 779 pass / 6 skip / 4 disabled / 0 fail out of 789 total.

Related work:
- #4828 -- referrers API, not yet implemented; disabled during conformance testing above
- #4420 -- sha512 push failures; disabled during conformance testing above

Assisted-By: "claude my eyes right out"